### PR TITLE
style(world-cup): place Best Pick badge on the tab row (right)

### DIFF
--- a/apps/web/app/[locale]/world-cup/groups/page.tsx
+++ b/apps/web/app/[locale]/world-cup/groups/page.tsx
@@ -39,17 +39,17 @@ export default async function GroupsPage({ params }: { params: Promise<{ locale:
   const settled = settledMatches.length;
   const hits = settledMatches.filter(({ m, r }) => r.winner === bestPickKey(m)).length;
   const accuracyPct = settled > 0 ? Math.round((hits / settled) * 100) : 0;
+  const accuracyBadge =
+    settled > 0 ? (
+      <div className={styles.accuracyBar}>
+        <span aria-hidden>✅</span>
+        {t(locale, "accuracyLabel")} · <strong>{hits}/{settled}</strong> · {accuracyPct}%
+      </div>
+    ) : null;
 
   return (
     <div>
-      <WcHero locale={locale} wide subKey="subGroups" />
-
-      {settled > 0 ? (
-        <div className={styles.accuracyBar}>
-          <span aria-hidden>✅</span>
-          {t(locale, "accuracyLabel")} · <strong>{hits}/{settled}</strong> · {accuracyPct}%
-        </div>
-      ) : null}
+      <WcHero locale={locale} wide subKey="subGroups" aside={accuracyBadge} />
 
       <div className={styles.groupGrid}>
         {groups.map(([g, ms]) => {

--- a/apps/web/components/world-cup/wc-hero.tsx
+++ b/apps/web/components/world-cup/wc-hero.tsx
@@ -1,10 +1,23 @@
+import type { ReactNode } from "react";
 import { getGeneratedAt } from "../../lib/world-cup/forecast-store";
 import { t, type Locale, type StrKey } from "../../lib/world-cup/i18n";
 import { TabNav } from "./tab-nav";
 import styles from "./world-cup.module.css";
 
-// Shared hero + tab switcher for the three forecast views.
-export function WcHero({ locale, subKey, wide }: { locale: Locale; subKey: StrKey; wide?: boolean }) {
+// Shared hero + tab switcher for the three forecast views. `aside` renders on
+// the tab row's right side (e.g. the groups page's Best Pick accuracy badge),
+// keeping the top edge full-width and balanced instead of a floating pill.
+export function WcHero({
+  locale,
+  subKey,
+  wide,
+  aside
+}: {
+  locale: Locale;
+  subKey: StrKey;
+  wide?: boolean;
+  aside?: ReactNode;
+}) {
   return (
     <section className={styles.hero}>
       <h1 className={styles.heroTitle}>{t(locale, "heroTitle")}</h1>
@@ -14,7 +27,10 @@ export function WcHero({ locale, subKey, wide }: { locale: Locale; subKey: StrKe
       <p className={styles.heroMeta}>
         {t(locale, "heroMeta")} {getGeneratedAt().slice(0, 16).replace("T", " ")} UTC
       </p>
-      <TabNav />
+      <div className={styles.tabRow}>
+        <TabNav />
+        {aside}
+      </div>
     </section>
   );
 }

--- a/apps/web/components/world-cup/world-cup.module.css
+++ b/apps/web/components/world-cup/world-cup.module.css
@@ -549,6 +549,14 @@
 
 /* aggregate Best-Pick accuracy banner (groups tab) */
 
+/* tab row: tabs on the left, an optional badge (groups accuracy) on the right */
+.tabRow {
+  display: flex;
+  align-items: center;
+  gap: 12px 16px;
+  flex-wrap: wrap;
+}
+
 .accuracyBar {
   display: flex;
   align-items: center;
@@ -556,7 +564,7 @@
   gap: 10px;
   width: fit-content;
   max-width: 100%;
-  margin: 0 0 18px auto; /* right-aligned to the content edge */
+  margin: 0 0 0 auto; /* pushed to the right end of the tab row */
   padding: 10px 20px;
   background: #fff;
   border: 1px solid #e8eaf0;


### PR DESCRIPTION
Moves the Best Pick accuracy badge into a right-side slot of the shared hero's tab row (tabs left, badge right) instead of a floating pill, so the groups top reads full-width and balanced like the champion page. On phones it wraps below the tabs, right-aligned. Verified at 375/desktop; typecheck passes.