### PR TITLE
feat(forecasting-engine): bilingual console (EN default + zh toggle)

### DIFF
--- a/apps/web/app/api/prediction-engine/run/route.ts
+++ b/apps/web/app/api/prediction-engine/run/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { buildPredictionDemoRun } from "../../../../lib/prediction-engine-demo";
+import { isConsoleLocale, type ConsoleLocale } from "../../../../lib/research/locale";
 import {
   completePredictionUsageEvent,
   consumePredictionRunQuota
@@ -227,9 +228,13 @@ export async function POST(request: Request) {
   const record = body && typeof body === "object" && !Array.isArray(body)
     ? body as Record<string, unknown>
     : {};
+  // This endpoint predates the locale work and historically emitted Chinese, so
+  // it defaults to Chinese unless the caller explicitly requests another locale.
+  const locale: ConsoleLocale = isConsoleLocale(record.locale) ? record.locale : "zh";
   const payload = {
     eventText: readEventText(record.eventText),
-    marketPrice: readMarketPrice(record.marketPrice)
+    marketPrice: readMarketPrice(record.marketPrice),
+    locale
   };
   const quota = await consumePredictionRunQuota(payload.eventText);
   if (!quota.allowed) {
@@ -263,7 +268,7 @@ export async function POST(request: Request) {
     return response;
   }
 
-  const run = buildPredictionDemoRun(payload);
+  const run = buildPredictionDemoRun(payload, new Date(), payload.locale);
   await completePredictionUsageEvent({
     usageEventId: quota.usageEventId,
     status: "complete",

--- a/apps/web/app/api/research/stream/route.ts
+++ b/apps/web/app/api/research/stream/route.ts
@@ -11,6 +11,7 @@ import { normalizeTier, type NornTier } from "@autopoly/norns";
 import { encodeResearchEvent, type ResearchEvent } from "../../../../lib/research/events";
 import { getDriver, resolveRequestedDriverId } from "../../../../lib/research/drivers";
 import { DriverNotConfiguredError } from "../../../../lib/research/drivers/types";
+import { normalizeConsoleLocale, pick, type ConsoleLocale } from "../../../../lib/research/locale";
 import {
   completePredictionUsageEvent,
   consumePredictionRunQuota
@@ -34,14 +35,16 @@ function readMarketPrice(value: unknown): number | null {
 }
 
 export async function POST(request: Request): Promise<Response> {
-  let payload: { eventText: string; marketPrice: number | null; tier: NornTier };
+  let payload: { eventText: string; marketPrice: number | null; tier: NornTier; locale: ConsoleLocale };
   try {
     const body = (await request.json()) as Record<string, unknown>;
     payload = {
       eventText: readEventText(body?.eventText),
       marketPrice: readMarketPrice(body?.marketPrice),
       // Per-request tier (from the UI) wins; else the server default; else verdandi.
-      tier: normalizeTier(body?.tier ?? process.env.RESEARCH_DEFAULT_TIER)
+      tier: normalizeTier(body?.tier ?? process.env.RESEARCH_DEFAULT_TIER),
+      // Output locale (from the UI); defaults to English.
+      locale: normalizeConsoleLocale(body?.locale)
     };
   } catch {
     return Response.json({ error: "Invalid JSON body." }, { status: 400 });
@@ -89,10 +92,15 @@ export async function POST(request: Request): Promise<Response> {
             await driver.run(payload, emit, abortController.signal);
           } catch (error) {
             if (error instanceof DriverNotConfiguredError) {
+              const missing = error.missing.join(", ") || error.message;
               emit({
                 type: "run.notice",
                 level: "warn",
-                message: `已请求 ${requestedId} 链路但未完成配置（${error.missing.join(", ") || error.message}），本次使用 mock。`
+                message: pick(
+                  payload.locale,
+                  `Requested the ${requestedId} chain but it isn't fully configured (${missing}); using mock this run.`,
+                  `已请求 ${requestedId} 链路但未完成配置（${missing}），本次使用 mock。`
+                )
               });
               driver = getDriver("mock");
               await driver.run(payload, emit, abortController.signal);
@@ -138,6 +146,7 @@ export async function POST(request: Request): Promise<Response> {
       connection: "keep-alive",
       "x-research-driver": requestedId,
       "x-research-tier": payload.tier,
+      "x-research-locale": payload.locale,
       "x-accel-buffering": "no"
     }
   });

--- a/apps/web/app/research/page.tsx
+++ b/apps/web/app/research/page.tsx
@@ -1,8 +1,5 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { ResearchConsole } from "../../components/research/research-console";
-import { LegalFooter } from "../../components/world-cup/legal-footer";
-import styles from "../../components/research/research.module.css";
 
 export const metadata: Metadata = {
   title: "Forecasting Engine — Predict Raven",
@@ -10,28 +7,11 @@ export const metadata: Metadata = {
     "Ask any verifiable future event in natural language and watch an AI superforecaster reason in the open: layered evidence, a conditional-probability model, Bayesian updates, and a calibrated probability with an 80% confidence interval."
 };
 
-// Public C-end surface. Streaming + interactivity live in the client console;
-// this shell only provides metadata, chrome, and the compliance footer.
+// Public Forecasting Engine surface. The interactive console owns the full
+// localized shell (header + language toggle + streaming + compliance footer);
+// this route only supplies metadata and the dynamic flag.
 export const dynamic = "force-dynamic";
 
 export default function ResearchPage() {
-  return (
-    <div className={styles.shell}>
-      <header className={styles.header}>
-        <div className={styles.headerRow}>
-          <Link href="/research" className={styles.brand}>
-            Predict Raven
-            <span className={styles.brandTag}>Forecasting Engine</span>
-          </Link>
-          <Link href="/world-cup" className={styles.brandTag} style={{ textDecoration: "none" }}>
-            世界杯预测 →
-          </Link>
-        </div>
-      </header>
-      <main className={styles.main}>
-        <ResearchConsole />
-      </main>
-      <LegalFooter locale="zh-CN" />
-    </div>
-  );
+  return <ResearchConsole />;
 }

--- a/apps/web/components/research/research-console.tsx
+++ b/apps/web/components/research/research-console.tsx
@@ -1,18 +1,25 @@
 "use client";
 
-// Top-level client orchestrator for the Deep Research page. Owns the input
-// composer, kicks off the SSE stream, and lays out the live visualisation:
-// state-machine legend → staged timeline → final charts. Conversational and
-// progressive — nothing below the composer exists until a run starts.
+// Top-level client orchestrator for the Forecasting Engine page. Owns the page
+// shell (header + language toggle + footer), the input composer, the SSE stream,
+// and the live visualisation: state-machine legend → staged timeline → final
+// charts. Conversational and progressive — nothing below the composer exists
+// until a run starts. Locale lives here so chrome, streamed content, and footer
+// all switch together; English is the default to match the public-site apex.
 
 import { useState } from "react";
+import Link from "next/link";
 import { DEFAULT_TIER, NORN_TIER_LIST, type NornTier } from "@autopoly/norns";
 import styles from "./research.module.css";
 import { useResearchStream } from "../../lib/research/use-research-stream";
+import { c } from "../../lib/research/i18n";
+import { DEFAULT_CONSOLE_LOCALE, type ConsoleLocale } from "../../lib/research/locale";
 import { StateMachineLegend } from "./state-machine-legend";
 import { StageTimeline } from "./stage-timeline";
 import { ResultCharts } from "./result-charts";
 import { SAMPLE_CASES, type SampleCase } from "../../lib/research/sample-cases";
+import { LegalFooter } from "../world-cup/legal-footer";
+import type { Locale as WorldCupLocale } from "../../lib/world-cup/i18n";
 
 const DRIVER_LABEL: Record<string, string> = {
   mock: "MOCK",
@@ -25,8 +32,13 @@ const TIER_LABEL: Record<string, string> = Object.fromEntries(
   NORN_TIER_LIST.map((spec) => [spec.tier, spec.label])
 );
 
+// Console locale → the World Cup footer's locale (it carries the shared
+// compliance footer; it has no "zh" so we map to the simplified variant).
+const FOOTER_LOCALE: Record<ConsoleLocale, WorldCupLocale> = { en: "en", zh: "zh-CN" };
+
 export function ResearchConsole() {
   const { state, start, reset } = useResearchStream();
+  const [locale, setLocale] = useState<ConsoleLocale>(DEFAULT_CONSOLE_LOCALE);
   const [eventText, setEventText] = useState("");
   const [marketPrice, setMarketPrice] = useState("");
   const [tier, setTier] = useState<NornTier>(DEFAULT_TIER);
@@ -43,7 +55,8 @@ export function ResearchConsole() {
     void start({
       eventText: trimmed,
       marketPrice: Number.isFinite(parsedMarket as number) ? parsedMarket : null,
-      tier
+      tier,
+      locale
     });
   };
 
@@ -54,12 +67,13 @@ export function ResearchConsole() {
       return;
     }
     const runTier = sample.tier ?? tier;
-    setEventText(sample.eventText);
+    const sampleText = sample.eventText[locale];
+    setEventText(sampleText);
     setMarketPrice(String(sample.marketPrice));
     if (sample.tier) {
       setTier(sample.tier);
     }
-    void start({ eventText: sample.eventText, marketPrice: sample.marketPrice, tier: runTier });
+    void start({ eventText: sampleText, marketPrice: sample.marketPrice, tier: runTier, locale });
   };
 
   const onComposerKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -70,117 +84,159 @@ export function ResearchConsole() {
   };
 
   return (
-    <>
-      <section className={styles.hero}>
-        <p className={styles.heroKicker}>Forecasting Engine</p>
-        <h1 className={styles.heroTitle}>把一个未来事件,变成可审计的概率。</h1>
-        <p className={styles.heroSub}>
-          用自然语言提出一个可被验证的二元问题。研究 agent 会分七步公开它的推理:理清定义 ·
-          条件拆解 · 证据收集与权重 · 条件概率模型 · 贝叶斯更新 · 结论与置信区间。
-        </p>
-      </section>
-
-      <div className={styles.composer}>
-        <textarea
-          className={styles.composerInput}
-          placeholder="例如:某事件会在某个截止日期前发生吗?"
-          value={eventText}
-          onChange={(event) => setEventText(event.target.value)}
-          onKeyDown={onComposerKeyDown}
-          rows={2}
-          disabled={running}
-        />
-        <div className={styles.tierRow}>
-          <span className={styles.tierRowLabel}>推理深度</span>
-          <div className={styles.tierGroup} role="radiogroup" aria-label="推理深度档位 (Norns)">
-            {NORN_TIER_LIST.map((spec) => (
+    <div className={styles.shell}>
+      <header className={styles.header}>
+        <div className={styles.headerRow}>
+          <Link href="/research" className={styles.brand}>
+            Predict Raven
+            <span className={styles.brandTag}>Forecasting Engine</span>
+          </Link>
+          <div className={styles.headerRight}>
+            <div className={styles.langToggle} role="radiogroup" aria-label={c(locale, "langLabel")}>
               <button
-                key={spec.tier}
                 type="button"
                 role="radio"
-                aria-checked={tier === spec.tier}
-                className={`${styles.tierChip} ${tier === spec.tier ? styles.tierChipActive : ""}`}
-                onClick={() => setTier(spec.tier)}
+                aria-checked={locale === "en"}
+                className={`${styles.langBtn} ${locale === "en" ? styles.langBtnActive : ""}`}
+                onClick={() => setLocale("en")}
                 disabled={running}
-                title={spec.blurb}
               >
-                {spec.label}
+                EN
               </button>
-            ))}
-          </div>
-        </div>
-        <div className={styles.composerRow}>
-          <label className={styles.marketField}>
-            市场隐含概率(可选)
-            <input
-              className={styles.marketInput}
-              inputMode="decimal"
-              placeholder="0.30"
-              value={marketPrice}
-              onChange={(event) => setMarketPrice(event.target.value)}
-              disabled={running}
-            />
-          </label>
-          <div style={{ display: "flex", gap: 10 }}>
-            {started && !running ? (
-              <button type="button" className={styles.secondaryBtn} onClick={reset}>
-                重新开始
-              </button>
-            ) : null}
-            <button type="button" className={styles.runBtn} onClick={submit} disabled={running || !eventText.trim()}>
-              {running ? "研究中…" : "开始研究"}
-            </button>
-          </div>
-        </div>
-        {!started ? (
-          <div className={styles.examples}>
-            <span className={styles.examplesHint}>已缓存示例 · 点击直接运行</span>
-            {SAMPLE_CASES.map((sample) => (
               <button
-                key={sample.id}
                 type="button"
-                className={styles.exampleChip}
-                onClick={() => runSample(sample)}
-                title={sample.eventText}
+                role="radio"
+                aria-checked={locale === "zh"}
+                className={`${styles.langBtn} ${locale === "zh" ? styles.langBtnActive : ""}`}
+                onClick={() => setLocale("zh")}
+                disabled={running}
               >
-                {sample.label}
-                <span className={styles.exampleChipSub}>{sample.blurb}</span>
+                中文
               </button>
-            ))}
+            </div>
+            <Link href="/world-cup" className={styles.brandTag} style={{ textDecoration: "none" }}>
+              {c(locale, "navWorldCup")}
+            </Link>
           </div>
-        ) : null}
-      </div>
+        </div>
+      </header>
 
-      {started ? (
-        <>
-          <div className={styles.questionBubble}>
-            <span className={styles.questionBubbleInner}>{state.eventText}</span>
+      <main className={styles.main}>
+        <section className={styles.hero}>
+          <p className={styles.heroKicker}>Forecasting Engine</p>
+          <h1 className={styles.heroTitle}>{c(locale, "heroTitle")}</h1>
+          <p className={styles.heroSub}>{c(locale, "heroSub")}</p>
+        </section>
+
+        <div className={styles.composer}>
+          <textarea
+            className={styles.composerInput}
+            placeholder={c(locale, "composerPlaceholder")}
+            value={eventText}
+            onChange={(event) => setEventText(event.target.value)}
+            onKeyDown={onComposerKeyDown}
+            rows={2}
+            disabled={running}
+          />
+          <div className={styles.tierRow}>
+            <span className={styles.tierRowLabel}>{c(locale, "tierRowLabel")}</span>
+            <div className={styles.tierGroup} role="radiogroup" aria-label={c(locale, "tierAria")}>
+              {NORN_TIER_LIST.map((spec) => (
+                <button
+                  key={spec.tier}
+                  type="button"
+                  role="radio"
+                  aria-checked={tier === spec.tier}
+                  className={`${styles.tierChip} ${tier === spec.tier ? styles.tierChipActive : ""}`}
+                  onClick={() => setTier(spec.tier)}
+                  disabled={running}
+                  title={spec.blurb}
+                >
+                  {spec.label}
+                </button>
+              ))}
+            </div>
           </div>
-
-          {state.driver ? (
-            <div className={styles.runMeta}>
-              {state.tier ? <span className={styles.tierPill}>{TIER_LABEL[state.tier] ?? state.tier}</span> : null}
-              <span className={styles.driverPill}>{DRIVER_LABEL[state.driver] ?? state.driver}</span>
+          <div className={styles.composerRow}>
+            <label className={styles.marketField}>
+              {c(locale, "marketLabel")}
+              <input
+                className={styles.marketInput}
+                inputMode="decimal"
+                placeholder={c(locale, "marketPlaceholder")}
+                value={marketPrice}
+                onChange={(event) => setMarketPrice(event.target.value)}
+                disabled={running}
+              />
+            </label>
+            <div style={{ display: "flex", gap: 10 }}>
+              {started && !running ? (
+                <button type="button" className={styles.secondaryBtn} onClick={reset}>
+                  {c(locale, "resetBtn")}
+                </button>
+              ) : null}
+              <button type="button" className={styles.runBtn} onClick={submit} disabled={running || !eventText.trim()}>
+                {running ? c(locale, "runBtnBusy") : c(locale, "runBtnIdle")}
+              </button>
+            </div>
+          </div>
+          {!started ? (
+            <div className={styles.examples}>
+              <span className={styles.examplesHint}>{c(locale, "examplesHint")}</span>
+              {SAMPLE_CASES.map((sample) => (
+                <button
+                  key={sample.id}
+                  type="button"
+                  className={styles.exampleChip}
+                  onClick={() => runSample(sample)}
+                  title={sample.eventText[locale]}
+                >
+                  {sample.label[locale]}
+                  <span className={styles.exampleChipSub}>{sample.blurb[locale]}</span>
+                </button>
+              ))}
             </div>
           ) : null}
+        </div>
 
-          {state.notices.map((notice, index) => (
-            <div
-              key={`${index}-${notice.message.slice(0, 16)}`}
-              className={`${styles.notice} ${notice.level === "warn" ? styles.noticeWarn : styles.noticeInfo}`}
-            >
-              {notice.message}
+        {started ? (
+          <>
+            <div className={styles.questionBubble}>
+              <span className={styles.questionBubbleInner}>{state.eventText}</span>
             </div>
-          ))}
 
-          <StateMachineLegend phase={state.phase} stages={state.stages} />
+            {state.driver ? (
+              <div className={styles.runMeta}>
+                {state.tier ? <span className={styles.tierPill}>{TIER_LABEL[state.tier] ?? state.tier}</span> : null}
+                <span className={styles.driverPill}>{DRIVER_LABEL[state.driver] ?? state.driver}</span>
+              </div>
+            ) : null}
 
-          {state.error ? <div className={styles.errorBox}>研究失败:{state.error}</div> : null}
+            {state.notices.map((notice, index) => (
+              <div
+                key={`${index}-${notice.message.slice(0, 16)}`}
+                className={`${styles.notice} ${notice.level === "warn" ? styles.noticeWarn : styles.noticeInfo}`}
+              >
+                {notice.message}
+              </div>
+            ))}
 
-          <StageTimeline state={state} />
-          <ResultCharts state={state} />
-        </>
-      ) : null}
-    </>
+            <StateMachineLegend phase={state.phase} stages={state.stages} locale={locale} />
+
+            {state.error ? (
+              <div className={styles.errorBox}>
+                {c(locale, "errorPrefix")}
+                {state.error}
+              </div>
+            ) : null}
+
+            <StageTimeline state={state} locale={locale} />
+            <ResultCharts state={state} locale={locale} />
+          </>
+        ) : null}
+      </main>
+
+      <LegalFooter locale={FOOTER_LOCALE[locale]} />
+    </div>
   );
 }

--- a/apps/web/components/research/research.module.css
+++ b/apps/web/components/research/research.module.css
@@ -47,6 +47,42 @@
   text-transform: uppercase;
 }
 
+.headerRight {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.langToggle {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid #d9dde6;
+  border-radius: 999px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.langBtn {
+  border: none;
+  background: transparent;
+  color: #5b6472;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 5px 11px;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.langBtn:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.langBtnActive {
+  background: #0f1115;
+  color: #fff;
+}
+
 .driverPill {
   font-size: 11px;
   font-weight: 700;
@@ -623,10 +659,25 @@
   margin-bottom: 6px;
 }
 
+.snapshotLine {
+  margin: 4px 0 14px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: #8a93a6;
+  font-variant-numeric: tabular-nums;
+}
+
 .ciText {
   font-size: 14px;
   color: #5b6472;
   font-variant-numeric: tabular-nums;
+}
+
+.ciNote {
+  margin: 4px 0 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #aab1be;
 }
 
 .verdict {

--- a/apps/web/components/research/result-charts.tsx
+++ b/apps/web/components/research/result-charts.tsx
@@ -2,11 +2,15 @@
 
 // Final visualisation, revealed when the run completes. Strong visual emphasis
 // on the headline probability + 80% confidence interval; supporting charts for
-// the conditional model, prior→posterior path, and the evidence ledger.
+// the conditional model, prior→posterior path, and the evidence ledger. All
+// chrome is localized via the console locale; the streamed content arrives
+// already in the requested language.
 
 import { Fragment } from "react";
 import styles from "./research.module.css";
 import { pct, pp, signedPoints } from "../../lib/research/format";
+import { c, stanceLabel } from "../../lib/research/i18n";
+import type { ConsoleLocale } from "../../lib/research/locale";
 import type { ResearchState } from "../../lib/research/state-machine";
 import type { PredictionEvidence } from "../../lib/prediction-engine-demo";
 
@@ -17,25 +21,42 @@ const STANCE_CLASS: Record<PredictionEvidence["stance"], string | undefined> = {
   neutral: styles.stanceNeutral
 };
 
-const STANCE_LABEL: Record<PredictionEvidence["stance"], string> = {
-  support: "支持",
-  oppose: "反对",
-  mixed: "中性",
-  neutral: "边界"
-};
-
 function clampPct(value: number): number {
   return Math.min(100, Math.max(0, value * 100));
+}
+
+// Whole days between two YYYY-MM-DD dates (null if either is unparseable).
+function daysBetween(from: string, to: string): number | null {
+  const a = Date.parse(from);
+  const b = Date.parse(to);
+  if (Number.isNaN(a) || Number.isNaN(b)) {
+    return null;
+  }
+  return Math.round((b - a) / 86_400_000);
+}
+
+// "Research snapshot <date> · <N days> to the <deadline> deadline" (localized).
+function snapshotLine(locale: ConsoleLocale, asOf: string, deadline?: string, days?: number | null): string {
+  const prefix = c(locale, "snapshotPrefix") + asOf;
+  if (!deadline) {
+    return prefix;
+  }
+  if (locale === "zh") {
+    return `${prefix} · 距 ${deadline} 截止${days != null ? `约 ${days} 天` : ""}`;
+  }
+  return `${prefix} · ${days != null ? `${days} days to ` : ""}the ${deadline} deadline`;
 }
 
 function ConfidenceBar({
   yes,
   interval,
-  market
+  market,
+  locale
 }: {
   yes: number;
   interval: [number, number];
   market: number | null;
+  locale: ConsoleLocale;
 }) {
   const lo = clampPct(interval[0]);
   const hi = clampPct(interval[1]);
@@ -53,41 +74,53 @@ function ConfidenceBar({
         <span>100%</span>
       </div>
       <p className={styles.ciText}>
-        80% 置信区间：{pct(interval[0])} – {pct(interval[1])}
-        {market != null ? <> · 市场隐含 <span style={{ color: "#c0392b" }}>{pct(market)}</span></> : null}
+        {c(locale, "ciLabel")}
+        {pct(interval[0])} – {pct(interval[1])}
+        {market != null ? (
+          <>
+            {" · "}
+            {c(locale, "ciMarket")} <span style={{ color: "#c0392b" }}>{pct(market)}</span>
+          </>
+        ) : null}
       </p>
+      <p className={styles.ciNote}>{c(locale, "ciNote")}</p>
     </div>
   );
 }
 
-function ConclusionCard({ state }: { state: ResearchState }) {
+function ConclusionCard({ state, locale }: { state: ResearchState; locale: ConsoleLocale }) {
   const conclusion = state.conclusion;
   if (!conclusion) {
     return null;
   }
   const edge = conclusion.edge;
+  const asOf = state.finalRun?.asOf;
+  const deadline = state.finalRun?.deadline;
+  const daysToDeadline = asOf && deadline ? daysBetween(asOf, deadline) : null;
   return (
     <section className={styles.conclusionCard}>
       <div className={styles.conclusionTop}>
         <div>
-          <div className={styles.bigProbLabel}>Yes 概率</div>
+          <div className={styles.bigProbLabel}>{c(locale, "bigProbLabel")}</div>
           <div className={styles.bigProb}>{pct(conclusion.yesProbability)}</div>
         </div>
       </div>
+      {asOf ? <p className={styles.snapshotLine}>{snapshotLine(locale, asOf, deadline, daysToDeadline)}</p> : null}
       <ConfidenceBar
         yes={conclusion.yesProbability}
         interval={conclusion.confidenceInterval}
         market={conclusion.marketProbability}
+        locale={locale}
       />
       <p className={styles.verdict}>{conclusion.verdict}</p>
       {conclusion.marketProbability != null ? (
         <div className={styles.edgeRow}>
           <div className={styles.metric}>
-            <div className={styles.metricLabel}>市场隐含</div>
+            <div className={styles.metricLabel}>{c(locale, "marketImplied")}</div>
             <div className={styles.metricValue}>{pct(conclusion.marketProbability)}</div>
           </div>
           <div className={styles.metric}>
-            <div className={styles.metricLabel}>Edge</div>
+            <div className={styles.metricLabel}>{c(locale, "edgeLabel")}</div>
             <div
               className={`${styles.metricValue} ${
                 edge != null && edge > 0 ? styles.metricPos : edge != null && edge < 0 ? styles.metricNeg : ""
@@ -98,16 +131,12 @@ function ConclusionCard({ state }: { state: ResearchState }) {
           </div>
         </div>
       ) : null}
-      {conclusion.marketProbability != null ? (
-        <p className={styles.edgeCaveat}>
-          edge = 模型 − 市场。若市场的结算口径比本题更宽松（如"任何公开核协议即算"），两者并非同一判定标准，该 edge 仅供参考、不可直接当成可交易信号。
-        </p>
-      ) : null}
+      {conclusion.marketProbability != null ? <p className={styles.edgeCaveat}>{c(locale, "edgeCaveat")}</p> : null}
     </section>
   );
 }
 
-function ConditionalTree({ state }: { state: ResearchState }) {
+function ConditionalTree({ state, locale }: { state: ResearchState; locale: ConsoleLocale }) {
   if (state.model.length === 0) {
     return null;
   }
@@ -116,7 +145,7 @@ function ConditionalTree({ state }: { state: ResearchState }) {
   const calibrated = finalProb != null && Math.abs(finalProb - product) >= 0.01;
   return (
     <section className={styles.card}>
-      <h3 className={styles.cardTitle}>条件概率模型 · P(A) × P(B|A) × P(C|A,B)</h3>
+      <h3 className={styles.cardTitle}>{c(locale, "treeTitle")}</h3>
       <div className={styles.tree}>
         {state.model.map((node, index) => (
           <Fragment key={node.id}>
@@ -130,16 +159,23 @@ function ConditionalTree({ state }: { state: ResearchState }) {
         ))}
         <div className={styles.treeOp}>=</div>
         <div className={styles.treeResult}>
-          <div className={styles.treeNodeLabel} style={{ color: "#9ec0ff" }}>条件乘积</div>
+          <div className={styles.treeNodeLabel} style={{ color: "#9ec0ff" }}>
+            {c(locale, "treeProduct")}
+          </div>
           <div className={styles.treeResultProb}>{pct(product, 0)}</div>
           {calibrated ? (
-            <div className={styles.treeResultNote}>校准后 → {pct(finalProb!, 0)}</div>
+            <div className={styles.treeResultNote}>
+              {c(locale, "treeCalibratedPrefix")}
+              {pct(finalProb!, 0)}
+            </div>
           ) : null}
         </div>
       </div>
       {calibrated ? (
         <p className={styles.treeNote}>
-          条件乘积是结构化下界；最终 Yes 概率经校准为 {pct(finalProb!, 0)}（见下方贝叶斯路径的"模型校准"步）。
+          {c(locale, "treeNotePre")}
+          {pct(finalProb!, 0)}
+          {c(locale, "treeNotePost")}
         </p>
       ) : null}
     </section>
@@ -147,7 +183,7 @@ function ConditionalTree({ state }: { state: ResearchState }) {
 }
 
 // Prior → posterior path as a small SVG step chart.
-function UpdateWaterfall({ state }: { state: ResearchState }) {
+function UpdateWaterfall({ state, locale }: { state: ResearchState; locale: ConsoleLocale }) {
   if (state.updates.length === 0) {
     return null;
   }
@@ -168,7 +204,7 @@ function UpdateWaterfall({ state }: { state: ResearchState }) {
 
   return (
     <section className={styles.card}>
-      <h3 className={styles.cardTitle}>贝叶斯更新路径 · 先验 → 后验</h3>
+      <h3 className={styles.cardTitle}>{c(locale, "waterfallTitle")}</h3>
       <svg viewBox={`0 0 ${width} ${height}`} width="100%" role="img" aria-label="prior to posterior update path">
         {[0, domainMax / 2, domainMax].map((tickVal) => {
           const y = yOf(tickVal);
@@ -198,7 +234,7 @@ function UpdateWaterfall({ state }: { state: ResearchState }) {
   );
 }
 
-function EvidenceLedger({ state }: { state: ResearchState }) {
+function EvidenceLedger({ state, locale }: { state: ResearchState; locale: ConsoleLocale }) {
   if (state.evidence.length === 0) {
     return null;
   }
@@ -206,22 +242,26 @@ function EvidenceLedger({ state }: { state: ResearchState }) {
   const rows = [...state.evidence].sort((a, b) => Math.abs(b.weightPct) - Math.abs(a.weightPct));
   return (
     <section className={styles.card}>
-      <h3 className={styles.cardTitle}>证据账本 · {state.evidence.length} 条</h3>
+      <h3 className={styles.cardTitle}>
+        {c(locale, "ledgerTitlePre")}
+        {state.evidence.length}
+        {c(locale, "ledgerTitlePost")}
+      </h3>
       <table className={styles.ledger}>
         <thead>
           <tr>
-            <th>立场</th>
-            <th>证据</th>
-            <th className={styles.num}>影响</th>
-            <th className={styles.num}>可信度</th>
-            <th>节点</th>
+            <th>{c(locale, "ledgerColStance")}</th>
+            <th>{c(locale, "ledgerColEvidence")}</th>
+            <th className={styles.num}>{c(locale, "ledgerColImpact")}</th>
+            <th className={styles.num}>{c(locale, "ledgerColReliability")}</th>
+            <th>{c(locale, "ledgerColNode")}</th>
           </tr>
         </thead>
         <tbody>
           {rows.map((item) => (
             <tr key={item.id}>
               <td>
-                <span className={`${styles.stance} ${STANCE_CLASS[item.stance]}`}>{STANCE_LABEL[item.stance]}</span>
+                <span className={`${styles.stance} ${STANCE_CLASS[item.stance]}`}>{stanceLabel(locale, item.stance)}</span>
               </td>
               <td>
                 <div className={styles.ledgerTitle}>{item.title}</div>
@@ -238,21 +278,19 @@ function EvidenceLedger({ state }: { state: ResearchState }) {
           ))}
         </tbody>
       </table>
-      <p className={styles.ledgerCaption}>
-        "影响"为每条证据对其所属节点（A / B / C）的有向强度（百分点量级），用于排序与定性，并非对最终概率的可加贡献——最终概率以上方条件概率模型与贝叶斯路径为准。
-      </p>
+      <p className={styles.ledgerCaption}>{c(locale, "ledgerCaption")}</p>
     </section>
   );
 }
 
-function Limitations({ state }: { state: ResearchState }) {
+function Limitations({ state, locale }: { state: ResearchState; locale: ConsoleLocale }) {
   const limitations = state.finalRun?.limitations ?? [];
   if (limitations.length === 0) {
     return null;
   }
   return (
     <section className={styles.card}>
-      <h3 className={styles.cardTitle}>边界与免责</h3>
+      <h3 className={styles.cardTitle}>{c(locale, "limitationsTitle")}</h3>
       <ul className={styles.limitList}>
         {limitations.map((limit) => (
           <li key={limit.slice(0, 30)}>{limit}</li>
@@ -262,17 +300,17 @@ function Limitations({ state }: { state: ResearchState }) {
   );
 }
 
-export function ResultCharts({ state }: { state: ResearchState }) {
+export function ResultCharts({ state, locale }: { state: ResearchState; locale: ConsoleLocale }) {
   if (state.phase !== "complete") {
     return null;
   }
   return (
     <div className={styles.result}>
-      <ConclusionCard state={state} />
-      <ConditionalTree state={state} />
-      <UpdateWaterfall state={state} />
-      <EvidenceLedger state={state} />
-      <Limitations state={state} />
+      <ConclusionCard state={state} locale={locale} />
+      <ConditionalTree state={state} locale={locale} />
+      <UpdateWaterfall state={state} locale={locale} />
+      <EvidenceLedger state={state} locale={locale} />
+      <Limitations state={state} locale={locale} />
     </div>
   );
 }

--- a/apps/web/components/research/stage-timeline.tsx
+++ b/apps/web/components/research/stage-timeline.tsx
@@ -6,6 +6,8 @@
 
 import styles from "./research.module.css";
 import { formatDuration, signedPoints } from "../../lib/research/format";
+import { stanceLabel } from "../../lib/research/i18n";
+import type { ConsoleLocale } from "../../lib/research/locale";
 import type { ResearchState, ResearchStageState } from "../../lib/research/state-machine";
 import type {
   PredictionEvidence,
@@ -20,19 +22,12 @@ const STANCE_CLASS: Record<PredictionEvidence["stance"], string | undefined> = {
   neutral: styles.stanceNeutral
 };
 
-const STANCE_LABEL: Record<PredictionEvidence["stance"], string> = {
-  support: "支持",
-  oppose: "反对",
-  mixed: "中性",
-  neutral: "边界"
-};
-
-function EvidenceRows({ items }: { items: PredictionEvidence[] }) {
+function EvidenceRows({ items, locale }: { items: PredictionEvidence[]; locale: ConsoleLocale }) {
   return (
     <div className={styles.liveList}>
       {items.map((item) => (
         <div key={item.id} className={styles.liveRow}>
-          <span className={`${styles.stance} ${STANCE_CLASS[item.stance]}`}>{STANCE_LABEL[item.stance]}</span>
+          <span className={`${styles.stance} ${STANCE_CLASS[item.stance]}`}>{stanceLabel(locale, item.stance)}</span>
           <span className={styles.liveTitle}>{item.title}</span>
           <span className={`${styles.liveWeight} ${item.weightPct >= 0 ? styles.weightPos : styles.weightNeg}`}>
             {signedPoints(item.weightPct)}
@@ -73,9 +68,9 @@ function UpdateRows({ items }: { items: PredictionUpdate[] }) {
 }
 
 // Which streamed artifacts belong in a given stage's live panel.
-function liveArtifacts(stageId: string, state: ResearchState) {
+function liveArtifacts(stageId: string, state: ResearchState, locale: ConsoleLocale) {
   if (stageId === "evidence" || stageId === "weighting") {
-    return state.evidence.length > 0 ? <EvidenceRows items={state.evidence} /> : null;
+    return state.evidence.length > 0 ? <EvidenceRows items={state.evidence} locale={locale} /> : null;
   }
   if (stageId === "model") {
     return state.model.length > 0 ? <ModelRows items={state.model} /> : null;
@@ -86,7 +81,7 @@ function liveArtifacts(stageId: string, state: ResearchState) {
   return null;
 }
 
-function StageCard({ stage, state }: { stage: ResearchStageState; state: ResearchState }) {
+function StageCard({ stage, state, locale }: { stage: ResearchStageState; state: ResearchState; locale: ConsoleLocale }) {
   const isActive = stage.status === "active";
   const isComplete = stage.status === "complete";
   const cardClass = `${styles.stage} ${
@@ -116,7 +111,7 @@ function StageCard({ stage, state }: { stage: ResearchStageState; state: Researc
               </span>
             ))}
           </div>
-          {liveArtifacts(stage.id, state)}
+          {liveArtifacts(stage.id, state, locale)}
         </div>
       ) : null}
 
@@ -133,14 +128,14 @@ function StageCard({ stage, state }: { stage: ResearchStageState; state: Researc
   );
 }
 
-export function StageTimeline({ state }: { state: ResearchState }) {
+export function StageTimeline({ state, locale }: { state: ResearchState; locale: ConsoleLocale }) {
   if (state.stages.length === 0) {
     return null;
   }
   return (
     <div className={styles.timeline}>
       {state.stages.map((stage) => (
-        <StageCard key={stage.id} stage={stage} state={state} />
+        <StageCard key={stage.id} stage={stage} state={state} locale={locale} />
       ))}
     </div>
   );

--- a/apps/web/components/research/state-machine-legend.tsx
+++ b/apps/web/components/research/state-machine-legend.tsx
@@ -5,13 +5,15 @@
 // picture of where the machine in `state-machine.ts` currently sits.
 
 import styles from "./research.module.css";
+import { c, type ConsoleStringKey } from "../../lib/research/i18n";
+import type { ConsoleLocale } from "../../lib/research/locale";
 import type { ResearchPhase, ResearchStageState } from "../../lib/research/state-machine";
 
-const PHASE_LABEL: Record<ResearchPhase, string> = {
-  idle: "待命 IDLE",
-  running: "运行中 RUNNING",
-  complete: "已完成 COMPLETE",
-  error: "出错 ERROR"
+const PHASE_KEY: Record<ResearchPhase, ConsoleStringKey> = {
+  idle: "phaseIdle",
+  running: "phaseRunning",
+  complete: "phaseComplete",
+  error: "phaseError"
 };
 
 const PHASE_CLASS: Record<ResearchPhase, string | undefined> = {
@@ -23,16 +25,18 @@ const PHASE_CLASS: Record<ResearchPhase, string | undefined> = {
 
 export function StateMachineLegend({
   phase,
-  stages
+  stages,
+  locale
 }: {
   phase: ResearchPhase;
   stages: ResearchStageState[];
+  locale: ConsoleLocale;
 }) {
   return (
     <div className={styles.machine}>
       <div className={styles.machineTop}>
-        <span className={styles.machineLabel}>Forecasting Engine 状态机</span>
-        <span className={`${styles.phasePill} ${PHASE_CLASS[phase]}`}>{PHASE_LABEL[phase]}</span>
+        <span className={styles.machineLabel}>{c(locale, "machineLabel")}</span>
+        <span className={`${styles.phasePill} ${PHASE_CLASS[phase]}`}>{c(locale, PHASE_KEY[phase])}</span>
       </div>
       <div className={styles.machineTrack}>
         {stages.map((stage, index) => {

--- a/apps/web/lib/prediction-engine-demo.ts
+++ b/apps/web/lib/prediction-engine-demo.ts
@@ -1,8 +1,13 @@
+import { pick, type ConsoleLocale } from "./research/locale";
+
 export type PredictionEvidenceStance = "support" | "oppose" | "mixed" | "neutral";
 
 export interface PredictionEngineRequest {
   eventText: string;
   marketPrice?: number | null;
+  // Output locale for all human-readable prose (verdict, evidence, narration,
+  // stage copy). English is the default to match the apex of the public site.
+  locale?: ConsoleLocale;
 }
 
 export interface PredictionStage {
@@ -88,6 +93,11 @@ export interface PredictionEngineRun {
   // real-research snapshot to surface the actual pipeline (search angles, raw
   // findings, adversarial verdicts) step by step.
   progressByStage?: Record<string, string[]>;
+  // Snapshot date + the event's resolution deadline (curated real-research cases
+  // supply these). Surfaced prominently because the forecast is a point-in-time
+  // read of a fast-moving, time-boxed event.
+  asOf?: string;
+  deadline?: string;
 }
 
 export const DEFAULT_PREDICTION_EVENT = "美国和伊朗能在 2026-06-30 前达成核协议吗？";
@@ -127,6 +137,27 @@ function parseMarketPrice(value: number | null | undefined, fallback: number): n
   return value > 1 ? roundProbability(value / 100) : roundProbability(value);
 }
 
+// Source-type category labels are authored in Chinese in the evidence data;
+// this maps the finite set to English so the ledger reads in one language.
+const SOURCE_TYPE_EN: Record<string, string> = {
+  官方声明: "Official statement",
+  官方数据: "Official data",
+  官方表态: "Official remarks",
+  主流媒体: "Mainstream media",
+  "主流媒体（区域）": "Mainstream media (regional)",
+  "第三方分析": "Third-party analysis",
+  "第三方分析（智库）": "Third-party analysis (think tank)",
+  "当事方媒体（伊朗官方）": "Party-side media (Iran official)",
+  "当事方/本地来源": "Party-side / local source",
+  预测市场: "Prediction market",
+  "国际机构/官方研究": "International body / official research",
+  "政治/安全动态": "Political / security development"
+};
+
+function localizeSourceType(locale: ConsoleLocale, zh: string): string {
+  return locale === "zh" ? zh : SOURCE_TYPE_EN[zh] ?? zh;
+}
+
 function isIranNuclearEvent(eventText: string): boolean {
   const lower = eventText.toLowerCase();
   return (
@@ -154,6 +185,8 @@ function buildFedEvidence(): PredictionEvidence[] {
   // first (lifts the baseline), then the counter-evidence (tempers it), then
   // the remaining supporting data. Node A = inflation room, B = growth/labour
   // softening, C = a ≥50bp cut actually landing before the deadline.
+  // Titles + excerpts are authored in English; only the sourceType category is
+  // localized at run assembly.
   return [
     {
       id: "fomc-statement-2026-06-12",
@@ -216,62 +249,118 @@ function buildFedEvidence(): PredictionEvidence[] {
   ];
 }
 
-function buildStages(): PredictionStage[] {
+function buildStages(locale: ConsoleLocale): PredictionStage[] {
   return [
     {
       id: "definition",
       order: 1,
-      title: "理清定义",
-      summary: "确定 Yes/No 触发条件、截止时间、主体和官方认定口径。",
-      detail: "把单方表态、继续谈判、临时框架和可结算协议分开，避免把新闻热度误当成事件完成。",
+      title: pick(locale, "Frame the definition", "理清定义"),
+      summary: pick(
+        locale,
+        "Pin down the Yes/No trigger, the deadline, the parties, and the official resolution criterion.",
+        "确定 Yes/No 触发条件、截止时间、主体和官方认定口径。"
+      ),
+      detail: pick(
+        locale,
+        "Separate one-sided statements, ongoing talks, an interim framework, and a settleable agreement — so news buzz isn't mistaken for the event completing.",
+        "把单方表态、继续谈判、临时框架和可结算协议分开，避免把新闻热度误当成事件完成。"
+      ),
       durationMs: 420
     },
     {
       id: "query-design",
       order: 2,
-      title: "基础推理与 query",
-      summary: "拆成 2-5 个必要条件，并为每个条件生成官方、媒体、当事方和第三方 query。",
-      detail: "这一步决定后续证据覆盖面，生产版会把 query plan 写入 Pulse artifact。",
+      title: pick(locale, "Base reasoning & queries", "基础推理与 query"),
+      summary: pick(
+        locale,
+        "Break the event into 2–5 necessary conditions and generate official, media, party-side, and third-party queries for each.",
+        "拆成 2-5 个必要条件，并为每个条件生成官方、媒体、当事方和第三方 query。"
+      ),
+      detail: pick(
+        locale,
+        "This step sets downstream evidence coverage; production writes the query plan into the Pulse artifact.",
+        "这一步决定后续证据覆盖面，生产版会把 query plan 写入 Pulse artifact。"
+      ),
       durationMs: 360
     },
     {
       id: "evidence",
       order: 3,
-      title: "证据收集与罗列",
-      summary: "按来源类型整理证据：官方声明、主流媒体、当事方媒体、第三方分析、政治/安全动态。",
-      detail: "Demo 展示的是可审计的数据结构；真实模式会来自 Pulse web-search 与页面抓取。",
+      title: pick(locale, "Evidence collection", "证据收集与罗列"),
+      summary: pick(
+        locale,
+        "Organize evidence by source type: official statements, mainstream media, party-side media, third-party analysis, political/security developments.",
+        "按来源类型整理证据：官方声明、主流媒体、当事方媒体、第三方分析、政治/安全动态。"
+      ),
+      detail: pick(
+        locale,
+        "The demo shows an auditable data structure; real mode draws from Pulse web-search and page scraping.",
+        "Demo 展示的是可审计的数据结构；真实模式会来自 Pulse web-search 与页面抓取。"
+      ),
       durationMs: 520
     },
     {
       id: "weighting",
       order: 4,
-      title: "证据权重更新",
-      summary: "按一手性、时效、交叉印证和战略性放话风险给每条证据加权。",
-      detail: "强支持/强反对不会只看标题，会落到具体模型节点。",
+      title: pick(locale, "Evidence weighting", "证据权重更新"),
+      summary: pick(
+        locale,
+        "Weight each item by primary-source quality, recency, cross-corroboration, and strategic-signalling risk.",
+        "按一手性、时效、交叉印证和战略性放话风险给每条证据加权。"
+      ),
+      detail: pick(
+        locale,
+        "Strong support/oppose isn't judged by headline alone — it maps to specific model nodes.",
+        "强支持/强反对不会只看标题，会落到具体模型节点。"
+      ),
       durationMs: 380
     },
     {
       id: "model",
       order: 5,
-      title: "结构化模型",
-      summary: "把事件拆成条件概率：P(Yes)=P(A)xP(B|A)xP(C|A,B)。",
-      detail: "每个节点保留概率、理由、关键证据和残余不确定性。",
+      title: pick(locale, "Structured model", "结构化模型"),
+      summary: pick(
+        locale,
+        "Decompose the event into conditional probabilities: P(Yes)=P(A)×P(B|A)×P(C|A,B).",
+        "把事件拆成条件概率：P(Yes)=P(A)xP(B|A)xP(C|A,B)。"
+      ),
+      detail: pick(
+        locale,
+        "Each node retains its probability, rationale, key evidence, and residual uncertainty.",
+        "每个节点保留概率、理由、关键证据和残余不确定性。"
+      ),
       durationMs: 460
     },
     {
       id: "bayes",
       order: 6,
-      title: "贝叶斯式更新",
-      summary: "从基线概率出发，逐条说明重要证据如何上调或下调。",
-      detail: "输出主概率和 80% 主观置信区间，而不是只给可能/不可能。",
+      title: pick(locale, "Bayesian update", "贝叶斯式更新"),
+      summary: pick(
+        locale,
+        "Start from a baseline probability and explain item by item how key evidence raises or lowers it.",
+        "从基线概率出发，逐条说明重要证据如何上调或下调。"
+      ),
+      detail: pick(
+        locale,
+        "Outputs a point probability and an 80% subjective interval — not just likely/unlikely.",
+        "输出主概率和 80% 主观置信区间，而不是只给可能/不可能。"
+      ),
       durationMs: 440
     },
     {
       id: "market",
       order: 7,
-      title: "结论与市场偏差",
-      summary: "给出 Yes 概率、置信区间，并和市场价格比较是否存在 edge。",
-      detail: "Demo 不会下单；真实执行仍要经过 Pulse 风控和交易所门槛。",
+      title: pick(locale, "Conclusion & market gap", "结论与市场偏差"),
+      summary: pick(
+        locale,
+        "Give the Yes probability and interval, then compare with the market price to check for an edge.",
+        "给出 Yes 概率、置信区间，并和市场价格比较是否存在 edge。"
+      ),
+      detail: pick(
+        locale,
+        "The demo never trades; real execution still passes Pulse risk controls and exchange thresholds.",
+        "Demo 不会下单；真实执行仍要经过 Pulse 风控和交易所门槛。"
+      ),
       durationMs: 340
     }
   ];
@@ -282,7 +371,8 @@ function buildStages(): PredictionStage[] {
 // 3 adversarial verifiers + synthesis). Live source URLs + dates below; this is
 // the flagship "Skuld" case's data, not hand-mocked. Re-run the workflow to
 // refresh it as the 2026-06-30 deadline approaches.
-function buildIranEvidence(): PredictionEvidence[] {
+function buildIranEvidence(locale: ConsoleLocale): PredictionEvidence[] {
+  const excerpts = IRAN_CONTENT[locale].excerpts;
   return [
     {
       id: "techtimes-2026-06-13",
@@ -293,8 +383,7 @@ function buildIranEvidence(): PredictionEvidence[] {
       weightPct: -14,
       reliability: 0.55,
       node: "B",
-      excerpt:
-        "在桌面上的唯一协议（Islamabad Declaration MOU）是非约束性工具，不要求交出/封顶约 440kg 60% 高浓铀，未指定核查机制，把浓缩/核查/库存谈判推到签署后才开始的 60 天窗口；截至 6/13 仍未签署，等待伊朗最高领袖批准。",
+      excerpt: excerpts["techtimes-2026-06-13"]!,
       url: "https://www.techtimes.com/articles/318319/20260613/iran-peace-deal-text-agreed-440kg-enriched-uranium-stays-tehran-during-60-day-talks.htm"
     },
     {
@@ -306,8 +395,7 @@ function buildIranEvidence(): PredictionEvidence[] {
       weightPct: 3,
       reliability: 0.7,
       node: "A",
-      excerpt:
-        "美伊（巴基斯坦斡旋）就草案 MOU 最终文本达成一致，Trump 暗示数日内可能在欧洲签署；伊朗承诺永不获取或发展核武器，但清除高浓铀库存的技术细节未决、被推迟到下一轮技术谈判。",
+      excerpt: excerpts["cnn-liveblog-2026-06-12"]!,
       url: "https://www.cnn.com/2026/06/12/world/live-news/iran-war-trump-israel"
     },
     {
@@ -319,8 +407,7 @@ function buildIranEvidence(): PredictionEvidence[] {
       weightPct: -10,
       reliability: 0.85,
       node: "C",
-      excerpt:
-        "IAEA 自 2026-02-28 起停止对伊核保障核查；机构对 8 处设施无准入，无法核查浓缩/再处理暂停，也无法核查约 440.9kg 60% 高浓铀。结论：在恢复准入前近期核查安排存在问题，节点 C 结构性受阻。",
+      excerpt: excerpts["isis-2026-06-04"]!,
       url: "https://isis-online.org/isis-reports/analysis-of-iaea-iran-verification-and-monitoring-and-npt-safeguards-reports-june-2026"
     },
     {
@@ -332,8 +419,7 @@ function buildIranEvidence(): PredictionEvidence[] {
       weightPct: -9,
       reliability: 0.8,
       node: "B",
-      excerpt:
-        "外交部发言人 Baghaei 称 14 点 MOU 聚焦结束战争、停止美海军行动、释放被冻结资产，并明确现阶段不讨论核问题细节，把核/浓缩事项推迟到后续谈判——框架本身不含合格核条款。",
+      excerpt: excerpts["presstv-baghaei-2026-05-23"]!,
       url: "https://www.presstv.ir/Detail/2026/05/23/769157/Iran-US-Baghaei-understanding-nuclear"
     },
     {
@@ -345,8 +431,7 @@ function buildIranEvidence(): PredictionEvidence[] {
       weightPct: -8,
       reliability: 0.85,
       node: "B",
-      excerpt:
-        "分析人士（Chatham House 的 Tabrizi、NATO Defense College 的 Weitz）称这不是最终核解决方案：伊朗方案把浓缩与导弹移出初始协议、把核细节推入 60 天窗口；敲定核细节相比重开霍尔木兹海峡极具挑战性。",
+      excerpt: excerpts["aljazeera-2026-06-12"]!,
       url: "https://www.aljazeera.com/features/2026/6/12/are-iran-us-really-close-to-a-breakthrough-deal"
     },
     {
@@ -358,8 +443,7 @@ function buildIranEvidence(): PredictionEvidence[] {
       weightPct: 6,
       reliability: 0.8,
       node: "C",
-      excerpt:
-        "直接截止日匹配：约 67% YES，约 $8.8M 成交量（6/14 直取页面确认）。结算口径宽泛——只要 6/30 前公开宣布任何相互核协议即可 YES，不要求浓缩上限/核查/库存条款，因此高估严格合格协议。",
+      excerpt: excerpts["polymarket-by-june30-2026-06-14"]!,
       url: "https://polymarket.com/event/us-iran-nuclear-deal-by-june-30"
     },
     {
@@ -371,8 +455,7 @@ function buildIranEvidence(): PredictionEvidence[] {
       weightPct: -7,
       reliability: 0.75,
       node: "C",
-      excerpt:
-        "Islamabad Declaration 将在 30 天内重开霍尔木兹海峡，但把伊朗 440kg 库存留待 60 天后续谈判，不要求签署前交出、移除、销毁或封顶；IAEA 无法核查剩余高浓铀——核条款在 6/30 前不可结算。",
+      excerpt: excerpts["ukcommons-cbp10637-2026-06-12"]!,
       url: "https://commonslibrary.parliament.uk/research-briefings/cbp-10637/"
     },
     {
@@ -384,8 +467,7 @@ function buildIranEvidence(): PredictionEvidence[] {
       weightPct: -2,
       reliability: 0.5,
       node: "C",
-      excerpt:
-        "Kalshi 市场早 6 月快照显示 7 月前仅约 23%、11 月前约 53%，显著低于 Polymarket 的 6/30 读数。实时数字因 HTTP 429 无法刷新，按陈旧下行锚点处理、已下调权重。",
+      excerpt: excerpts["kalshi-index-2026-06-14"]!,
       url: "https://kalshi.com/markets/kxusairanagreement"
     }
   ];
@@ -454,55 +536,26 @@ function buildGenericEvidence(eventText: string, hash: number): PredictionEviden
   ];
 }
 
-function buildModel(eventText: string, hash: number): PredictionModelNode[] {
+function buildModel(eventText: string, hash: number, locale: ConsoleLocale): PredictionModelNode[] {
   if (isIranNuclearEvent(eventText)) {
     // Real research snapshot (2026-06-13): product ≈ 0.72×0.15×0.45 ≈ 5%,
     // calibrated up to 10% (see resolveCuratedCase) for the broad-criterion tail.
+    const labels = IRAN_CONTENT[locale].modelLabels;
+    const rationales = IRAN_CONTENT[locale].modelRationales;
     return [
-      {
-        id: "A",
-        label: "A: 双方公开接受框架/MOU",
-        probability: 0.72,
-        rationale:
-          "Islamabad Declaration MOU 文本约 6/12 达成、签署被吹风为临近；但截至 6/14 仍未签署，等待伊朗最高领袖批准，Baghaei 还公开反驳了 Trump 的时间表。框架获双方公开接受概率高但不确定。"
-      },
-      {
-        id: "B",
-        label: "B|A: 框架含充分合格核条款（浓缩/核查/库存）",
-        probability: 0.15,
-        rationale:
-          "结构性致命点。CNN、Al Jazeera、ISIS、UK Commons Library 及伊美双方官员一致确认 MOU 刻意把核实质剥离：约 440kg 高浓铀留在德黑兰、无指定核查机制、浓缩时长争议未解，全部推迟到签署后 60 天窗口。该工具按设计不构成合格核协议。"
-      },
-      {
-        id: "C",
-        label: "C|A,B: 6/30 前可公开确认并可结算",
-        probability: 0.45,
-        rationale:
-          "即便假设存在合格框架，IAEA 已约 97 天零准入、无法核查 440.9kg 库存，核查在窗口内物理上不可能，且 60 天时钟跑到约 8 月底。核档案的可结算性高度受限。"
-      }
+      { id: "A", label: labels.A, probability: 0.72, rationale: rationales.A },
+      { id: "B", label: labels.B, probability: 0.15, rationale: rationales.B },
+      { id: "C", label: labels.C, probability: 0.45, rationale: rationales.C }
     ];
   }
 
   if (isFedRateCutEvent(eventText)) {
+    const labels = FED_CONTENT[locale].modelLabels;
+    const rationales = FED_CONTENT[locale].modelRationales;
     return [
-      {
-        id: "A",
-        label: "A: 通胀回落给出降息空间",
-        probability: 0.8,
-        rationale: "核心 CPI 降温、通胀预期回落，使政策转向宽松具备条件。"
-      },
-      {
-        id: "B",
-        label: "B|A: 增长/就业走弱构成宽松理由",
-        probability: 0.85,
-        rationale: "劳动力市场和增长放缓通常是 Fed 真正动手的触发条件。"
-      },
-      {
-        id: "C",
-        label: "C|A,B: 9 月前累计降息 ≥50bp 落地",
-        probability: 0.84,
-        rationale: "两次 25bp 或一次 50bp 须在窗口内兑现；点阵图支持，但时点是关键不确定性。"
-      }
+      { id: "A", label: labels.A, probability: 0.8, rationale: rationales.A },
+      { id: "B", label: labels.B, probability: 0.85, rationale: rationales.B },
+      { id: "C", label: labels.C, probability: 0.84, rationale: rationales.C }
     ];
   }
 
@@ -512,52 +565,85 @@ function buildModel(eventText: string, hash: number): PredictionModelNode[] {
   return [
     {
       id: "A",
-      label: "A: 事件进入可执行阶段",
+      label: pick(locale, "A: Event reaches an actionable stage", "A: 事件进入可执行阶段"),
       probability: a,
-      rationale: "基于事件描述先估计各方是否已经越过纯表态阶段。"
+      rationale: pick(
+        locale,
+        "Estimate from the description whether the parties have moved past pure posturing.",
+        "基于事件描述先估计各方是否已经越过纯表态阶段。"
+      )
     },
     {
       id: "B",
-      label: "B|A: 关键约束被满足",
+      label: pick(locale, "B|A: Key constraints are satisfied", "B|A: 关键约束被满足"),
       probability: b,
-      rationale: "检查法律、资金、政治、技术或军事约束是否仍会阻断结果。"
+      rationale: pick(
+        locale,
+        "Check whether legal, financial, political, technical, or military constraints still block the outcome.",
+        "检查法律、资金、政治、技术或军事约束是否仍会阻断结果。"
+      )
     },
     {
       id: "C",
-      label: "C|A,B: 截止前可被公开确认",
+      label: pick(locale, "C|A,B: Publicly confirmable before the deadline", "C|A,B: 截止前可被公开确认"),
       probability: c,
-      rationale: "短期限事件最后通常卡在确认口径、执行细节或公开披露。"
+      rationale: pick(
+        locale,
+        "Short-deadline events usually hinge on the confirmation criterion, execution detail, or public disclosure.",
+        "短期限事件最后通常卡在确认口径、执行细节或公开披露。"
+      )
     }
   ];
 }
 
-function buildUpdates(baseline: number, finalProbability: number, evidence: PredictionEvidence[]): PredictionUpdate[] {
+function buildUpdates(
+  baseline: number,
+  finalProbability: number,
+  evidence: PredictionEvidence[],
+  locale: ConsoleLocale
+): PredictionUpdate[] {
   const first = roundProbability(clamp(baseline + evidence[0]!.weightPct / 100, 0.02, 0.98));
   const second = roundProbability(clamp(first + evidence.slice(1, 3).reduce((sum, item) => sum + item.weightPct, 0) / 100, 0.02, 0.98));
   return [
     {
-      label: "基线",
+      label: pick(locale, "Baseline", "基线"),
       from: baseline,
       to: baseline,
-      explanation: "从同类型、同期限事件的基础成功率开始。"
+      explanation: pick(
+        locale,
+        "Start from the base success rate of same-type, same-horizon events.",
+        "从同类型、同期限事件的基础成功率开始。"
+      )
     },
     {
-      label: "官方/主流证据",
+      label: pick(locale, "Official / mainstream evidence", "官方/主流证据"),
       from: baseline,
       to: first,
-      explanation: "官方信号和主流报道决定是否把概率推离基线。"
+      explanation: pick(
+        locale,
+        "Official signals and mainstream reporting decide whether to move off the baseline.",
+        "官方信号和主流报道决定是否把概率推离基线。"
+      )
     },
     {
-      label: "反向证据",
+      label: pick(locale, "Counter-evidence", "反向证据"),
       from: first,
       to: second,
-      explanation: "当事方否认、执行障碍或验证问题会下调可结算结果概率。"
+      explanation: pick(
+        locale,
+        "Party-side denials, execution obstacles, or verification problems lower the settleable-outcome probability.",
+        "当事方否认、执行障碍或验证问题会下调可结算结果概率。"
+      )
     },
     {
-      label: "模型校准",
+      label: pick(locale, "Model calibration", "模型校准"),
       from: second,
       to: finalProbability,
-      explanation: "条件概率模型给出最终 Yes 概率和置信区间。"
+      explanation: pick(
+        locale,
+        "The conditional-probability model yields the final Yes probability and interval.",
+        "条件概率模型给出最终 Yes 概率和置信区间。"
+      )
     }
   ];
 }
@@ -569,39 +655,76 @@ function buildProgressItems(input: {
   yesProbability: number;
   marketProbability: number | null;
   edge: number | null;
+  locale: ConsoleLocale;
 }): PredictionProgressItem[] {
+  const { locale } = input;
   const evidenceCount = input.evidence.length;
   const supportCount = input.evidence.filter((item) => item.stance === "support").length;
   const opposeCount = input.evidence.filter((item) => item.stance === "oppose").length;
-  const marketText = input.marketProbability == null ? "未提供市场价格" : `市场 ${formatProbability(input.marketProbability)}`;
-  const edgeText = input.edge == null ? "edge 未计算" : `edge ${(input.edge * 100).toFixed(1)}pp`;
+  const marketText =
+    input.marketProbability == null
+      ? pick(locale, "no market price", "未提供市场价格")
+      : pick(locale, `market ${formatProbability(input.marketProbability)}`, `市场 ${formatProbability(input.marketProbability)}`);
+  const edgeText =
+    input.edge == null
+      ? pick(locale, "edge n/a", "edge 未计算")
+      : `edge ${(input.edge * 100).toFixed(1)}pp`;
+  const modelIds = input.model.map((node) => node.id).join("/");
   const outcomes: Record<string, { outcome: string; artifactLabel: string }> = {
     definition: {
-      outcome: "已确定事件主体、截止时间、Yes/No 触发边界和需要人工复核的结算口径。",
+      outcome: pick(
+        locale,
+        "Locked the event's parties, deadline, Yes/No trigger boundary, and the resolution criterion needing human review.",
+        "已确定事件主体、截止时间、Yes/No 触发边界和需要人工复核的结算口径。"
+      ),
       artifactLabel: "resolution_definition"
     },
     "query-design": {
-      outcome: "已把事件拆成 A/B/C 条件节点，并准备官方、媒体、当事方、本地与第三方 query。",
+      outcome: pick(
+        locale,
+        "Decomposed the event into A/B/C condition nodes and prepared official, media, party-side, local, and third-party queries.",
+        "已把事件拆成 A/B/C 条件节点，并准备官方、媒体、当事方、本地与第三方 query。"
+      ),
       artifactLabel: "query_plan"
     },
     evidence: {
-      outcome: `已整理 ${evidenceCount} 条证据，其中支持 ${supportCount} 条、反对 ${opposeCount} 条，其余用于边界校验。`,
+      outcome: pick(
+        locale,
+        `Compiled ${evidenceCount} evidence items — ${supportCount} supporting, ${opposeCount} opposing, the rest for boundary checks.`,
+        `已整理 ${evidenceCount} 条证据，其中支持 ${supportCount} 条、反对 ${opposeCount} 条，其余用于边界校验。`
+      ),
       artifactLabel: "evidence_ledger"
     },
     weighting: {
-      outcome: "已按来源一手性、时效、交叉印证和战略性放话风险写入证据权重。",
+      outcome: pick(
+        locale,
+        "Wrote evidence weights from source primacy, recency, cross-corroboration, and strategic-signalling risk.",
+        "已按来源一手性、时效、交叉印证和战略性放话风险写入证据权重。"
+      ),
       artifactLabel: "evidence_weights"
     },
     model: {
-      outcome: `已建立 ${input.model.map((node) => node.id).join("/")} 条件概率模型，并完成乘法结构校验。`,
+      outcome: pick(
+        locale,
+        `Built the ${modelIds} conditional-probability model and verified its multiplicative structure.`,
+        `已建立 ${modelIds} 条件概率模型，并完成乘法结构校验。`
+      ),
       artifactLabel: "conditional_model"
     },
     bayes: {
-      outcome: `已将证据影响合并到基线，最终 Yes 概率为 ${formatProbability(input.yesProbability)}。`,
+      outcome: pick(
+        locale,
+        `Merged evidence impact into the baseline; final Yes probability ${formatProbability(input.yesProbability)}.`,
+        `已将证据影响合并到基线，最终 Yes 概率为 ${formatProbability(input.yesProbability)}。`
+      ),
       artifactLabel: "bayes_update"
     },
     market: {
-      outcome: `已输出结论：${formatProbability(input.yesProbability)}，${marketText}，${edgeText}。`,
+      outcome: pick(
+        locale,
+        `Output the conclusion: ${formatProbability(input.yesProbability)}, ${marketText}, ${edgeText}.`,
+        `已输出结论：${formatProbability(input.yesProbability)}，${marketText}，${edgeText}。`
+      ),
       artifactLabel: "market_comparison"
     }
   };
@@ -617,6 +740,201 @@ function buildProgressItems(input: {
     durationMs: stage.durationMs
   }));
 }
+
+// ── Curated real-research content, locale-keyed ─────────────────────────────
+// The US–Iran case is a REAL deep-research snapshot (2026-06-13). The English
+// side is a faithful translation of the authored Chinese — every number, date,
+// unit, URL, and proper noun is preserved identically; only prose differs.
+
+interface IranContent {
+  verdict: string;
+  excerpts: Record<string, string>;
+  modelLabels: Record<"A" | "B" | "C", string>;
+  modelRationales: Record<"A" | "B" | "C", string>;
+  updateLabels: [string, string, string, string];
+  updateExplanations: [string, string, string, string];
+  limitations: string[];
+  progressByStage: Record<string, string[]>;
+}
+
+const IRAN_CONTENT: Record<ConsoleLocale, IranContent> = {
+  zh: {
+    verdict:
+      "判 NO（严格意义上的合格核协议在 2026-06-30 前达成的概率约 10%）。核心驱动：实际临近签署的 MOU 按设计就不是核协议——浓缩上限、核查机制、约 440kg 高浓铀处置全部被推迟到签署后 60 天窗口（跑到约 8 月底），而 IAEA 约 97 天零准入使任何可结算的核协议在 16 天内物理上不可能。Polymarket 的 67% 衡量的是宽泛口径（任何公开宣布的核协议），并非本题的严格判定标准。",
+    excerpts: {
+      "techtimes-2026-06-13":
+        "在桌面上的唯一协议（Islamabad Declaration MOU）是非约束性工具，不要求交出/封顶约 440kg 60% 高浓铀，未指定核查机制，把浓缩/核查/库存谈判推到签署后才开始的 60 天窗口；截至 6/13 仍未签署，等待伊朗最高领袖批准。",
+      "cnn-liveblog-2026-06-12":
+        "美伊（巴基斯坦斡旋）就草案 MOU 最终文本达成一致，Trump 暗示数日内可能在欧洲签署；伊朗承诺永不获取或发展核武器，但清除高浓铀库存的技术细节未决、被推迟到下一轮技术谈判。",
+      "isis-2026-06-04":
+        "IAEA 自 2026-02-28 起停止对伊核保障核查；机构对 8 处设施无准入，无法核查浓缩/再处理暂停，也无法核查约 440.9kg 60% 高浓铀。结论：在恢复准入前近期核查安排存在问题，节点 C 结构性受阻。",
+      "presstv-baghaei-2026-05-23":
+        "外交部发言人 Baghaei 称 14 点 MOU 聚焦结束战争、停止美海军行动、释放被冻结资产，并明确现阶段不讨论核问题细节，把核/浓缩事项推迟到后续谈判——框架本身不含合格核条款。",
+      "aljazeera-2026-06-12":
+        "分析人士（Chatham House 的 Tabrizi、NATO Defense College 的 Weitz）称这不是最终核解决方案：伊朗方案把浓缩与导弹移出初始协议、把核细节推入 60 天窗口；敲定核细节相比重开霍尔木兹海峡极具挑战性。",
+      "polymarket-by-june30-2026-06-14":
+        "直接截止日匹配：约 67% YES，约 $8.8M 成交量（6/14 直取页面确认）。结算口径宽泛——只要 6/30 前公开宣布任何相互核协议即可 YES，不要求浓缩上限/核查/库存条款，因此高估严格合格协议。",
+      "ukcommons-cbp10637-2026-06-12":
+        "Islamabad Declaration 将在 30 天内重开霍尔木兹海峡，但把伊朗 440kg 库存留待 60 天后续谈判，不要求签署前交出、移除、销毁或封顶；IAEA 无法核查剩余高浓铀——核条款在 6/30 前不可结算。",
+      "kalshi-index-2026-06-14":
+        "Kalshi 市场早 6 月快照显示 7 月前仅约 23%、11 月前约 53%，显著低于 Polymarket 的 6/30 读数。实时数字因 HTTP 429 无法刷新，按陈旧下行锚点处理、已下调权重。"
+    },
+    modelLabels: {
+      A: "A: 双方公开接受框架/MOU",
+      B: "B|A: 框架含充分合格核条款（浓缩/核查/库存）",
+      C: "C|A,B: 6/30 前可公开确认并可结算"
+    },
+    modelRationales: {
+      A: "Islamabad Declaration MOU 文本约 6/12 达成、签署被吹风为临近；但截至 6/14 仍未签署，等待伊朗最高领袖批准，Baghaei 还公开反驳了 Trump 的时间表。框架获双方公开接受概率高但不确定。",
+      B: "结构性致命点。CNN、Al Jazeera、ISIS、UK Commons Library 及伊美双方官员一致确认 MOU 刻意把核实质剥离：约 440kg 高浓铀留在德黑兰、无指定核查机制、浓缩时长争议未解，全部推迟到签署后 60 天窗口。该工具按设计不构成合格核协议。",
+      C: "即便假设存在合格框架，IAEA 已约 97 天零准入、无法核查 440.9kg 库存，核查在窗口内物理上不可能，且 60 天时钟跑到约 8 月底。核档案的可结算性高度受限。"
+    },
+    updateLabels: ["基线", "官方信号/框架动能", "反向证据（核条款被推迟）", "模型校准"],
+    updateExplanations: [
+      "起点：16 天硬窗口内达成并可结算一份带核查的完整核协议历史上罕见，基率偏低。",
+      "White House 视频、行政官员称协议导向拆解伊朗核计划、CNN 报道伊朗承诺永不发展核武器、Polymarket 宽口径约 67%——把节点 A 推高并提供少量上行。",
+      "决定性反向证据：MOU 按设计把浓缩上限/核查/约 440kg 高浓铀处置推到签署后 60 天窗口；IAEA 约 97 天零准入使核查不可能；MOU 6/14 仍未签且伊朗公开拖延。节点 B 基本不满足、C 结构性受阻。",
+      "条件模型 P(A)·P(B|A)·P(C|A,B)≈0.72·0.15·0.45≈0.05；考虑题目有一定概率按更宽松的市场标准结算，向上微调至 0.10，与三条验证视角 0.08–0.22 区间一致。"
+    ],
+    limitations: [
+      "本结论是 2026-06-13 的真实联网研究快照（6 路 web 搜索 + 3 路对抗校验 + 综合）；截止 6/30 前局势可能变化，临近截止应重跑刷新。",
+      "市场参考为 Polymarket 宽口径市场（任何公开核协议即 YES，约 67%），与本题严格判定标准（需含浓缩上限/核查/库存）不同，故出现约 -57pp 的大幅 edge。",
+      "关键不确定性（IAEA 核查缺位、MOU 是否如期签署、60 天窗口走向）见证据账本中的来源链接。",
+      "完整原始数据（6 路角度共 34 条发现 + 3 路对抗校验全文 + 综合）已存快照：apps/web/lib/research/snapshots/us-iran-nuclear-2026-06-13.json。"
+    ],
+    progressByStage: {
+      definition: [
+        "结算口径：6/30 前双方公开确认、可结算、且含核条款（浓缩上限/核查/库存）的协议；停火、模糊声明或继续谈判都不算。",
+        "拆成三个必要条件：A 双方接受框架 × B 含合格核条款 × C 6/30 前可结算。"
+      ],
+      "query-design": [
+        "并行 6 路联网检索 + 3 路对抗校验。",
+        "角度：美国官方 / 伊朗官方 / IAEA·国际机构 / 西方媒体 / 区域分析 / 预测市场。"
+      ],
+      evidence: [
+        "联网搜索得 34 条原始发现（2026 年源优先；一条 2015 旧闻、一条 2025 旧红线已剔除或标注）。",
+        "美国官方：Trump 称『已有协议、伊朗永不拥核』(6/11)，但行政官员把拆解/核查放进签署后 60 天窗口、自评置信仅 80-85%。",
+        "伊朗官方：发言人 Baghaei 明确『现阶段不谈核细节』；伊朗否认已同意交出浓缩铀。",
+        "IAEA：约 97 天零准入、440.9kg 60% 高浓铀无法核查（ISIS 6/4、理事会 6/10 决议）。",
+        "西方媒体：MOU 约 95% 完成但仍未签，核条款明确推迟到 60 天窗口（CNN/TechTimes/UK Commons）。",
+        "区域分析：浓缩时长美 20 年 vs 伊 5 年僵局未解；预测市场 Polymarket 6/30 宽口径约 67%($8.8M)，Kalshi 7 月前约 23%（陈旧）。"
+      ],
+      weighting: [
+        "按一手性 / 时效 / 交叉印证加权；去重后保留 8 条进入账本。",
+        "对抗校验①时效真实性：两条 support 为真且属 2026，但只支撑『框架』弱版本；Polymarket 67% 衡量宽口径、非严格 B 节点。",
+        "对抗校验②反方求证：MOU 按设计就不是核协议，核实质全在签署后 60 天窗口；16 天内达成并核查完整协议基率极低。",
+        "对抗校验③市场校准：严格口径约 0.08–0.18；若按市场宽口径结算约 0.50–0.62；三视角综合区间 0.08–0.40。"
+      ],
+      model: ["条件概率模型：A 0.72 × B|A 0.15 × C|A,B 0.45 ≈ 模型基线 5%（再校准上调到 10%）。"],
+      bayes: ["贝叶斯路径：基线 12% → 官方信号/框架动能 18% → 核条款被推迟 8% → 模型校准 10%。"],
+      market: ["对比 Polymarket 宽口径 67%（任何公开核协议即 YES，口径不同）→ edge 约 -57pp。"]
+    }
+  },
+  en: {
+    verdict:
+      "Verdict: NO (the probability of a strictly qualifying nuclear deal being reached before 2026-06-30 is ~10%). Core driver: the MOU actually nearing signature is by design not a nuclear deal — the enrichment cap, verification mechanism, and disposition of ~440kg of HEU are all deferred to a 60-day window that starts only after signing (running to ~end of August), while IAEA's ~97 days of zero access make any settleable nuclear deal physically impossible within 16 days. Polymarket's 67% measures a broad criterion (any publicly announced nuclear deal), not this question's strict resolution standard.",
+    excerpts: {
+      "techtimes-2026-06-13":
+        "The only agreement on the table (the Islamabad Declaration MOU) is a non-binding instrument that does not require surrendering/capping the ~440kg of 60% HEU, specifies no verification mechanism, and pushes the enrichment/verification/stockpile negotiations into a 60-day window that begins only after signing; as of 6/13 it remains unsigned, awaiting approval by Iran's Supreme Leader.",
+      "cnn-liveblog-2026-06-12":
+        "The US and Iran (with Pakistan brokering) have agreed on the final text of a draft MOU, and Trump hinted at a possible signing in Europe within days; Iran pledged to never acquire or develop nuclear weapons, but the technical details of clearing the HEU stockpile remain unresolved and have been deferred to the next round of technical talks.",
+      "isis-2026-06-04":
+        "IAEA has halted its nuclear safeguards verification of Iran since 2026-02-28; the agency has no access to 8 facilities, cannot verify the suspension of enrichment/reprocessing, and cannot verify the ~440.9kg of 60% HEU. Conclusion: near-term verification arrangements are problematic until access is restored, leaving node C structurally blocked.",
+      "presstv-baghaei-2026-05-23":
+        "Foreign ministry spokesman Baghaei said the 14-point MOU focuses on ending the war, halting US naval operations, and releasing frozen assets, and stated explicitly that nuclear-issue details are not being discussed at this stage, deferring nuclear/enrichment matters to subsequent talks — the framework itself contains no qualifying nuclear clauses.",
+      "aljazeera-2026-06-12":
+        "Analysts (Chatham House's Tabrizi, NATO Defense College's Weitz) say this is not a final nuclear settlement: Iran's proposal moves enrichment and missiles out of the initial agreement and pushes nuclear details into the 60-day window; nailing down the nuclear details is far more challenging than reopening the Strait of Hormuz.",
+      "polymarket-by-june30-2026-06-14":
+        "Direct deadline match: ~67% YES, ~$8.8M volume (confirmed by pulling the page directly on 6/14). The resolution criterion is broad — YES requires only that any mutual nuclear agreement be publicly announced before 6/30, with no enrichment cap/verification/stockpile clauses required, so it overstates a strictly qualifying agreement.",
+      "ukcommons-cbp10637-2026-06-12":
+        "The Islamabad Declaration would reopen the Strait of Hormuz within 30 days, but leaves Iran's 440kg stockpile to 60-day follow-on talks, requiring no surrender, removal, destruction, or cap before signing; IAEA cannot verify the remaining HEU — the nuclear clauses are not settleable before 6/30.",
+      "kalshi-index-2026-06-14":
+        "The Kalshi market's early-June snapshot shows only ~23% before July and ~53% before November, markedly below Polymarket's 6/30 reading. The live numbers could not be refreshed due to HTTP 429, so they are treated as a stale downside anchor with reduced weight."
+    },
+    modelLabels: {
+      A: "A: Both sides publicly accept the framework/MOU",
+      B: "B|A: The framework contains sufficient qualifying nuclear clauses (enrichment/verification/stockpile)",
+      C: "C|A,B: Publicly confirmable and settleable before 6/30"
+    },
+    modelRationales: {
+      A: "The Islamabad Declaration MOU text was reached ~6/12 and signing has been spun as imminent; but as of 6/14 it remains unsigned, awaiting approval by Iran's Supreme Leader, and Baghaei has publicly rebutted Trump's timeline. The probability of both sides publicly accepting the framework is high but uncertain.",
+      B: "The structural fatal point. CNN, Al Jazeera, ISIS, the UK Commons Library, and officials on both the Iranian and US sides all confirm that the MOU deliberately strips out the nuclear substance: ~440kg of HEU stays in Tehran, no verification mechanism is specified, and the enrichment-duration dispute is unresolved — all deferred to a 60-day window after signing. By design this instrument does not constitute a qualifying nuclear deal.",
+      C: "Even assuming a qualifying framework exists, IAEA has had ~97 days of zero access and cannot verify the 440.9kg stockpile, making verification physically impossible within the window, and the 60-day clock runs to ~end of August. The settleability of the nuclear file is highly constrained."
+    },
+    updateLabels: ["Baseline", "Official signals / framework momentum", "Counter-evidence (nuclear clauses deferred)", "Model calibration"],
+    updateExplanations: [
+      "Starting point: reaching and settling a complete nuclear deal with verification within a hard 16-day window is historically rare, so the base rate is low.",
+      "A White House video, administration officials calling the deal oriented toward dismantling Iran's nuclear program, CNN reporting Iran's pledge to never develop nuclear weapons, and Polymarket's broad-criterion ~67% — these push node A higher and provide modest upside.",
+      "The decisive counter-evidence: the MOU by design pushes the enrichment cap/verification/disposition of ~440kg of HEU into a 60-day window after signing; IAEA's ~97 days of zero access make verification impossible; the MOU is still unsigned as of 6/14 and Iran is publicly stalling. Node B is essentially unmet and C is structurally blocked.",
+      "Conditional model P(A)·P(B|A)·P(C|A,B)≈0.72·0.15·0.45≈0.05; allowing some probability that the question settles by the looser market standard, nudged up to 0.10, consistent with the three verification perspectives' 0.08–0.22 range."
+    ],
+    limitations: [
+      "This conclusion is a real online-research snapshot from 2026-06-13 (6 web-search angles + 3 adversarial verifiers + synthesis); the situation may change before the 6/30 deadline, so it should be re-run to refresh as the deadline nears.",
+      "The market reference is the broad-criterion Polymarket market (any publicly announced nuclear deal counts as YES, ~67%), which differs from this question's strict resolution standard (must include enrichment cap/verification/stockpile), hence the large ~-57pp edge.",
+      "Key uncertainties (the IAEA verification gap, whether the MOU is signed on schedule, the trajectory of the 60-day window) are documented via the source links in the evidence ledger.",
+      "The full raw data (34 findings across 6 angles + the full text of 3 adversarial verifiers + synthesis) is saved as a snapshot: apps/web/lib/research/snapshots/us-iran-nuclear-2026-06-13.json."
+    ],
+    progressByStage: {
+      definition: [
+        "Resolution criterion: an agreement that is publicly confirmed by both sides before 6/30, settleable, and contains nuclear clauses (enrichment cap/verification/stockpile); a ceasefire, a vague statement, or continued talks do not count.",
+        "Decomposed into three necessary conditions: A both sides accept the framework × B contains qualifying nuclear clauses × C settleable before 6/30."
+      ],
+      "query-design": [
+        "6 parallel online-search angles + 3 adversarial verifiers.",
+        "Angles: US official / Iran official / IAEA·international bodies / Western media / regional analysis / prediction markets."
+      ],
+      evidence: [
+        "The web search yielded 34 raw findings (2026 sources prioritized; one 2015 old item and one 2025 old red line were removed or flagged).",
+        "US official: Trump said 'there's already a deal, Iran will never go nuclear' (6/11), but administration officials placed dismantlement/verification in a 60-day window after signing and self-rated confidence at only 80-85%.",
+        "Iran official: spokesman Baghaei stated explicitly 'no nuclear details at this stage'; Iran denied having agreed to hand over enriched uranium.",
+        "IAEA: ~97 days of zero access, the 440.9kg of 60% HEU cannot be verified (ISIS 6/4, Board of Governors 6/10 resolution).",
+        "Western media: the MOU is ~95% complete but still unsigned, with nuclear clauses explicitly deferred to the 60-day window (CNN/TechTimes/UK Commons).",
+        "Regional analysis: the enrichment-duration impasse (US 20 years vs Iran 5 years) is unresolved; prediction market Polymarket's 6/30 broad criterion ~67% ($8.8M), Kalshi ~23% before July (stale)."
+      ],
+      weighting: [
+        "Weighted by primary-source quality / recency / cross-corroboration; after deduplication, 8 items were retained for the ledger.",
+        "Adversarial verifier ① recency authenticity: both support items are genuine and from 2026, but only support the weak 'framework' version; Polymarket's 67% measures the broad criterion, not the strict B node.",
+        "Adversarial verifier ② counter-side challenge: the MOU is by design not a nuclear deal, with all nuclear substance in the 60-day window after signing; the base rate of reaching and verifying a complete agreement within 16 days is extremely low.",
+        "Adversarial verifier ③ market calibration: strict criterion ~0.08–0.18; if settled by the broad market criterion ~0.50–0.62; the three-perspective combined range is 0.08–0.40."
+      ],
+      model: ["Conditional probability model: A 0.72 × B|A 0.15 × C|A,B 0.45 ≈ model baseline 5% (recalibrated up to 10%)."],
+      bayes: ["Bayesian path: baseline 12% → official signals/framework momentum 18% → nuclear clauses deferred 8% → model calibration 10%."],
+      market: ["Compared against Polymarket's broad criterion 67% (any publicly announced nuclear deal counts as YES, different criterion) → edge ~-57pp."]
+    }
+  }
+};
+
+interface FedContent {
+  modelLabels: Record<"A" | "B" | "C", string>;
+  modelRationales: Record<"A" | "B" | "C", string>;
+}
+
+const FED_CONTENT: Record<ConsoleLocale, FedContent> = {
+  zh: {
+    modelLabels: {
+      A: "A: 通胀回落给出降息空间",
+      B: "B|A: 增长/就业走弱构成宽松理由",
+      C: "C|A,B: 9 月前累计降息 ≥50bp 落地"
+    },
+    modelRationales: {
+      A: "核心 CPI 降温、通胀预期回落，使政策转向宽松具备条件。",
+      B: "劳动力市场和增长放缓通常是 Fed 真正动手的触发条件。",
+      C: "两次 25bp 或一次 50bp 须在窗口内兑现；点阵图支持，但时点是关键不确定性。"
+    }
+  },
+  en: {
+    modelLabels: {
+      A: "A: Cooling inflation provides room to cut",
+      B: "B|A: Weakening growth/employment constitutes a reason to ease",
+      C: "C|A,B: Cumulative cut of ≥50bp lands before September"
+    },
+    modelRationales: {
+      A: "Cooling core CPI and falling inflation expectations create the conditions for a policy pivot toward easing.",
+      B: "A slowing labour market and growth are typically the trigger for the Fed to actually move.",
+      C: "Two 25bp moves or one 50bp move must materialize within the window; the dot plot supports it, but timing is the key uncertainty."
+    }
+  }
+};
 
 // Hand-curated demo cases (Iran nuclear deal, Fed rate cut). When the question
 // matches one, the run uses its authored evidence + fixed probability/interval
@@ -636,91 +954,38 @@ interface CuratedCase {
   updates?: PredictionUpdate[];
   limitations?: string[];
   progressByStage?: Record<string, string[]>;
+  asOf?: string;
+  deadline?: string;
 }
 
-function resolveCuratedCase(eventText: string): CuratedCase | null {
+function resolveCuratedCase(eventText: string, locale: ConsoleLocale): CuratedCase | null {
   if (isIranNuclearEvent(eventText)) {
     // REAL deep-research snapshot, 2026-06-13 (6 web-search angles + 3
     // adversarial verifiers + synthesis). P(YES) 10% vs Polymarket ~67%.
+    const content = IRAN_CONTENT[locale];
+    const updateFromTo: Array<[number, number]> = [
+      [0.12, 0.12],
+      [0.12, 0.18],
+      [0.18, 0.08],
+      [0.08, 0.1]
+    ];
     return {
-      evidence: buildIranEvidence(),
+      evidence: buildIranEvidence(locale),
       yesProbability: 0.1,
       baseline: 0.12,
       defaultMarketProbability: 0.67,
+      asOf: "2026-06-13",
+      deadline: "2026-06-30",
       confidenceInterval: [0.05, 0.2],
-      verdict:
-        "判 NO（严格意义上的合格核协议在 2026-06-30 前达成的概率约 10%）。核心驱动：实际临近签署的 MOU 按设计就不是核协议——浓缩上限、核查机制、约 440kg 高浓铀处置全部被推迟到签署后 60 天窗口（跑到约 8 月底），而 IAEA 约 97 天零准入使任何可结算的核协议在 16 天内物理上不可能。Polymarket 的 67% 衡量的是宽泛口径（任何公开宣布的核协议），并非本题的严格判定标准。",
-      updates: [
-        {
-          label: "基线",
-          from: 0.12,
-          to: 0.12,
-          explanation: "起点：16 天硬窗口内达成并可结算一份带核查的完整核协议历史上罕见，基率偏低。"
-        },
-        {
-          label: "官方信号/框架动能",
-          from: 0.12,
-          to: 0.18,
-          explanation:
-            "White House 视频、行政官员称协议导向拆解伊朗核计划、CNN 报道伊朗承诺永不发展核武器、Polymarket 宽口径约 67%——把节点 A 推高并提供少量上行。"
-        },
-        {
-          label: "反向证据（核条款被推迟）",
-          from: 0.18,
-          to: 0.08,
-          explanation:
-            "决定性反向证据：MOU 按设计把浓缩上限/核查/约 440kg 高浓铀处置推到签署后 60 天窗口；IAEA 约 97 天零准入使核查不可能；MOU 6/14 仍未签且伊朗公开拖延。节点 B 基本不满足、C 结构性受阻。"
-        },
-        {
-          label: "模型校准",
-          from: 0.08,
-          to: 0.1,
-          explanation:
-            "条件模型 P(A)·P(B|A)·P(C|A,B)≈0.72·0.15·0.45≈0.05；考虑题目有一定概率按更宽松的市场标准结算，向上微调至 0.10，与三条验证视角 0.08–0.22 区间一致。"
-        }
-      ],
-      limitations: [
-        "本结论是 2026-06-13 的真实联网研究快照（6 路 web 搜索 + 3 路对抗校验 + 综合）；截止 6/30 前局势可能变化，临近截止应重跑刷新。",
-        "市场参考为 Polymarket 宽口径市场（任何公开核协议即 YES，约 67%），与本题严格判定标准（需含浓缩上限/核查/库存）不同，故出现约 -57pp 的大幅 edge。",
-        "关键不确定性（IAEA 核查缺位、MOU 是否如期签署、60 天窗口走向）见证据账本中的来源链接。",
-        "完整原始数据（6 路角度共 34 条发现 + 3 路对抗校验全文 + 综合）已存快照：apps/web/lib/research/snapshots/us-iran-nuclear-2026-06-13.json。"
-      ],
-      // Real per-stage narration drawn from the actual run (search angles, raw
-      // findings by angle, the 3 adversarial verdicts). Replayed verbatim so the
-      // streamed steps reflect the genuine pipeline, not synthetic filler.
-      progressByStage: {
-        definition: [
-          "结算口径：6/30 前双方公开确认、可结算、且含核条款（浓缩上限/核查/库存）的协议；停火、模糊声明或继续谈判都不算。",
-          "拆成三个必要条件：A 双方接受框架 × B 含合格核条款 × C 6/30 前可结算。"
-        ],
-        "query-design": [
-          "并行 6 路联网检索 + 3 路对抗校验。",
-          "角度：美国官方 / 伊朗官方 / IAEA·国际机构 / 西方媒体 / 区域分析 / 预测市场。"
-        ],
-        evidence: [
-          "联网搜索得 34 条原始发现（2026 年源优先；一条 2015 旧闻、一条 2025 旧红线已剔除或标注）。",
-          "美国官方：Trump 称『已有协议、伊朗永不拥核』(6/11)，但行政官员把拆解/核查放进签署后 60 天窗口、自评置信仅 80-85%。",
-          "伊朗官方：发言人 Baghaei 明确『现阶段不谈核细节』；伊朗否认已同意交出浓缩铀。",
-          "IAEA：约 97 天零准入、440.9kg 60% 高浓铀无法核查（ISIS 6/4、理事会 6/10 决议）。",
-          "西方媒体：MOU 约 95% 完成但仍未签，核条款明确推迟到 60 天窗口（CNN/TechTimes/UK Commons）。",
-          "区域分析：浓缩时长美 20 年 vs 伊 5 年僵局未解；预测市场 Polymarket 6/30 宽口径约 67%($8.8M)，Kalshi 7 月前约 23%（陈旧）。"
-        ],
-        weighting: [
-          "按一手性 / 时效 / 交叉印证加权；去重后保留 8 条进入账本。",
-          "对抗校验①时效真实性：两条 support 为真且属 2026，但只支撑『框架』弱版本；Polymarket 67% 衡量宽口径、非严格 B 节点。",
-          "对抗校验②反方求证：MOU 按设计就不是核协议，核实质全在签署后 60 天窗口；16 天内达成并核查完整协议基率极低。",
-          "对抗校验③市场校准：严格口径约 0.08–0.18；若按市场宽口径结算约 0.50–0.62；三视角综合区间 0.08–0.40。"
-        ],
-        model: [
-          "条件概率模型：A 0.72 × B|A 0.15 × C|A,B 0.45 ≈ 模型基线 5%（再校准上调到 10%）。"
-        ],
-        bayes: [
-          "贝叶斯路径：基线 12% → 官方信号/框架动能 18% → 核条款被推迟 8% → 模型校准 10%。"
-        ],
-        market: [
-          "对比 Polymarket 宽口径 67%（任何公开核协议即 YES，口径不同）→ edge 约 -57pp。"
-        ]
-      }
+      verdict: content.verdict,
+      updates: updateFromTo.map(([from, to], index) => ({
+        label: content.updateLabels[index]!,
+        from,
+        to,
+        explanation: content.updateExplanations[index]!
+      })),
+      limitations: content.limitations,
+      progressByStage: content.progressByStage
     };
   }
   if (isFedRateCutEvent(eventText)) {
@@ -729,13 +994,20 @@ function resolveCuratedCase(eventText: string): CuratedCase | null {
   return null;
 }
 
-export function buildPredictionDemoRun(input: PredictionEngineRequest, now = new Date()): PredictionEngineRun {
+export function buildPredictionDemoRun(
+  input: PredictionEngineRequest,
+  now = new Date(),
+  locale: ConsoleLocale = "en"
+): PredictionEngineRun {
   const eventText = input.eventText.trim() || DEFAULT_PREDICTION_EVENT;
   const hash = hashText(eventText);
-  const model = buildModel(eventText, hash);
+  const model = buildModel(eventText, hash, locale);
   const rawModelProbability = model.reduce((product, node) => product * node.probability, 1);
-  const curated = resolveCuratedCase(eventText);
-  const evidence = curated ? curated.evidence : buildGenericEvidence(eventText, hash);
+  const curated = resolveCuratedCase(eventText, locale);
+  const rawEvidence = curated ? curated.evidence : buildGenericEvidence(eventText, hash);
+  // Source-type categories are authored in Chinese; localize them so the ledger
+  // reads in one language while keeping titles / excerpts as authored.
+  const evidence = rawEvidence.map((item) => ({ ...item, sourceType: localizeSourceType(locale, item.sourceType) }));
   const evidenceDelta = evidence.reduce((sum, item) => sum + item.weightPct, 0) / 100;
   const yesProbability = curated
     ? curated.yesProbability
@@ -748,12 +1020,26 @@ export function buildPredictionDemoRun(input: PredictionEngineRequest, now = new
     roundProbability(yesProbability - intervalWidth),
     roundProbability(yesProbability + intervalWidth)
   ];
-  const verdict = curated?.verdict ?? (edge > 0.03
-    ? "模型概率高于市场，存在正 edge，但仍需真实来源复核。"
-    : edge < -0.03
-      ? "模型概率低于市场，当前更像高估，适合继续观察或寻找 No 侧机会。"
-      : "模型概率与市场接近，暂时没有清晰偏差。");
-  const stages = buildStages();
+  const verdict =
+    curated?.verdict ??
+    (edge > 0.03
+      ? pick(
+          locale,
+          "Model probability exceeds the market — a positive edge, but still needs real-source review.",
+          "模型概率高于市场，存在正 edge，但仍需真实来源复核。"
+        )
+      : edge < -0.03
+        ? pick(
+            locale,
+            "Model probability is below the market — currently looks overpriced; keep watching or look for No-side opportunities.",
+            "模型概率低于市场，当前更像高估，适合继续观察或寻找 No 侧机会。"
+          )
+        : pick(
+            locale,
+            "Model probability is close to the market — no clear gap for now.",
+            "模型概率与市场接近，暂时没有清晰偏差。"
+          ));
+  const stages = buildStages(locale);
 
   return {
     id: `demo-${hash.toString(16)}`,
@@ -764,7 +1050,11 @@ export function buildPredictionDemoRun(input: PredictionEngineRequest, now = new
       source: "demo",
       endpointLabel: "in-process demo builder",
       status: "complete",
-      note: "未配置本地或 VPS 预测服务，因此使用确定性只读 demo 数据。"
+      note: pick(
+        locale,
+        "No local or VPS prediction service configured, so deterministic read-only demo data is used.",
+        "未配置本地或 VPS 预测服务，因此使用确定性只读 demo 数据。"
+      )
     },
     conclusion: {
       yesProbability,
@@ -776,20 +1066,29 @@ export function buildPredictionDemoRun(input: PredictionEngineRequest, now = new
     stages,
     evidence,
     model,
-    updates: curated?.updates ?? buildUpdates(curated ? curated.baseline : 0.32, yesProbability, evidence),
+    updates: curated?.updates ?? buildUpdates(curated ? curated.baseline : 0.32, yesProbability, evidence, locale),
     progress: buildProgressItems({
       stages,
       evidence,
       model,
       yesProbability,
       marketProbability,
-      edge
+      edge,
+      locale
     }),
-    limitations: curated?.limitations ?? [
-      "当前前端 demo 不触发真实 Pulse、实时 web-search 或真钱交易。",
-      "非默认事件使用确定性示例证据结构，生产模式需替换为 Pulse recommendation.json、web_search 和 evidence ledger。",
-      "市场价格比较只有在事件能映射到 Polymarket market 时才可作为真实 edge。"
-    ],
+    limitations:
+      curated?.limitations ??
+      (locale === "zh"
+        ? [
+            "当前前端 demo 不触发真实 Pulse、实时 web-search 或真钱交易。",
+            "非默认事件使用确定性示例证据结构，生产模式需替换为 Pulse recommendation.json、web_search 和 evidence ledger。",
+            "市场价格比较只有在事件能映射到 Polymarket market 时才可作为真实 edge。"
+          ]
+        : [
+            "This front-end demo does not trigger real Pulse, live web-search, or real-money trades.",
+            "Non-default events use a deterministic sample evidence structure; production must replace it with Pulse recommendation.json, web_search, and the evidence ledger.",
+            "The market comparison is only a real edge when the event maps to a Polymarket market."
+          ]),
     archiveLinks: [
       {
         label: "Stage-flow implementation note",
@@ -800,6 +1099,8 @@ export function buildPredictionDemoRun(input: PredictionEngineRequest, now = new
         path: "runtime-artifacts/probability-analysis/2026-06-05-us-iran-nuclear-deal/"
       }
     ],
-    progressByStage: curated?.progressByStage
+    progressByStage: curated?.progressByStage,
+    asOf: curated?.asOf,
+    deadline: curated?.deadline
   };
 }

--- a/apps/web/lib/research/drivers/api-driver.ts
+++ b/apps/web/lib/research/drivers/api-driver.ts
@@ -18,6 +18,7 @@ import {
   type NornTier
 } from "@autopoly/norns";
 import { buildPredictionDemoRun } from "../../prediction-engine-demo";
+import { normalizeConsoleLocale, pick, type ConsoleLocale } from "../locale";
 import { replayRun, type EmitFn } from "../replay";
 import { DriverNotConfiguredError, type ResearchDriver, type ResearchRequest } from "./types";
 
@@ -76,13 +77,22 @@ function resolveApiConfig(tier: NornTier): ApiConfig {
   return { provider, apiKey, model, live: readBool("RESEARCH_API_LIVE"), maxTokens, tier };
 }
 
-function buildResearchPrompt(eventText: string): string {
+function buildResearchPrompt(eventText: string, locale: ConsoleLocale): string {
+  if (locale === "zh") {
+    return [
+      "你是一个事件概率研究助手。针对下面的问题，按 Forecasting Engine 流程逐步分析：",
+      `问题：${eventText}`,
+      "",
+      "请输出简洁的分步推理（理清定义 → 条件拆解 → 证据 → 权重 → 条件概率模型 → 贝叶斯更新 → 结论），",
+      "每步 1-2 句中文，便于在流式 UI 中逐行展示。先不要下任何交易结论。"
+    ].join("\n");
+  }
   return [
-    "你是一个事件概率研究助手。针对下面的问题，按 Deep Research 流程逐步分析：",
-    `问题：${eventText}`,
+    "You are an event-probability research assistant. Analyze the question below step by step, following the Forecasting Engine pipeline:",
+    `Question: ${eventText}`,
     "",
-    "请输出简洁的分步推理（理清定义 → 条件拆解 → 证据 → 权重 → 条件概率模型 → 贝叶斯更新 → 结论），",
-    "每步 1-2 句中文，便于在流式 UI 中逐行展示。先不要下任何交易结论。"
+    "Output concise step-by-step reasoning (frame the definition → decompose conditions → evidence → weighting → conditional-probability model → Bayesian update → conclusion),",
+    "1-2 sentences per step in English, suitable for line-by-line display in a streaming UI. Do not draw any trading conclusion yet."
   ].join("\n");
 }
 
@@ -194,34 +204,56 @@ export const apiDriver: ResearchDriver = {
   id: "api",
   async run(request: ResearchRequest, emit: EmitFn, signal?: AbortSignal): Promise<void> {
     const tier = normalizeTier(request.tier);
+    const locale = normalizeConsoleLocale(request.locale);
     const config = resolveApiConfig(tier); // throws DriverNotConfiguredError → route falls back to mock
 
     // INTEGRATION POINT: structured backbone is scaffolded by the deterministic
     // generator. Replace this with a schema-validated extraction of the model's
     // own evidence / conditional model / conclusion to make the numbers live.
-    const run = buildPredictionDemoRun({
-      eventText: request.eventText,
-      marketPrice: request.marketPrice ?? null
-    });
+    const run = buildPredictionDemoRun(
+      {
+        eventText: request.eventText,
+        marketPrice: request.marketPrice ?? null
+      },
+      new Date(),
+      locale
+    );
 
     let narration: string[] = [];
     if (config.live) {
       try {
-        const text = await streamModelText(config, buildResearchPrompt(request.eventText), signal);
+        const text = await streamModelText(config, buildResearchPrompt(request.eventText, locale), signal);
         narration = splitNarration(text);
-        await emit({ type: "run.notice", level: "info", message: `已接入 ${config.provider}/${config.model} 实时推理。` });
+        await emit({
+          type: "run.notice",
+          level: "info",
+          message: pick(
+            locale,
+            `Connected to ${config.provider}/${config.model} live reasoning.`,
+            `已接入 ${config.provider}/${config.model} 实时推理。`
+          )
+        });
       } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
         await emit({
           type: "run.notice",
           level: "warn",
-          message: `${config.provider} 实时调用失败，本次回退到 demo 推理：${error instanceof Error ? error.message : String(error)}`
+          message: pick(
+            locale,
+            `${config.provider} live call failed; falling back to demo reasoning this run: ${detail}`,
+            `${config.provider} 实时调用失败，本次回退到 demo 推理：${detail}`
+          )
         });
       }
     } else {
       await emit({
         type: "run.notice",
         level: "info",
-        message: `API 链路已配置 (${config.provider})，但 RESEARCH_API_LIVE 未开启——本次使用 demo 结构回放。`
+        message: pick(
+          locale,
+          `API chain is configured (${config.provider}), but RESEARCH_API_LIVE is off — using a demo structural replay this run.`,
+          `API 链路已配置 (${config.provider})，但 RESEARCH_API_LIVE 未开启——本次使用 demo 结构回放。`
+        )
       });
     }
 
@@ -233,8 +265,16 @@ export const apiDriver: ResearchDriver = {
         source: "local" as const,
         endpointLabel: `${config.provider}:${config.model}`,
         note: config.live
-          ? "Chain B：直接 API 驱动；实时推理叠加在 demo 结构骨架上（数值待 schema 抽取打通）。"
-          : "Chain B：直接 API 驱动骨架；live 未开启，使用 demo 结构回放。"
+          ? pick(
+              locale,
+              "Chain B: direct-API driver; live reasoning overlaid on the demo structural scaffold (numbers pending schema extraction).",
+              "Chain B：直接 API 驱动；实时推理叠加在 demo 结构骨架上（数值待 schema 抽取打通）。"
+            )
+          : pick(
+              locale,
+              "Chain B: direct-API driver skeleton; live is off, using a demo structural replay.",
+              "Chain B：直接 API 驱动骨架；live 未开启，使用 demo 结构回放。"
+            )
       }
     };
 
@@ -242,6 +282,7 @@ export const apiDriver: ResearchDriver = {
     await replayRun(annotated, emit, {
       driver: "api",
       tier,
+      locale,
       signal,
       extraProgress: (stageId) => (stageId === "evidence" ? narration : [])
     });

--- a/apps/web/lib/research/drivers/mock-driver.ts
+++ b/apps/web/lib/research/drivers/mock-driver.ts
@@ -7,6 +7,7 @@
 
 import { getTierSpec, normalizeTier } from "@autopoly/norns";
 import { buildPredictionDemoRun } from "../../prediction-engine-demo";
+import { normalizeConsoleLocale, pick } from "../locale";
 import { replayRun, type EmitFn } from "../replay";
 import type { ResearchDriver, ResearchRequest } from "./types";
 
@@ -23,11 +24,16 @@ export const mockDriver: ResearchDriver = {
   id: "mock",
   async run(request: ResearchRequest, emit: EmitFn, signal?: AbortSignal): Promise<void> {
     const tier = normalizeTier(request.tier);
+    const locale = normalizeConsoleLocale(request.locale);
     const spec = getTierSpec(tier);
-    const run = buildPredictionDemoRun({
-      eventText: request.eventText,
-      marketPrice: request.marketPrice ?? null
-    });
+    const run = buildPredictionDemoRun(
+      {
+        eventText: request.eventText,
+        marketPrice: request.marketPrice ?? null
+      },
+      new Date(),
+      locale
+    );
     // The replayed run still carries demo metadata; mark its origin clearly. The
     // mock makes no model call, but the chosen Norns tier is surfaced so the
     // capability layer is visible even in deterministic demo mode.
@@ -37,9 +43,13 @@ export const mockDriver: ResearchDriver = {
         ...run.service,
         source: "demo" as const,
         endpointLabel: `in-process mock driver · ${spec.label}`,
-        note: `确定性只读 demo（${spec.label}）：复用 prediction-engine 生成器，按 Deep Research 状态机流式回放。`
+        note: pick(
+          locale,
+          `Deterministic read-only demo (${spec.label}): reuses the prediction-engine generator, replayed through the Forecasting Engine state machine.`,
+          `确定性只读 demo（${spec.label}）：复用 prediction-engine 生成器，按 Forecasting Engine 状态机流式回放。`
+        )
       }
     };
-    await replayRun(annotated, emit, { driver: "mock", tier, speed: readSpeed(), signal });
+    await replayRun(annotated, emit, { driver: "mock", tier, locale, speed: readSpeed(), signal });
   }
 };

--- a/apps/web/lib/research/drivers/types.ts
+++ b/apps/web/lib/research/drivers/types.ts
@@ -6,6 +6,7 @@
 import type { NornTier } from "@autopoly/norns";
 import type { ResearchEvent } from "../events";
 import type { EmitFn } from "../replay";
+import type { ConsoleLocale } from "../locale";
 
 export interface ResearchRequest {
   eventText: string;
@@ -16,6 +17,9 @@ export interface ResearchRequest {
   // Norns capability tier (urd / verdandi / skuld). The route normalises this
   // from the request body before handing it to a driver; defaults to verdandi.
   tier?: NornTier;
+  // Output locale for all human-readable prose. The route normalises this from
+  // the request body; defaults to English to match the public-site apex.
+  locale?: ConsoleLocale;
 }
 
 export interface ResearchDriver {

--- a/apps/web/lib/research/drivers/vps-agent-driver.ts
+++ b/apps/web/lib/research/drivers/vps-agent-driver.ts
@@ -20,6 +20,7 @@
 import { normalizeTier } from "@autopoly/norns";
 import { buildPredictionDemoRun, type PredictionEngineRun } from "../../prediction-engine-demo";
 import { parseResearchEvent } from "../events";
+import { normalizeConsoleLocale, pick } from "../locale";
 import { replayRun, type EmitFn } from "../replay";
 import { DriverNotConfiguredError, type ResearchDriver, type ResearchRequest } from "./types";
 
@@ -94,6 +95,7 @@ export const vpsAgentDriver: ResearchDriver = {
   async run(request: ResearchRequest, emit: EmitFn, signal?: AbortSignal): Promise<void> {
     const config = resolveVpsConfig(); // throws DriverNotConfiguredError → route falls back to mock
     const tier = normalizeTier(request.tier);
+    const locale = normalizeConsoleLocale(request.locale);
 
     const controller = new AbortController();
     const onAbort = () => controller.abort();
@@ -110,7 +112,7 @@ export const vpsAgentDriver: ResearchDriver = {
       const response = await fetch(config.url, {
         method: "POST",
         headers,
-        body: JSON.stringify({ eventText: request.eventText, marketPrice: request.marketPrice ?? null, tier }),
+        body: JSON.stringify({ eventText: request.eventText, marketPrice: request.marketPrice ?? null, tier, locale }),
         signal: controller.signal
       });
 
@@ -126,27 +128,41 @@ export const vpsAgentDriver: ResearchDriver = {
 
       const json = (await response.json()) as unknown;
       if (isPredictionRun(json)) {
-        await replayRun(json, emit, { driver: "vps", tier, signal });
+        await replayRun(json, emit, { driver: "vps", tier, locale, signal });
         return;
       }
       throw new Error("VPS endpoint returned an unrecognised payload shape.");
     } catch (error) {
       // Configured-but-failing VPS: keep the UI alive with a demo replay and a
       // loud warning rather than a dead stream.
+      const detail = error instanceof Error ? error.message : String(error);
       await emit({
         type: "run.notice",
         level: "warn",
-        message: `VPS agent 链路调用失败，本次回退到 demo：${error instanceof Error ? error.message : String(error)}`
+        message: pick(
+          locale,
+          `VPS agent chain call failed; falling back to demo this run: ${detail}`,
+          `VPS agent 链路调用失败，本次回退到 demo：${detail}`
+        )
       });
-      const run = buildPredictionDemoRun({ eventText: request.eventText, marketPrice: request.marketPrice ?? null });
+      const run = buildPredictionDemoRun(
+        { eventText: request.eventText, marketPrice: request.marketPrice ?? null },
+        new Date(),
+        locale
+      );
       await replayRun(
         {
           ...run,
           mode: "vps_proxy",
-          service: { ...run.service, source: "vps", endpointLabel: config.url, note: "Chain A 回退 demo（VPS 不可用）。" }
+          service: {
+            ...run.service,
+            source: "vps",
+            endpointLabel: config.url,
+            note: pick(locale, "Chain A fell back to demo (VPS unavailable).", "Chain A 回退 demo（VPS 不可用）。")
+          }
         },
         emit,
-        { driver: "vps", tier, signal }
+        { driver: "vps", tier, locale, signal }
       );
     } finally {
       clearTimeout(timer);

--- a/apps/web/lib/research/i18n.ts
+++ b/apps/web/lib/research/i18n.ts
@@ -1,0 +1,180 @@
+// Chrome dictionary for the Forecasting Engine console.
+//
+// Only the structural UI strings live here (hero, composer, buttons, stance and
+// phase labels, chart titles, captions). The streamed research *content*
+// (stages, evidence, verdict, narration) is localized server-side in
+// prediction-engine-demo.ts / replay.ts via the `locale` threaded through the
+// request. English is the default to match the apex of forecasting-agent.com.
+
+import type { ConsoleLocale } from "./locale";
+import type { PredictionEvidenceStance } from "../prediction-engine-demo";
+
+export type ConsoleStringKey =
+  | "heroTitle"
+  | "heroSub"
+  | "composerPlaceholder"
+  | "tierRowLabel"
+  | "tierAria"
+  | "marketLabel"
+  | "marketPlaceholder"
+  | "resetBtn"
+  | "runBtnIdle"
+  | "runBtnBusy"
+  | "examplesHint"
+  | "errorPrefix"
+  | "navWorldCup"
+  | "langLabel"
+  | "stanceSupport"
+  | "stanceOppose"
+  | "stanceMixed"
+  | "stanceNeutral"
+  | "phaseIdle"
+  | "phaseRunning"
+  | "phaseComplete"
+  | "phaseError"
+  | "machineLabel"
+  | "bigProbLabel"
+  | "snapshotPrefix"
+  | "ciLabel"
+  | "ciMarket"
+  | "ciNote"
+  | "marketImplied"
+  | "edgeLabel"
+  | "edgeCaveat"
+  | "treeTitle"
+  | "treeProduct"
+  | "treeCalibratedPrefix"
+  | "treeNotePre"
+  | "treeNotePost"
+  | "waterfallTitle"
+  | "ledgerTitlePre"
+  | "ledgerTitlePost"
+  | "ledgerColStance"
+  | "ledgerColEvidence"
+  | "ledgerColImpact"
+  | "ledgerColReliability"
+  | "ledgerColNode"
+  | "ledgerCaption"
+  | "limitationsTitle";
+
+const STRINGS: Record<ConsoleLocale, Record<ConsoleStringKey, string>> = {
+  en: {
+    heroTitle: "Turn a future event into an auditable probability.",
+    heroSub:
+      "Pose a verifiable binary question in plain language. The research agent opens its reasoning in seven steps: frame the definition · decompose conditions · collect and weight evidence · build a conditional-probability model · run a Bayesian update · conclude with a confidence interval.",
+    composerPlaceholder: "e.g. Will some event happen before a given deadline?",
+    tierRowLabel: "Reasoning depth",
+    tierAria: "Reasoning-depth tier (Norns)",
+    marketLabel: "Market-implied probability (optional)",
+    marketPlaceholder: "0.30",
+    resetBtn: "Restart",
+    runBtnIdle: "Run research",
+    runBtnBusy: "Researching…",
+    examplesHint: "Cached examples · click to run",
+    errorPrefix: "Research failed: ",
+    navWorldCup: "World Cup forecast →",
+    langLabel: "Language",
+    stanceSupport: "Support",
+    stanceOppose: "Oppose",
+    stanceMixed: "Mixed",
+    stanceNeutral: "Boundary",
+    phaseIdle: "IDLE",
+    phaseRunning: "RUNNING",
+    phaseComplete: "COMPLETE",
+    phaseError: "ERROR",
+    machineLabel: "Forecasting Engine state machine",
+    bigProbLabel: "Yes probability",
+    snapshotPrefix: "Research snapshot ",
+    ciLabel: "80% subjective credible interval: ",
+    ciMarket: "market-implied",
+    ciNote:
+      "Subjective credible interval: ~80% confidence the Yes probability falls in this range (a Bayesian judgment, not a frequentist confidence interval).",
+    marketImplied: "Market-implied",
+    edgeLabel: "Edge",
+    edgeCaveat:
+      "edge = model − market. If the market's resolution criterion is looser than this question's (e.g. \"any publicly announced nuclear deal counts\"), the two are not the same standard — this edge is indicative only and is not a directly tradable signal.",
+    treeTitle: "Conditional-probability model · P(A) × P(B|A) × P(C|A,B)",
+    treeProduct: "Conditional product",
+    treeCalibratedPrefix: "calibrated → ",
+    treeNotePre: "The conditional product is a structured lower bound; the final Yes probability is calibrated to ",
+    treeNotePost: " (see the \"model calibration\" step of the Bayesian path below).",
+    waterfallTitle: "Bayesian update path · prior → posterior",
+    ledgerTitlePre: "Evidence ledger · ",
+    ledgerTitlePost: " items",
+    ledgerColStance: "Stance",
+    ledgerColEvidence: "Evidence",
+    ledgerColImpact: "Impact",
+    ledgerColReliability: "Reliability",
+    ledgerColNode: "Node",
+    ledgerCaption:
+      "\"Impact\" is each item's directed strength on its node (A / B / C), on a percentage-point scale, used for ordering and qualitative read — not an additive contribution to the final probability. The final probability comes from the conditional-probability model and Bayesian path above.",
+    limitationsTitle: "Boundaries & disclaimer"
+  },
+  zh: {
+    heroTitle: "把一个未来事件,变成可审计的概率。",
+    heroSub:
+      "用自然语言提出一个可被验证的二元问题。研究 agent 会分七步公开它的推理:理清定义 · 条件拆解 · 证据收集与权重 · 条件概率模型 · 贝叶斯更新 · 结论与置信区间。",
+    composerPlaceholder: "例如:某事件会在某个截止日期前发生吗?",
+    tierRowLabel: "推理深度",
+    tierAria: "推理深度档位 (Norns)",
+    marketLabel: "市场隐含概率(可选)",
+    marketPlaceholder: "0.30",
+    resetBtn: "重新开始",
+    runBtnIdle: "开始研究",
+    runBtnBusy: "研究中…",
+    examplesHint: "已缓存示例 · 点击直接运行",
+    errorPrefix: "研究失败:",
+    navWorldCup: "世界杯预测 →",
+    langLabel: "语言",
+    stanceSupport: "支持",
+    stanceOppose: "反对",
+    stanceMixed: "中性",
+    stanceNeutral: "边界",
+    phaseIdle: "待命 IDLE",
+    phaseRunning: "运行中 RUNNING",
+    phaseComplete: "已完成 COMPLETE",
+    phaseError: "出错 ERROR",
+    machineLabel: "Forecasting Engine 状态机",
+    bigProbLabel: "Yes 概率",
+    snapshotPrefix: "研究快照 ",
+    ciLabel: "80% 主观可信区间：",
+    ciMarket: "市场隐含",
+    ciNote:
+      "主观可信区间：对 Yes 概率有约 80% 把握落在此范围(贝叶斯式判断,非数据频率意义上的置信区间)。",
+    marketImplied: "市场隐含",
+    edgeLabel: "Edge",
+    edgeCaveat:
+      "edge = 模型 − 市场。若市场的结算口径比本题更宽松(如\"任何公开核协议即算\"),两者并非同一判定标准,该 edge 仅供参考、不可直接当成可交易信号。",
+    treeTitle: "条件概率模型 · P(A) × P(B|A) × P(C|A,B)",
+    treeProduct: "条件乘积",
+    treeCalibratedPrefix: "校准后 → ",
+    treeNotePre: "条件乘积是结构化下界;最终 Yes 概率经校准为 ",
+    treeNotePost: "(见下方贝叶斯路径的\"模型校准\"步)。",
+    waterfallTitle: "贝叶斯更新路径 · 先验 → 后验",
+    ledgerTitlePre: "证据账本 · ",
+    ledgerTitlePost: " 条",
+    ledgerColStance: "立场",
+    ledgerColEvidence: "证据",
+    ledgerColImpact: "影响",
+    ledgerColReliability: "可信度",
+    ledgerColNode: "节点",
+    ledgerCaption:
+      "\"影响\"为每条证据对其所属节点(A / B / C)的有向强度(百分点量级),用于排序与定性,并非对最终概率的可加贡献——最终概率以上方条件概率模型与贝叶斯路径为准。",
+    limitationsTitle: "边界与免责"
+  }
+};
+
+export function c(locale: ConsoleLocale, key: ConsoleStringKey): string {
+  return STRINGS[locale][key];
+}
+
+const STANCE_KEY: Record<PredictionEvidenceStance, ConsoleStringKey> = {
+  support: "stanceSupport",
+  oppose: "stanceOppose",
+  mixed: "stanceMixed",
+  neutral: "stanceNeutral"
+};
+
+export function stanceLabel(locale: ConsoleLocale, stance: PredictionEvidenceStance): string {
+  return c(locale, STANCE_KEY[stance]);
+}

--- a/apps/web/lib/research/locale.ts
+++ b/apps/web/lib/research/locale.ts
@@ -1,0 +1,24 @@
+// Console locale primitives for the Forecasting Engine.
+//
+// Leaf module: imports nothing so both the server-side content generator
+// (prediction-engine-demo.ts) and the client chrome dictionary (i18n.ts) can
+// depend on it without a cycle. English is the default to match the apex of
+// forecasting-agent.com; Chinese is the toggle.
+
+export type ConsoleLocale = "en" | "zh";
+
+export const DEFAULT_CONSOLE_LOCALE: ConsoleLocale = "en";
+
+export function isConsoleLocale(value: unknown): value is ConsoleLocale {
+  return value === "en" || value === "zh";
+}
+
+export function normalizeConsoleLocale(value: unknown): ConsoleLocale {
+  return isConsoleLocale(value) ? value : DEFAULT_CONSOLE_LOCALE;
+}
+
+// Pick localized prose. English first to keep call sites readable as
+// `pick(locale, "English", "中文")`.
+export function pick(locale: ConsoleLocale, en: string, zh: string): string {
+  return locale === "zh" ? zh : en;
+}

--- a/apps/web/lib/research/replay.ts
+++ b/apps/web/lib/research/replay.ts
@@ -7,6 +7,7 @@
 
 import type { NornTier } from "@autopoly/norns";
 import type { PredictionEngineRun, PredictionStage } from "../prediction-engine-demo";
+import { pick, type ConsoleLocale } from "./locale";
 import type { ResearchDriverId, ResearchEvent, ResearchStageMeta } from "./events";
 
 export type EmitFn = (event: ResearchEvent) => void | Promise<void>;
@@ -15,6 +16,9 @@ export interface ReplayOptions {
   driver: ResearchDriverId;
   // Norns capability tier this run was dispatched at, surfaced in run.accepted.
   tier?: NornTier;
+  // Locale for the synthetic per-stage narration (the fallback lines emitted
+  // when a run has no real progressByStage). Defaults to English.
+  locale?: ConsoleLocale;
   // Wall-clock pacing multiplier. Higher = slower / more readable. Default 0.9
   // gives a deliberate ~12-14s walk-through so a viewer can read each step;
   // RESEARCH_MOCK_SPEED can dial it anywhere in [0.1, 3].
@@ -54,35 +58,71 @@ function toStageMeta(stage: PredictionStage): ResearchStageMeta {
 // Per-stage progress narration synthesised from the run. These read like a
 // research agent thinking aloud and give the active-stage panel something to
 // stream even in deterministic demo mode.
-function progressLinesFor(run: PredictionEngineRun, stage: PredictionStage): string[] {
+function progressLinesFor(run: PredictionEngineRun, stage: PredictionStage, locale: ConsoleLocale): string[] {
+  const supportCount = run.evidence.filter((e) => e.stance === "support").length;
+  const opposeCount = run.evidence.filter((e) => e.stance === "oppose").length;
   switch (stage.id) {
     case "definition":
       return [
-        `锁定事件主体与截止时间：${run.eventText}`,
-        "区分单方表态 / 继续谈判 / 临时框架 / 可结算协议四种状态。",
-        "标注需要人工复核的官方结算口径。"
+        pick(locale, `Lock the event's parties and deadline: ${run.eventText}`, `锁定事件主体与截止时间：${run.eventText}`),
+        pick(
+          locale,
+          "Separate four states: one-sided statement / ongoing talks / interim framework / settleable agreement.",
+          "区分单方表态 / 继续谈判 / 临时框架 / 可结算协议四种状态。"
+        ),
+        pick(locale, "Flag the official resolution criterion that needs human review.", "标注需要人工复核的官方结算口径。")
       ];
     case "query-design":
       return [
-        "把事件拆成 2-5 个必要条件节点 (A / B / C)。",
-        "为每个条件生成官方、主流媒体、当事方、本地与第三方 query。"
+        pick(locale, "Break the event into 2–5 necessary condition nodes (A / B / C).", "把事件拆成 2-5 个必要条件节点 (A / B / C)。"),
+        pick(
+          locale,
+          "Generate official, mainstream-media, party-side, local, and third-party queries for each condition.",
+          "为每个条件生成官方、主流媒体、当事方、本地与第三方 query。"
+        )
       ];
     case "evidence":
-      return [`按来源类型收集证据，共 ${run.evidence.length} 条待权重化。`];
+      return [
+        pick(
+          locale,
+          `Collect evidence by source type — ${run.evidence.length} items to be weighted.`,
+          `按来源类型收集证据，共 ${run.evidence.length} 条待权重化。`
+        )
+      ];
     case "weighting":
       return [
-        "按一手性、时效、交叉印证、战略性放话风险给每条证据打分。",
-        `支持 ${run.evidence.filter((e) => e.stance === "support").length} 条 · 反对 ${run.evidence.filter((e) => e.stance === "oppose").length} 条。`
+        pick(
+          locale,
+          "Score each item by primary-source quality, recency, cross-corroboration, and strategic-signalling risk.",
+          "按一手性、时效、交叉印证、战略性放话风险给每条证据打分。"
+        ),
+        pick(locale, `${supportCount} supporting · ${opposeCount} opposing.`, `支持 ${supportCount} 条 · 反对 ${opposeCount} 条。`)
       ];
     case "model":
-      return [`构建条件概率模型 ${run.model.map((n) => n.id).join(" × ")}，乘法结构校验中。`];
+      return [
+        pick(
+          locale,
+          `Build the conditional-probability model ${run.model.map((n) => n.id).join(" × ")}; verifying the multiplicative structure.`,
+          `构建条件概率模型 ${run.model.map((n) => n.id).join(" × ")}，乘法结构校验中。`
+        )
+      ];
     case "bayes":
-      return ["从基线出发，逐条把证据折算成对先验的有界更新。"];
+      return [
+        pick(locale, "From the baseline, fold each item into a bounded update of the prior.", "从基线出发，逐条把证据折算成对先验的有界更新。")
+      ];
     case "market":
       return [
         run.conclusion.marketProbability == null
-          ? "未提供市场价格，仅输出独立概率与置信区间。"
-          : `对比市场隐含概率 ${(run.conclusion.marketProbability * 100).toFixed(1)}%，计算 edge。`
+          ? pick(
+              locale,
+              "No market price provided; output the standalone probability and interval only.",
+              "未提供市场价格，仅输出独立概率与置信区间。"
+            )
+          : pick(
+              locale,
+              `Compare with the market-implied ${(run.conclusion.marketProbability * 100).toFixed(1)}%; compute the edge.`,
+              `对比市场隐含概率 ${(run.conclusion.marketProbability * 100).toFixed(1)}%，计算 edge。`
+            )
       ];
     default:
       return [stage.detail];
@@ -108,6 +148,7 @@ function emitArtifactsForStage(run: PredictionEngineRun, stageId: string): Resea
 export async function replayRun(run: PredictionEngineRun, emit: EmitFn, options: ReplayOptions): Promise<void> {
   const speed = Math.min(Math.max(options.speed ?? 0.9, 0.1), 3);
   const { signal } = options;
+  const locale: ConsoleLocale = options.locale ?? "en";
 
   await emit({
     type: "run.accepted",
@@ -130,7 +171,7 @@ export async function replayRun(run: PredictionEngineRun, emit: EmitFn, options:
     const lines =
       realLines && realLines.length > 0
         ? realLines
-        : [...progressLinesFor(run, stage), ...(options.extraProgress?.(stage.id) ?? [])];
+        : [...progressLinesFor(run, stage, locale), ...(options.extraProgress?.(stage.id) ?? [])];
     for (const text of lines) {
       await emit({ type: "stage.progress", stageId: stage.id, text });
       await sleep(stage.durationMs * speed * 0.5, signal);

--- a/apps/web/lib/research/sample-cases.ts
+++ b/apps/web/lib/research/sample-cases.ts
@@ -1,4 +1,4 @@
-// Pre-saved demo cases for the public Deep Research console.
+// Pre-saved demo cases for the public Forecasting Engine console.
 //
 // Clicking a case streams a full run — layered evidence, a conditional model,
 // Bayesian updates, and a calibrated probability + CI — with zero input.
@@ -8,14 +8,19 @@
 //   at the flagship Skuld tier, and carries live source URLs. See
 //   `resolveCuratedCase` in prediction-engine-demo.ts.
 // • fed-rate-cut is a curated mock demo.
+//
+// Every human-readable field is locale-keyed; the event text is localized too so
+// an English run shows an English question (event detection matches both
+// languages, so the curated case resolves either way).
 
 import type { NornTier } from "@autopoly/norns";
+import type { ConsoleLocale } from "./locale";
 
 export interface SampleCase {
   id: string;
-  label: string;
-  blurb: string;
-  eventText: string;
+  label: Record<ConsoleLocale, string>;
+  blurb: Record<ConsoleLocale, string>;
+  eventText: Record<ConsoleLocale, string>;
   marketPrice: number;
   // Optional tier to dispatch this case at (the flagship real-research case runs
   // at Skuld). When omitted, the console uses the user's selected tier.
@@ -25,17 +30,29 @@ export interface SampleCase {
 export const SAMPLE_CASES: SampleCase[] = [
   {
     id: "iran-nuclear",
-    label: "美伊核协议",
-    blurb: "Skuld 实跑 · 真实研究快照 2026-06-13",
-    eventText: "美国和伊朗能在 2026-06-30 前达成核协议吗？",
+    label: { en: "US-Iran nuclear deal", zh: "美伊核协议" },
+    blurb: {
+      en: "Skuld live run · Real research snapshot 2026-06-13",
+      zh: "Skuld 实跑 · 真实研究快照 2026-06-13"
+    },
+    eventText: {
+      en: "Can the US and Iran reach a nuclear deal before 2026-06-30?",
+      zh: "美国和伊朗能在 2026-06-30 前达成核协议吗？"
+    },
     marketPrice: 0.67,
     tier: "skuld"
   },
   {
     id: "fed-rate-cut",
-    label: "美联储降息",
-    blurb: "演示 · Fed cuts ≥50bp before Sept 2026",
-    eventText: "美联储会在 2026 年 9 月前降息至少 50 个基点吗？",
+    label: { en: "Fed rate cut", zh: "美联储降息" },
+    blurb: {
+      en: "Demo · Fed cuts ≥50bp before Sept 2026",
+      zh: "演示 · Fed cuts ≥50bp before Sept 2026"
+    },
+    eventText: {
+      en: "Will the Fed cut rates by at least 50bp before September 2026?",
+      zh: "美联储会在 2026 年 9 月前降息至少 50 个基点吗？"
+    },
     marketPrice: 0.52
   }
 ];

--- a/apps/web/lib/research/use-research-stream.ts
+++ b/apps/web/lib/research/use-research-stream.ts
@@ -8,6 +8,7 @@
 import { useCallback, useReducer, useRef } from "react";
 import type { NornTier } from "@autopoly/norns";
 import { parseResearchEvent } from "./events";
+import { pick, type ConsoleLocale } from "./locale";
 import {
   initialResearchState,
   researchReducer,
@@ -19,6 +20,7 @@ export interface StartResearchInput {
   eventText: string;
   marketPrice?: number | null;
   tier?: NornTier;
+  locale?: ConsoleLocale;
 }
 
 const RESET = { type: "__reset__" } as const;
@@ -72,7 +74,9 @@ export function useResearchStream(): UseResearchStream {
           const detail = await response.json().catch(() => ({}));
           dispatch({
             type: "run.error",
-            message: (detail as { error?: string }).error ?? `请求失败（${response.status}）`
+            message:
+              (detail as { error?: string }).error ??
+              pick(input.locale ?? "en", `Request failed (${response.status})`, `请求失败（${response.status}）`)
           });
           return;
         }


### PR DESCRIPTION
## What

Makes the public **Forecasting Engine** console (`/research`) fully bilingual — chrome *and* streamed research content switch together with one toggle, **English-default** to match the apex of forecasting-agent.com. Also folds in the three forecaster-review follow-ups.

## Human review entry points

1. [apps/web/lib/research/i18n.ts](apps/web/lib/research/i18n.ts) — chrome dictionary (EN/zh) + `stanceLabel`.
2. [apps/web/lib/research/locale.ts](apps/web/lib/research/locale.ts) — leaf locale type + `pick(locale, en, zh)` (no imports → no cycle).
3. [apps/web/lib/prediction-engine-demo.ts](apps/web/lib/prediction-engine-demo.ts) — locale-keyed curated content (`IRAN_CONTENT`/`FED_CONTENT`); **every number/date/unit/URL/proper-noun preserved** across EN/zh.
4. [apps/web/components/research/research-console.tsx](apps/web/components/research/research-console.tsx) — now owns the full shell + the language toggle.
5. [apps/web/app/api/prediction-engine/run/route.ts](apps/web/app/api/prediction-engine/run/route.ts) — legacy route defaults to **zh** to preserve its prior output (no regression).

## How it works

`locale` is threaded from the composer → SSE POST body → route → driver → `buildPredictionDemoRun(..., locale)` + `replayRun({locale})`, so the server builds content in the requested language (not just UI labels). Default `en`; toggle to `中文`.

## Folded-in polish (forecaster review)

- Prominent research-snapshot date + days-to-deadline on the conclusion card.
- "80% subjective credible interval" relabel + a one-line clarification note.
- Edge caveat (model − market, broad-vs-strict criterion).

## Test plan

- [x] `pnpm --filter @autopoly/web typecheck` — clean
- [x] `pnpm --filter @autopoly/web build` — passes (`/research` dynamic, world-cup SSG intact)
- [x] `vitest run lib/research/state-machine.test.ts` — 7/7 green
- [x] Headless Playwright QA: EN + zh × desktop + mobile → correct chrome + content + charts, **zero console/page errors**, layout intact

Note: the `/research` beta entry remains **dormant** (commented-out button on the self-host page); this PR localizes the surface ahead of exposing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)