### PR TITLE
chore(web): disable Deep Research beta button for now + fix deploy note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@
 
 - **i18n**：所有面向用户的文案走 i18n（`apps/web/lib/world-cup/messages/` 下 `en` / `zh-CN` / `zh-TW` 三语都补齐，新文案进 message resource、不要硬编码；`zh-TW` 为生成文件，必要时同步更新生成器）。
 - **移动端**：桌面 + 移动两个视口都要适配并截图自评（布局不崩、文字不溢出、交互可用）。
-- **自动发布**：合入 `main` 即触发 Vercel 自动部署（forecasting-agent.com）。因此合并前必须本地 `pnpm --filter @autopoly/web exec next build` 通过 + 桌面/移动截图自评，避免把坏构建推上生产。
+- **自动发布**：合入 `main` 会触发 GitHub→Vercel 自动部署（当前自动部署到 `autopoly-pizza-spectator` 项目，后续会并入 `forecasting-agent.com`；`forecasting-agent.com` = 独立的 `web` 项目，暂为手动部署）。无论走哪条路径，合并前都必须本地 `pnpm --filter @autopoly/web exec next build` 通过 + 桌面/移动截图自评，避免把坏构建推上生产。
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@
 
 - **i18n**：所有面向用户的文案走 i18n（`apps/web/lib/world-cup/messages/` 下 `en` / `zh-CN` / `zh-TW` 三语都补齐，新文案进 message resource、不要硬编码；`zh-TW` 为生成文件，必要时同步更新生成器）。
 - **移动端**：桌面 + 移动两个视口都要适配并截图自评（布局不崩、文字不溢出、交互可用）。
-- **自动发布**：合入 `main` 即触发 Vercel 自动部署（forecasting-agent.com）。因此合并前必须本地 `pnpm --filter @autopoly/web exec next build` 通过 + 桌面/移动截图自评，避免把坏构建推上生产。
+- **自动发布**：合入 `main` 会触发 GitHub→Vercel 自动部署（当前自动部署到 `autopoly-pizza-spectator` 项目，后续会并入 `forecasting-agent.com`；`forecasting-agent.com` = 独立的 `web` 项目，暂为手动部署）。无论走哪条路径，合并前都必须本地 `pnpm --filter @autopoly/web exec next build` 通过 + 桌面/移动截图自评，避免把坏构建推上生产。
 
 ---
 

--- a/apps/web/app/[locale]/prediction-engine/page.tsx
+++ b/apps/web/app/[locale]/prediction-engine/page.tsx
@@ -4,7 +4,8 @@ import { WorldCupHeader } from "../../../components/world-cup/wc-header";
 import { LegalFooter } from "../../../components/world-cup/legal-footer";
 import { FormulaCard } from "../../../components/world-cup/formula-card";
 import { SampleRun, type SampleView } from "../../../components/world-cup/sample-run";
-import { BetaAccess } from "../../../components/world-cup/beta-access";
+// Beta gate to the Deep Research console — disabled for now (see hero below).
+// import { BetaAccess } from "../../../components/world-cup/beta-access";
 import { getPredictionAccessState } from "../../../lib/prediction-access";
 import { contentFor, getAllForecasts, sortedOutcomes } from "../../../lib/world-cup/forecast-store";
 import { resolveTeam } from "../../../lib/world-cup/team-meta";
@@ -86,6 +87,9 @@ export default async function PredictionEnginePage({ params }: { params: Promise
           <p className={styles.peKicker}>{t(locale, "peKicker")}</p>
           <div className={styles.peTitleRow}>
             <h1 className={styles.peTitle}>{t(locale, "peTitle")}</h1>
+            {/* Beta access to the Deep Research console (/research) — folded into
+                the codebase but disabled for now; re-enable by uncommenting this
+                block and the BetaAccess import above.
             <BetaAccess
               target="/research"
               labels={{
@@ -97,7 +101,7 @@ export default async function PredictionEnginePage({ params }: { params: Promise
                 cancel: t(locale, "betaCancel"),
                 wrong: t(locale, "betaWrong")
               }}
-            />
+            /> */}
           </div>
           <p className={styles.peSub}>{t(locale, "peSub")}</p>
           {cta ? (

--- a/docs/en/CLAUDE.md
+++ b/docs/en/CLAUDE.md
@@ -114,7 +114,7 @@ For any user-visible change, close out with: **screenshot → read the image →
 
 - **i18n**: all user-facing copy goes through i18n (fill in `en` / `zh-CN` / `zh-TW` under `apps/web/lib/world-cup/messages/`; put new strings in the message resources, never hardcode; `zh-TW` is generated — update the generator when needed).
 - **Mobile**: adapt and self-review on both desktop and mobile viewports (layout intact, no overflow, interactions work).
-- **Auto-publish**: merging to `main` triggers an automatic Vercel deploy (forecasting-agent.com). So before merging, a local `pnpm --filter @autopoly/web exec next build` must pass plus a desktop/mobile screenshot self-review — never ship a broken build to production.
+- **Auto-publish**: merging to `main` triggers a GitHub→Vercel auto-deploy (currently to the `autopoly-pizza-spectator` project, to be folded into `forecasting-agent.com` later; `forecasting-agent.com` itself is the separate `web` project, currently a manual deploy). Either way, before merging a local `pnpm --filter @autopoly/web exec next build` must pass plus a desktop/mobile screenshot self-review — never ship a broken build to production.
 
 ---
 


### PR DESCRIPTION
Comment out the beta-access entry on the self-host page (the `/research` console + code stay in the codebase, dormant). Correct the auto-publish note: main pushes auto-deploy `autopoly-pizza-spectator` (to fold into forecasting-agent.com later); forecasting-agent.com is the separate manual `web` project. `next build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)