### PR TITLE
refactor(web): rename C-end console to Forecasting Engine

### DIFF
--- a/apps/web/app/research/page.tsx
+++ b/apps/web/app/research/page.tsx
@@ -5,7 +5,7 @@ import { LegalFooter } from "../../components/world-cup/legal-footer";
 import styles from "../../components/research/research.module.css";
 
 export const metadata: Metadata = {
-  title: "Deep Research — Predict Raven",
+  title: "Forecasting Engine — Predict Raven",
   description:
     "Ask any verifiable future event in natural language and watch an AI superforecaster reason in the open: layered evidence, a conditional-probability model, Bayesian updates, and a calibrated probability with an 80% confidence interval."
 };
@@ -21,7 +21,7 @@ export default function ResearchPage() {
         <div className={styles.headerRow}>
           <Link href="/research" className={styles.brand}>
             Predict Raven
-            <span className={styles.brandTag}>Deep Research</span>
+            <span className={styles.brandTag}>Forecasting Engine</span>
           </Link>
           <Link href="/world-cup" className={styles.brandTag} style={{ textDecoration: "none" }}>
             世界杯预测 →

--- a/apps/web/components/research/research-console.tsx
+++ b/apps/web/components/research/research-console.tsx
@@ -72,7 +72,7 @@ export function ResearchConsole() {
   return (
     <>
       <section className={styles.hero}>
-        <p className={styles.heroKicker}>Deep Research</p>
+        <p className={styles.heroKicker}>Forecasting Engine</p>
         <h1 className={styles.heroTitle}>把一个未来事件,变成可审计的概率。</h1>
         <p className={styles.heroSub}>
           用自然语言提出一个可被验证的二元问题。研究 agent 会分七步公开它的推理:理清定义 ·

--- a/apps/web/components/research/state-machine-legend.tsx
+++ b/apps/web/components/research/state-machine-legend.tsx
@@ -31,7 +31,7 @@ export function StateMachineLegend({
   return (
     <div className={styles.machine}>
       <div className={styles.machineTop}>
-        <span className={styles.machineLabel}>Deep Research 状态机</span>
+        <span className={styles.machineLabel}>Forecasting Engine 状态机</span>
         <span className={`${styles.phasePill} ${PHASE_CLASS[phase]}`}>{PHASE_LABEL[phase]}</span>
       </div>
       <div className={styles.machineTrack}>

--- a/apps/web/lib/world-cup/messages/en.json
+++ b/apps/web/lib/world-cup/messages/en.json
@@ -70,7 +70,7 @@
   "peSeeFirst": "See our forecasts first",
   "betaButton": "Beta test",
   "betaTitle": "Beta access",
-  "betaDesc": "Enter the beta password to open the Deep Research console.",
+  "betaDesc": "Enter the beta password to open the Forecasting Engine console.",
   "betaPlaceholder": "Beta password",
   "betaEnter": "Enter",
   "betaCancel": "Cancel",

--- a/apps/web/lib/world-cup/messages/zh-CN.json
+++ b/apps/web/lib/world-cup/messages/zh-CN.json
@@ -70,7 +70,7 @@
   "peSeeFirst": "先看我们的预测",
   "betaButton": "Beta 测试",
   "betaTitle": "Beta 测试访问",
-  "betaDesc": "输入 Beta 密码，进入 Deep Research 控制台。",
+  "betaDesc": "输入 Beta 密码，进入 Forecasting Engine 控制台。",
   "betaPlaceholder": "Beta 密码",
   "betaEnter": "进入",
   "betaCancel": "取消",

--- a/apps/web/lib/world-cup/messages/zh-TW.generated.json
+++ b/apps/web/lib/world-cup/messages/zh-TW.generated.json
@@ -70,7 +70,7 @@
   "peSeeFirst": "先看我們的預測",
   "betaButton": "Beta 測試",
   "betaTitle": "Beta 測試存取",
-  "betaDesc": "輸入 Beta 密碼，進入 Deep Research 控制台。",
+  "betaDesc": "輸入 Beta 密碼，進入 Forecasting Engine 控制台。",
   "betaPlaceholder": "Beta 密碼",
   "betaEnter": "進入",
   "betaCancel": "取消",


### PR DESCRIPTION
Rename the C-end console branding **Deep Research → Forecasting Engine** (user-facing only; `/research` route unchanged): page title, brand tag, hero kicker, state-machine label, beta-modal copy (en/zh-CN/zh-TW). `next build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)