### PR TITLE
feat(orchestrator): persistent Raven agent-loop artifact builders (library-only, #6)

### DIFF
--- a/docs/internal/plan/2026-05-04-persistent-runtime-plan.en.md
+++ b/docs/internal/plan/2026-05-04-persistent-runtime-plan.en.md
@@ -1,0 +1,377 @@
+# Predict Raven Agent-first Persistent Runtime Plan
+
+## Goal
+
+- Turn the persistence module into an **Agent-first trading runtime**: Raven Agent owns full-context reasoning, trade intent, and self-correction; core code provides tools, feedback injection, audit trails, and a small set of non-bypassable hard boundaries.
+- Start with a `12h` continuous-run target to validate the achieve-evaluate-update loop before aiming for 30+ unattended days.
+- This document is only a plan and task breakdown. It does not start implementation.
+
+## Review Entry Points
+
+- `services/orchestrator/src/runtime/`: best place for the Raven Agent loop, Evaluator, and feedback injection.
+- `services/orchestrator/src/jobs/agent-cycle.ts`: current stateful agent-cycle entry point; can become the per-run orchestrator.
+- `services/orchestrator/src/lib/execution-planning.ts`: where trade intents enter risk clipping before execution.
+- `scripts/pulse-live.ts`: existing live preflight, archives, and error summaries can be extracted into shared capabilities.
+- `scripts/position-monitor.ts`: model-free stop-loss guardian.
+- `docs/risk-controls.md`: needs to distinguish soft feedback from hard limits.
+
+## Core Design
+
+### 1. Raven Agent Is The Driver
+
+Each run starts with Raven Agent reading a complete context pack and producing a trading judgment:
+
+- Current positions, balance, risk caps, and system status.
+- The latest N run summaries, prior Raven Agent reasoning, and failure records.
+- Latest pulse, market candidates, and relevant sources.
+- Evaluator findings from the previous run and this run's required checklist.
+
+Raven Agent outputs:
+
+- Human-readable reasoning.
+- Structured `trade_intents.json`.
+- Current position review: whether each position should be held, reduced, closed, or kept waiting for resolution.
+- Responses to evaluator feedback.
+- Whether to investigate more, downgrade, pause, or execute.
+
+### 2. Evaluator / Feedback Continuously Improves Raven Agent
+
+The Evaluator does not replace Raven Agent's judgment. It checks output quality and injects findings back into the current conversation.
+
+Evaluator v1 is split into several types that assess Raven Agent reasoning quality, decision-making quality, and process completeness:
+
+| Evaluator type | What it checks | Output |
+| --- | --- | --- |
+| Reasoning quality | Thesis, counter-evidence, probability gap, confidence, stale information, missing scenarios | Reasoning gaps and questions to answer |
+| Decision quality | Whether open / hold / reduce / close matches edge, odds, position state, and prior reasoning | Trading judgments that need response or revision |
+| Process completeness | Correct sources, resolution rules, official references, latest order book, current positions, and wallet state | Missing steps, wrong sources, queries to rerun |
+| Execution feasibility | Token tradability, order book depth, minimum order size, slippage, liquidity | Execution risks and size revision suggestions |
+| Post-training data | Whether context / decision / feedback / revised decision can be reviewed and trained on | Missing artifacts and structured fields |
+
+Process completeness is especially important:
+
+- Raven Agent must explicitly review current positions, not only new opportunities.
+- For every held market, it must identify the resolution terms, correct resolution source, and whether the fetched information is current.
+- Sources should be primary or trusted aggregated sources, not only second-hand conclusions.
+- Market probability, Raven Agent probability, liquidity, and order book data should come from the same time window.
+- If sources are missing or conflicting, the run should query or collect more evidence instead of jumping to a trade conclusion.
+
+Feedback uses a simple `1-5` score:
+
+| Score | Meaning | System action |
+| --- | --- | --- |
+| `1` | Pass | Record result and continue |
+| `2` | Minor reminder | Inject soft reminder and continue |
+| `3` | Response required | Inject a challenge and require itemized Raven Agent response |
+| `4` | Revision required | Inject feedback and require a new decision |
+| `5` | Hard boundary or real state unclear | Do not execute live-money actions; only explain, collect evidence, downgrade, or enter diagnostic mode |
+
+### 3. Core Code Is The Agent Operating System
+
+Core code provides:
+
+- context pack builder
+- evaluator runner
+- feedback injector
+- intent schema validator
+- archive writer
+- Query Code environment
+- scheduler / heartbeat / lock
+- executor queue adapter
+- minimal hard risk controls
+
+Core code should not invent strategy for Raven Agent, and Raven Agent should not be reduced to a report writer.
+
+The Query Code environment:
+
+- Gives Raven Agent and Evaluator a fast, read-only, reproducible query environment.
+- Can inspect artifacts, DB snapshots, current positions, run summaries, market metadata, resolution sources, order books, and wallet preflight results.
+- Can run small read-only analysis snippets to check whether a conclusion is supported by data.
+- Cannot write state, place orders, or modify wallets by default; it only produces `query-code-result.json` as evidence for feedback and revised decisions.
+
+### 4. A Small Set Of Hard Boundaries Remain Non-bypassable
+
+These cannot be handled by feedback alone:
+
+- Wallet address or env mismatch.
+- System `paused` / `halted`.
+- Re-entry lock already held.
+- Token is not in the allowed trading set or cannot be verified.
+- Trade, total exposure, event exposure, or max-position caps exceeded.
+- Critical state is missing enough that real risk cannot be verified.
+
+Additional definitions:
+
+- System `paused` is a temporary pause state: no new live-money opens are allowed. Common triggers include manual pause, two consecutive failed runs, wallet/env mismatch, conflicting critical state, stale heartbeat, or repeated Evaluator score `5` hard-risk findings. `paused` can be manually resumed after diagnosis.
+- System `halted` is a stronger risk stop, usually caused by portfolio drawdown, hard risk triggers, or material fund-safety concerns. In `halted`, new opens are forbidden; only diagnosis, cancel-open-orders, and necessary reduce / close flows are allowed.
+- The re-entry lock prevents two Raven Agent runs, two schedulers, or a manual command from trading the same wallet at the same time. Each run writes runId, wallet, startedAt, heartbeat, and expiry; if the lock is active, the second run must skip instead of placing concurrent orders.
+- "Critical state missing" means the system cannot identify real risk, not merely that one API failed. Examples: DB positions, remote Polymarket positions, wallet balance, latest archive, order book, or resolution source conflict. The system classifies state as `verified / stale / conflict / missing`; `conflict` or missing critical fields enter diagnostic mode and do not continue execution.
+
+Outside those hard boundaries, prefer evaluator feedback so Raven Agent corrects itself.
+
+## 12h Target
+
+### Target Definition
+
+Run a `12h` Agent-first persistence loop in a main-derived worktree or VPS environment:
+
+- Wake Raven Agent every `90` to `120` minutes, for roughly `6` to `8` runs.
+- Each run completes:
+  1. build context pack
+  2. current position review: per-position original thesis, current edge, resolution progress, order book, PnL, and risk usage
+  3. Raven Agent initial analysis
+  4. evaluator review
+  5. feedback injection
+  6. Raven Agent revised decision
+  7. execution gate
+  8. live execution dispatch
+  9. archive + metrics
+  10. update next-run checklist
+- The first stage is live-first: use real wallet preflight, real positions, real market data, real order books, the full execution gate, and produce a dispatchable live execution plan.
+- Code tests use a mock executor / fixture wallet to prevent accidental orders; product logic does not use `recommend-only` as the target state.
+- The trading loop must be complete. It should not be centered on canceling orders or a temporary live-money switch; every run covers current-position review, new-opportunity scan, no-edge / overpriced asset handling, feedback revision, execution gate, live execution plan, and post-run review.
+- If the user provides a new wallet address or env file, the 12h runner must print and archive the actual wallet address, collateral, chain, and env path. Address mismatch enters paused / diagnostic mode instead of continuing live execution.
+
+### 12h Success Criteria
+
+- Complete at least `6` loop runs.
+- Every run writes complete artifacts:
+  - `context-pack.json`
+  - `position-review.json`
+  - `source-resolution-audit.json`
+  - `initial-decision.json`
+  - `evaluator-report.json`
+  - `feedback-injection.md`
+  - `revised-decision.json`
+  - `execution-gate.json`
+  - `execution-dispatch-plan.json`
+  - `run-summary.md`
+  - `transcript-summary.md`
+- Evaluator triggers and records at least one score `3` or `4` feedback item.
+- Raven Agent must respond to feedback explicitly, not simply repeat it.
+- Every existing position must be reviewed with a hold / reduce / close / wait-resolution reason.
+- For positions with no edge, reversed edge, market overvaluation, broken thesis, or changed resolution risk, Raven Agent must evaluate reduce / close.
+- Re-entry lock, heartbeat, and latest state refresh normally.
+- Consecutive failures must not exceed `2`; if they do, the loop enters paused / diagnostic mode.
+- At the end, write `12h-review.md`: which feedback improved decisions, which evaluator rules were false positives, and what should be updated next.
+
+### Non-goals For 12h
+
+- Do not require profit during the 12h run.
+- Do not require unrestricted live trading.
+- Do not require the evaluator to be perfect on the first iteration.
+- Do not let core code automatically replace Raven Agent's strategy fallback.
+
+## Achieve-Evaluate-Update Loop
+
+### Achieve
+
+Each run must produce a checkable result:
+
+- Raven Agent completes one full trading judgment.
+- Raven Agent completes a current-position review, especially checking whether no-edge or overpriced positions should be sold.
+- Evaluator completes one quality review.
+- Feedback is injected and produces a revised decision.
+- Execution gate outputs execute, skip, downgrade, or block.
+- Test mode may mock the executor, but the runtime must produce a real execution plan instead of only recommendations.
+- The whole process is archived as a post-training trajectory.
+
+### Evaluate
+
+At the end of each run, evaluate:
+
+- `analysis_completeness_score`: whether required dimensions were covered.
+- `feedback_response_score`: whether Raven Agent genuinely absorbed feedback.
+- `decision_stability`: whether the change from initial to revised decision is reasonable.
+- `risk_alignment`: whether the decision matches current positions and hard limits.
+- `position_review_quality`: whether every position was checked for edge, resolution, order book, PnL, and sell rationale.
+- `process_completeness_score`: whether source / resolution / order book / wallet / current-position checks were completed.
+- `artifact_quality`: whether later review and training are possible.
+- `operator_intervention_needed`: whether a human must take over.
+
+### Update
+
+Each run writes evaluation results into the next-run checklist:
+
+- Add or adjust evaluator rules.
+- Add this run's exposed issue to the Raven Agent prompt.
+- Add missing data to the context pack.
+- Add quick queries to the Query Code environment.
+- If a feedback type repeatedly false-positives, lower its score.
+- If Raven Agent repeatedly ignores a risk, raise its score.
+- If two runs fail consecutively, enter diagnostic mode and do not continue live execution.
+
+## Implementation Phases
+
+### Phase 0: Define Data Contracts
+
+Create or standardize these schemas:
+
+- `AgentContextPack`
+- `PositionReview`
+- `SourceResolutionAudit`
+- `AgentInitialDecision`
+- `EvaluatorReport`
+- `FeedbackInjection`
+- `AgentRevisedDecision`
+- `ExecutionGateResult`
+- `QueryCodeResult`
+- `ExecutionDispatchPlan`
+- `LoopMetrics`
+
+Success criteria:
+
+- Every artifact has a clear JSON schema.
+- Any run can be replayed from artifacts alone.
+
+### Phase 1: Build The 12h Runner
+
+Add `agent-persistent-runner`:
+
+- accepts `--duration-hours 12`
+- accepts `--interval-minutes 90`
+- defaults to live-first: full preflight, position review, execution gate, and a real execution plan
+- supports `--env-file <path>` or wallet profile so a user-provided wallet address can be used
+- supports `--mock-executor` for code testing only; production runs do not use recommend-only
+- refreshes heartbeat every run
+- uses a re-entry lock
+- writes failures to `run-error/<timestamp>-agent-persistent/`
+
+Success criteria:
+
+- Local short smoke works with `--duration-minutes 20 --interval-minutes 5`.
+- Smoke writes artifacts for at least 2 runs.
+
+### Phase 2: Add Evaluator / Feedback
+
+Implement evaluator:
+
+- V1 includes reasoning quality, decision quality, process completeness, execution feasibility, and post-training data evaluators.
+- Start with deterministic checklist + optional small-model critic.
+- Output findings and `1-5` scores.
+- Generate feedback prompts for scores `3` and above; score `4` requires a new decision; score `5` enters hard-boundary or diagnostic handling.
+
+Implement feedback injector:
+
+- Inject evaluator findings into the same-run Raven Agent revision stage.
+- Require Raven Agent to respond to every finding.
+
+Success criteria:
+
+- A manually incomplete decision triggers revise.
+- Raven Agent revised decision references and handles evaluator findings.
+
+### Phase 3: Add Execution Gate And Hard Boundaries
+
+Implement execution gate:
+
+- schema validation
+- system status: distinguish running / paused / halted and explain why paused
+- wallet / env / collateral
+- stale pulse
+- token allowability
+- risk caps
+- lock / idempotency
+- critical state classifier: mark critical state as verified / stale / conflict / missing
+
+Success criteria:
+
+- Soft problems go to feedback, not direct block.
+- Hard problems always block.
+- paused / halted / lock / critical-state reasons are understandable from the archive.
+- Gate result is archived clearly.
+
+### Phase 4: 12h Soak
+
+Run sequence:
+
+1. `20min` local smoke.
+2. `2h` live-first runner + mock executor trial to validate code and archives.
+3. `12h` live-first runner with the user-provided wallet/env and real preflight; whether executor is mocked must be printed by runtime parameters.
+4. If live execution is enabled, every archive must record wallet, collateral, risk caps, execution dispatch plan, and executor response.
+
+Success criteria:
+
+- The 12h review clearly lists:
+  - what was achieved
+  - which evaluator feedback worked
+  - how Raven Agent improved
+  - which current positions had no edge, which looked overpriced, and which should continue to hold
+  - which data gaps blocked judgment
+  - how the next run should update prompt / evaluator / context pack
+
+## User Decisions
+
+- Decision: should the 12h stage use real executor or mock executor?
+  - Why it matters: the user does not need recommend-only, but code testing still needs protection against accidental orders.
+  - Recommended default: use `--mock-executor` for code debugging, then use real executor for the formal 12h live-first runner with execution mode printed.
+
+- Decision: should Evaluator v1 use deterministic checklist or small-model critic?
+  - Why it matters: checklist is controllable; small-model critic is closer to the post-training target.
+  - Recommended default: checklist first, with a small-model critic adapter kept open.
+
+- Decision: which provider runs Raven Agent?
+  - Why it matters: Claude Code / Codex / OpenClaw differ in session persistence, tool permissions, and cost.
+  - Recommended default: build a provider-neutral runner so Raven Agent can be swapped.
+
+- Decision: new wallet address or env file.
+  - Why it matters: the 12h runner must verify the actual wallet, collateral, and risk caps instead of assuming `.env.pizza` is always the active account.
+  - Recommended default: support `--env-file` / wallet profile; preflight prints and archives the actual address, and mismatches pause the run.
+
+## Risks And Assumptions
+
+- Risk: too much feedback makes Raven Agent overly conservative.
+  - Mitigation: track feedback hit rate and false positives, then update scores each run.
+
+- Risk: feedback is too soft and Raven Agent ignores it.
+  - Mitigation: score `3` and above require itemized responses; score `4` requires a new JSON decision.
+
+- Risk: Agent-first decisions become irreproducible.
+  - Mitigation: force full archiving of context pack, decision, feedback, revised decision, and gate.
+
+- Risk: post-training data is weak if only natural-language summaries are stored.
+  - Mitigation: every key step writes both machine-readable JSON and transcript summaries.
+
+- Assumption: the first 12h target is live-first; local code testing may mock the executor, but that is not the product default mode.
+- Assumption: core code can be refactored into an Agent operating system rather than a fixed strategy engine.
+- Assumption: the user wants Raven Agent to be able to reach order placement, while accepting a small set of non-bypassable hard boundaries.
+
+## Execution Gate
+
+- Wait for user review of this plan.
+- If approved, start with Phase 0 plus a 20min mock-executor smoke, then proceed to the 2h / 12h live-first runner.
+
+## Current Implementation Progress (2026-05-04)
+
+- Added `services/orchestrator/src/runtime/raven-agent-loop.ts`:
+  - `AgentContextPack`
+  - `PositionReviewArtifact`
+  - `SourceResolutionAudit`
+  - `EvaluatorReport`
+  - `FeedbackInjection`
+  - `ExecutionGateResult`
+  - `ExecutionDispatchPlan`
+  - `LoopMetrics`
+- Added `scripts/agent-persistent-runner.ts` and `pnpm agent:persistent`:
+  - supports `--duration-minutes`
+  - supports `--interval-minutes`
+  - supports `--max-iterations`
+  - supports `--archive-root`
+  - supports `--env-file`
+  - supports `--mock-executor` for code testing
+  - writes and releases `runner.lock` by default to prevent re-entry
+- The current runner is a live-first artifact loop: it generates a real execution plan in `execution-dispatch-plan.json` and no longer targets recommend-only.
+- Real executor dispatch is not wired yet; running without `--mock-executor` fails fast to avoid accidental orders from a partial implementation.
+- Added `services/orchestrator/src/runtime/raven-agent-loop.test.ts`, covering evaluator behavior, execution gate behavior, and artifact writing.
+- Verified:
+  - `pnpm exec vitest run --config config/vitest.config.ts services/orchestrator/src/runtime/raven-agent-loop.test.ts`
+  - `pnpm agent:persistent -- --duration-minutes 0 --max-iterations 1 --interval-minutes 0 --mock-executor --archive-root runtime-artifacts/raven-agent-smoke`
+  - `pnpm agent:persistent` without `--mock-executor` refuses live dispatch
+  - Pre-seeding `runner.lock` makes the runner refuse startup, validating re-entry protection
+- Fixed pre-existing typecheck blockers found while validating:
+  - `paper-trading.test.ts` `PlannedExecution` fixture now includes `orderType` / `gtcLimitPrice` / `categorySlug` / `negRisk`
+  - `full-pulse.ts` now uses existing `TextMetrics.approxTokens`
+- Current validation:
+  - `pnpm typecheck` passes
+  - `pnpm test` passes (39 files / 320 tests)
+  - Because `vendor/repos` is an ignored runtime dependency, this worktree needs `vendor/repos/all-polymarket-skill` copied from the main worktree before the full provider runtime tests pass

--- a/docs/internal/plan/2026-05-04-persistent-runtime-plan.md
+++ b/docs/internal/plan/2026-05-04-persistent-runtime-plan.md
@@ -1,0 +1,377 @@
+# Predict Raven Agent-first 持久化运行改造计划
+
+## Goal
+
+- 把持久化运行模块改造成 **Agent-first trading runtime**：Raven Agent 负责完整上下文推理、交易意图和自我修正，core code 负责工具、反馈注入、审计、少量不可绕过硬边界。
+- 先设定一个能连续运行 `12h` 的目标，验证“达成-评估-更新”的闭环，而不是直接追求 30 天无人值守。
+- 本计划只做方案和任务拆分，不开始实现。
+
+## Review 入口
+
+- `services/orchestrator/src/runtime/`：放 Raven Agent loop、Evaluator、Feedback injection 最合适。
+- `services/orchestrator/src/jobs/agent-cycle.ts`：当前 stateful agent cycle 入口，可改造成每轮 agent run 的编排器。
+- `services/orchestrator/src/lib/execution-planning.ts`：交易意图进入执行前的风险裁剪位置。
+- `scripts/pulse-live.ts`：现有 live preflight、archive、错误摘要可抽成共享能力。
+- `scripts/position-monitor.ts`：模型无关的 stop-loss 常驻守护。
+- `docs/risk-controls.md`：需要补充“软反馈”和“硬限制”的边界。
+
+## 核心设计
+
+### 1. Raven Agent 是主驾驶
+
+每一轮运行都由 Raven Agent 读取完整 context pack 后输出交易判断：
+
+- 当前持仓、余额、risk caps、系统状态。
+- 最近 N 次 run summary、上次 Raven Agent reasoning、失败记录。
+- 最新 pulse / market candidates / relevant sources。
+- evaluator 上一轮指出的问题和本轮必须重点修正的 checklist。
+
+Raven Agent 输出：
+
+- 人类可读 reasoning。
+- 结构化 `trade_intents.json`。
+- 当前持仓 review：每个仓位继续持有、减仓、平仓或等待 resolution 的理由。
+- 对 evaluator feedback 的逐条回应。
+- 是否需要继续调查、降级、暂停或执行。
+
+### 2. Evaluator / Feedback 层不断推动 Raven Agent 修正
+
+Evaluator 不替 Raven Agent 下结论，而是检查 Raven Agent 的输出质量，并把发现注入回当前对话。
+
+Evaluator 第一版分成几类，分别评估 Raven Agent 在推理质量、决策质量和流程完整性上的表现：
+
+| Evaluator 类型 | 检查什么 | 输出 |
+| --- | --- | --- |
+| 推理质量评估 | thesis、反证、概率差、置信度、信息是否过期、是否遗漏关键情景 | 推理缺口、需要补充的问题 |
+| 决策质量评估 | open / hold / reduce / close 是否和 edge、赔率、仓位、历史理由一致 | 需要 Raven Agent 回应或修订的交易判断 |
+| 流程完整性评估 | 是否检查了正确信息源、resolution 规则、官方来源、最新盘口、当前持仓和钱包状态 | 缺失步骤、错误来源、需要重新查询的内容 |
+| 执行可行性评估 | token 是否可交易、order book 是否支撑 size、最小下单量、滑点、流动性 | 执行风险和 size 修正建议 |
+| 后训练数据评估 | context / decision / feedback / revised decision 是否可复盘、可训练 | 缺失 artifact 和结构化字段 |
+
+流程完整性评估要特别检查：
+
+- Raven Agent 是否明确读过当前持仓，而不是只看新市场。
+- 对每个已持仓 market，是否找到 resolution 条款、正确 resolution source，并确认拿到的是当前有效信息。
+- 信息源是否是原始来源或可信聚合来源，而不是只引用二手结论。
+- 市场概率、Raven Agent 概率、流动性和盘口是否来自同一时间窗口。
+- 如果信息源缺失或冲突，是否进入查询/补证流程，而不是直接给交易结论。
+
+反馈不用英文等级，统一用 `1-5` 分：
+
+| 分数 | 含义 | 系统动作 |
+| --- | --- | --- |
+| `1` | 通过 | 记录结果，允许继续 |
+| `2` | 轻微提醒 | 注入软提醒，允许继续 |
+| `3` | 需要回应 | 注入质疑，要求 Raven Agent 逐条回应 |
+| `4` | 需要修订 | 注入反馈，要求 Raven Agent 重新生成 decision |
+| `5` | 硬边界或真实状态不明 | 不执行真钱动作，只允许解释、补证、降级或进入 diagnostic mode |
+
+### 3. Core code 是 Agent 操作系统，不是策略主脑
+
+Core code 提供：
+
+- context pack builder
+- evaluator runner
+- feedback injector
+- intent schema validator
+- archive writer
+- Query Code 环境
+- scheduler / heartbeat / lock
+- executor queue adapter
+- 最小硬风控
+
+Core code 不应该替 Raven Agent 发明策略，不应该把 Raven Agent 降级成日报机器人。
+
+Query Code 环境的定位：
+
+- 给 Raven Agent 和 Evaluator 一个快速、只读、可复现的查询环境。
+- 可以查 artifacts、DB 快照、当前持仓、run summary、market metadata、resolution source、order book 和 wallet preflight 结果。
+- 可以运行小段只读分析代码来核对“这个结论是否有数据支持”。
+- 默认不能写状态、不能下单、不能改 wallet；它只产出 `query-code-result.json`，作为 feedback 和 revised decision 的证据。
+
+### 4. 少量硬边界仍不可绕过
+
+这些情况不能只靠反馈提醒：
+
+- 钱包地址或 env 不匹配。
+- 系统 `paused` / `halted`。
+- 重入 lock 已被占用。
+- token 不在允许交易集合或无法验证。
+- 单笔、总敞口、事件敞口、最大仓位数超过硬上限。
+- 关键状态缺失到无法确认真实风险。
+
+补充说明：
+
+- 系统 `paused` 是临时暂停状态，表示本轮不允许新的真钱开仓；常见触发包括人工暂停、连续两轮失败、wallet/env 不匹配、关键状态互相冲突、heartbeat 过期、Evaluator 连续给出 `5` 分硬风险。`paused` 可以在诊断后人工恢复。
+- 系统 `halted` 是更强的风控停机状态，通常来自组合回撤、硬风控触发或不可忽略的资金安全问题；`halted` 下禁止新的 open，只能做诊断、取消挂单、必要的减仓/平仓流程。
+- 重入 lock 用来防止两个 Raven Agent run、两个 scheduler 或人工命令同时触发同一钱包的交易。每轮开始时写入 runId、wallet、startedAt、heartbeat 和过期时间；lock 未过期时第二个 run 必须跳过，不能并发下单。
+- “关键状态缺失”不是简单的 API 报错，而是无法判断真实风险：例如 DB 持仓、Polymarket 远端持仓、钱包余额、最新 archive、order book 或 resolution source 之间出现冲突。系统要把状态标记为 `verified / stale / conflict / missing`，只要处于 `conflict` 或关键字段 `missing`，真钱动作进入 diagnostic，不继续执行。
+
+除这些硬边界外，优先用 evaluator feedback 让 Raven Agent 自己修正。
+
+## 12h 目标
+
+### 目标定义
+
+在一个 main-derived worktree 或 VPS 环境中，运行 `12h` 的 Agent-first 持久化循环：
+
+- 每 `90` 到 `120` 分钟唤醒一次 Raven Agent，预计 `6` 到 `8` 轮。
+- 每轮完整执行：
+  1. build context pack
+  2. 当前持仓 review：逐仓检查原始 thesis、当前 edge、resolution 进展、盘口、PnL 和风险占用
+  3. Raven Agent initial analysis
+  4. evaluator 检查
+  5. feedback 注入
+  6. Raven Agent revised decision
+  7. execution gate
+  8. live execution dispatch
+  9. archive + metrics
+  10. update next-run checklist
+- 默认第一阶段就是 live-first 完整循环：使用真实钱包 preflight、真实持仓、真实 market data、真实 order book、完整 execution gate，并生成可 dispatch 到 executor 的真实执行计划。
+- 代码测试阶段使用 mock executor / fixture wallet 防止误下单；产品逻辑不把 `recommend-only` 作为目标状态。
+- 交易循环必须是完整闭环，不以“取消订单”或“临时真钱开关”作为核心目标；每轮都要覆盖持仓 review、新机会筛选、无 edge/高估资产处置、反馈修订、执行门、真实执行计划、复盘更新。
+- 如果用户提供新的钱包地址或 env 文件，本轮 12h runner 必须在 preflight 中打印并归档实际使用的钱包地址、collateral、chain、env path；地址不匹配时进入 paused / diagnostic，不继续真钱执行。
+
+### 12h 成功条件
+
+- 至少完成 `6` 轮循环。
+- 每轮都有完整 artifact：
+  - `context-pack.json`
+  - `position-review.json`
+  - `source-resolution-audit.json`
+  - `initial-decision.json`
+  - `evaluator-report.json`
+  - `feedback-injection.md`
+  - `revised-decision.json`
+  - `execution-gate.json`
+  - `execution-dispatch-plan.json`
+  - `run-summary.md`
+  - `transcript-summary.md`
+- evaluator 至少能触发并记录一次 `3` 分或 `4` 分反馈。
+- Raven Agent 必须对反馈作出明确回应，不能只原样复述。
+- 每个已有持仓都必须被 review，并给出 hold / reduce / close / wait-resolution 的理由。
+- 对没有 edge、edge 反转、市场被高估、原 thesis 失效或 resolution 风险变化的持仓，Raven Agent 必须评估 reduce / close。
+- 重入 lock、heartbeat、latest state 都正常刷新。
+- 连续失败不能超过 `2` 轮；达到阈值后进入 paused / diagnostic mode。
+- 12h 结束时输出 `12h-review.md`：哪些反馈改善了决策，哪些 evaluator 规则误伤，下一轮要更新什么。
+
+### 12h 不追求的目标
+
+- 不要求 12h 内真实盈利。
+- 不要求 12h 内直接开启无限制 live。
+- 不要求 evaluator 一次设计完美。
+- 不要求 core code 自动替 Raven Agent 做策略 fallback。
+
+## 达成-评估-更新流程
+
+### 达成
+
+每轮要达成一个可检查结果：
+
+- Raven Agent 完成一次完整交易判断。
+- Raven Agent 完成一次当前持仓 review，尤其检查无 edge 或被市场高估的仓位是否应卖出。
+- Evaluator 完成一次质量检查。
+- Feedback 被注入并产生 revised decision。
+- Execution gate 输出执行、跳过、降级或阻断结论。
+- 测试阶段可以 mock executor，但运行链路必须生成真实执行计划，而不是只写建议。
+- 所有过程落盘，成为后训练轨迹。
+
+### 评估
+
+每轮结束时评估：
+
+- `analysis_completeness_score`：分析是否覆盖必要维度。
+- `feedback_response_score`：Raven Agent 是否真正吸收反馈。
+- `decision_stability`：修改前后结论是否合理变化。
+- `risk_alignment`：是否贴合当前仓位和硬风控。
+- `position_review_quality`：是否逐仓检查 edge、resolution、盘口、PnL 和卖出理由。
+- `process_completeness_score`：是否完成 source / resolution / order book / wallet / current position 检查。
+- `artifact_quality`：后续能否复盘和训练。
+- `operator_intervention_needed`：是否需要人工接管。
+
+### 更新
+
+每轮把评估结果写入下一轮 checklist：
+
+- evaluator 新增或调整规则。
+- Raven Agent prompt 增加本轮暴露的问题。
+- context pack 增加缺失数据。
+- Query Code 环境增加本轮需要的快捷查询。
+- 如果某类反馈连续误伤，降低分数。
+- 如果某类风险被 Raven Agent 忽略，提高分数。
+- 如果连续两轮失败，进入 diagnostic mode，不继续真钱执行。
+
+## 实现阶段
+
+### Phase 0：设计数据契约
+
+新增或整理这些 schema：
+
+- `AgentContextPack`
+- `PositionReview`
+- `SourceResolutionAudit`
+- `AgentInitialDecision`
+- `EvaluatorReport`
+- `FeedbackInjection`
+- `AgentRevisedDecision`
+- `ExecutionGateResult`
+- `QueryCodeResult`
+- `ExecutionDispatchPlan`
+- `LoopMetrics`
+
+成功标准：
+
+- 每个 artifact 都有明确 JSON schema。
+- 任何一轮都能从 artifact 独立复盘。
+
+### Phase 1：做 12h runner
+
+新增 `agent-persistent-runner`：
+
+- 接受 `--duration-hours 12`
+- 接受 `--interval-minutes 90`
+- 默认 live-first：完整 preflight、持仓 review、execution gate、真实执行计划
+- 支持 `--env-file <path>` 或 wallet profile，方便接入用户新钱包地址
+- 支持 `--mock-executor` 仅用于代码测试；正式运行不走 recommend-only
+- 每轮刷新 heartbeat
+- 使用 lock 防重入
+- 失败写 `run-error/<timestamp>-agent-persistent/`
+
+成功标准：
+
+- 本地能跑短版 `--duration-minutes 20 --interval-minutes 5` smoke。
+- smoke 至少完成 2 轮 artifact 写入。
+
+### Phase 2：接入 Evaluator / Feedback
+
+实现 evaluator：
+
+- 第一版包含推理质量、决策质量、流程完整性、执行可行性、后训练数据五类 evaluator。
+- 先用 deterministic checklist + 可选小模型 critic。
+- 输出 findings 和 `1-5` 分。
+- 对 `3` 分以上生成 feedback prompt；`4` 分要求重新生成 decision；`5` 分进入硬边界或 diagnostic。
+
+实现 feedback injector：
+
+- 把 evaluator findings 注入同一轮 Raven Agent 修正阶段。
+- 要求 Raven Agent 对每条 finding 给出 response。
+
+成功标准：
+
+- 人工构造一个分析不完整的 decision，evaluator 能触发 revise。
+- Raven Agent revised decision 能引用并处理 evaluator finding。
+
+### Phase 3：执行门与 hard boundary
+
+实现 execution gate：
+
+- schema validation
+- system status：区分 running / paused / halted，并写明为什么 pause
+- wallet / env / collateral
+- stale pulse
+- token allowability
+- risk caps
+- lock / idempotency
+- critical state classifier：把关键状态标记为 verified / stale / conflict / missing
+
+成功标准：
+
+- 软问题走 feedback，不直接 block。
+- 硬问题必须 block。
+- paused / halted / lock / critical state 的原因必须能在 archive 中读懂。
+- gate 结果清晰写入 archive。
+
+### Phase 4：12h soak
+
+执行顺序：
+
+1. `20min` 本地 smoke。
+2. `2h` live-first runner + mock executor trial，用来验证代码和归档。
+3. `12h` live-first runner，使用用户提供的钱包/env 与真实 preflight；executor 是否 mock 由运行参数明确打印。
+4. 如果进入真钱执行，必须在每轮 archive 中记录 wallet、collateral、risk caps、execution dispatch plan 和 executor response。
+
+成功标准：
+
+- 12h review 文件清楚列出：
+  - 达成了什么
+  - evaluator 哪些反馈有效
+  - Raven Agent 哪些地方变好了
+  - 当前持仓中哪些没有 edge、哪些被高估、哪些应继续 hold
+  - 哪些数据缺口阻碍判断
+  - 下一轮如何更新 prompt / evaluator / context pack
+
+## User Decisions
+
+- Decision：12h 阶段使用真实 executor 还是 mock executor。
+  - Why it matters：用户不需要 recommend-only；但代码测试阶段仍要避免误下单。
+  - Recommended default：代码调试先 `--mock-executor`，正式 12h 用真实 executor 并强制打印 execution mode。
+
+- Decision：Evaluator 第一版使用 deterministic checklist 还是小模型 critic。
+  - Why it matters：checklist 可控，小模型 critic 更像真实后训练目标。
+  - Recommended default：checklist 先行，保留 small model critic adapter。
+
+- Decision：Raven Agent 运行载体。
+  - Why it matters：Claude Code / Codex / OpenClaw 的会话持久性、工具权限和成本不同。
+  - Recommended default：先做 provider-neutral runner，让 Raven Agent 作为可替换 provider。
+
+- Decision：新钱包地址或 env 文件。
+  - Why it matters：12h runner 必须验证实际钱包、collateral 和风险阈值，不能继续假设 `.env.pizza` 永远是活跃账户。
+  - Recommended default：支持 `--env-file` / wallet profile；preflight 打印并归档实际地址，地址不符直接 pause。
+
+## Risks and Assumptions
+
+- 风险：feedback 太多会让 Raven Agent 过度保守。
+  - 处理：记录 feedback 命中率和误伤率，每轮更新评分。
+
+- 风险：feedback 太软会被 Raven Agent 忽略。
+  - 处理：`3` 分以上要求逐条回应，`4` 分必须重新输出 JSON。
+
+- 风险：Agent-first 容易产生不可复现决策。
+  - 处理：强制 context pack、decision、feedback、revised decision、gate 全量归档。
+
+- 风险：长期目标需要 post-training 数据，不能只存自然语言总结。
+  - 处理：所有关键节点同时存 machine-readable JSON 和 transcript summary。
+
+- 假设：第一版 12h 目标为 live-first；本地代码测试可以 mock executor，但不是产品默认模式。
+- 假设：core code 可以改造成 Agent 操作系统，而不是固定策略引擎。
+- 假设：用户希望 Raven Agent 能触达下单，但接受少量不可绕过硬边界。
+
+## Execution Gate
+
+- 等用户 review 本计划。
+- 下一步若确认执行，先做 Phase 0 + 20min mock-executor smoke，再进入 2h / 12h live-first runner。
+
+## 当前实现进度（2026-05-04）
+
+- 已新增 `services/orchestrator/src/runtime/raven-agent-loop.ts`：
+  - `AgentContextPack`
+  - `PositionReviewArtifact`
+  - `SourceResolutionAudit`
+  - `EvaluatorReport`
+  - `FeedbackInjection`
+  - `ExecutionGateResult`
+  - `ExecutionDispatchPlan`
+  - `LoopMetrics`
+- 已新增 `scripts/agent-persistent-runner.ts` 和 `pnpm agent:persistent`：
+  - 支持 `--duration-minutes`
+  - 支持 `--interval-minutes`
+  - 支持 `--max-iterations`
+  - 支持 `--archive-root`
+  - 支持 `--env-file`
+  - 支持 `--mock-executor` 用于代码测试
+  - 默认写入并释放 `runner.lock`，防止重入
+- 当前 runner 是 live-first artifact loop：生成真实执行计划 `execution-dispatch-plan.json`，不再以 recommend-only 为目标。
+- 当前真实 executor dispatch 尚未 wired；不带 `--mock-executor` 会 fail-fast，避免半成品误下单。
+- 已新增 `services/orchestrator/src/runtime/raven-agent-loop.test.ts`，覆盖 evaluator、execution gate、artifact 写入。
+- 已验证：
+  - `pnpm exec vitest run --config config/vitest.config.ts services/orchestrator/src/runtime/raven-agent-loop.test.ts`
+  - `pnpm agent:persistent -- --duration-minutes 0 --max-iterations 1 --interval-minutes 0 --mock-executor --archive-root runtime-artifacts/raven-agent-smoke`
+  - `pnpm agent:persistent` 不带 `--mock-executor` 会拒绝执行真钱 dispatch
+  - 预置 `runner.lock` 时，runner 会拒绝启动，验证重入保护有效
+- 已修复顺手发现的既有 typecheck 阻塞：
+  - `paper-trading.test.ts` 的 `PlannedExecution` fixture 补齐 `orderType` / `gtcLimitPrice` / `categorySlug` / `negRisk`
+  - `full-pulse.ts` 改用现有 `TextMetrics.approxTokens`
+- 当前验证结果：
+  - `pnpm typecheck` 通过
+  - `pnpm test` 通过（39 files / 320 tests）
+  - 因 `vendor/repos` 是 ignored 运行依赖，本 worktree 需要从主工作区补齐 `vendor/repos/all-polymarket-skill` 后全量 provider runtime 测试才会通过

--- a/services/orchestrator/src/runtime/raven-agent-loop.test.ts
+++ b/services/orchestrator/src/runtime/raven-agent-loop.test.ts
@@ -1,0 +1,271 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import type { OverviewResponse, PublicPosition, TradeDecision, TradeDecisionSet } from "@autopoly/contracts";
+import type { PulseSnapshot } from "../pulse/market-pulse.js";
+import type { PositionReviewResult } from "./decision-metadata.js";
+import {
+  buildAgentContextPack,
+  buildExecutionDispatchPlan,
+  buildExecutionGateResult,
+  buildPositionReviewArtifact,
+  buildRavenAgentIterationArtifacts,
+  buildSourceResolutionAudit,
+  evaluateRavenAgentIteration,
+  writeRavenAgentIterationArtifacts
+} from "./raven-agent-loop.js";
+
+const generatedAtUtc = "2026-05-04T12:00:00.000Z";
+
+function overview(status: OverviewResponse["status"] = "running"): OverviewResponse {
+  return {
+    status,
+    cash_balance_usd: 100,
+    total_equity_usd: 500,
+    high_water_mark_usd: 520,
+    drawdown_pct: 0.038,
+    open_positions: 1,
+    last_run_at: null,
+    latest_risk_event: null,
+    equity_curve: []
+  };
+}
+
+function position(overrides: Partial<PublicPosition> = {}): PublicPosition {
+  return {
+    id: "pos-1",
+    event_slug: "event-1",
+    market_slug: "market-1",
+    token_id: "token-1",
+    side: "BUY",
+    outcome_label: "Yes",
+    size: 20,
+    avg_cost: 0.5,
+    current_price: 0.52,
+    current_value_usd: 10.4,
+    unrealized_pnl_pct: 0.04,
+    stop_loss_pct: 0.3,
+    opened_at: generatedAtUtc,
+    updated_at: generatedAtUtc,
+    ...overrides
+  };
+}
+
+function pulse(overrides: Partial<PulseSnapshot> = {}): PulseSnapshot {
+  return {
+    id: "pulse-1",
+    generatedAtUtc,
+    title: "Pulse",
+    relativeMarkdownPath: "reports/pulse.md",
+    absoluteMarkdownPath: "/tmp/pulse.md",
+    relativeJsonPath: "reports/pulse.json",
+    absoluteJsonPath: "/tmp/pulse.json",
+    markdown: "# Pulse",
+    totalFetched: 100,
+    totalFiltered: 20,
+    selectedCandidates: 1,
+    minLiquidityUsd: 5000,
+    candidates: [],
+    riskFlags: [],
+    tradeable: true,
+    ...overrides
+  };
+}
+
+function decision(overrides: Partial<TradeDecision> = {}): TradeDecision {
+  return {
+    action: "open",
+    event_slug: "event-1",
+    market_slug: "market-1",
+    token_id: "token-1",
+    side: "BUY",
+    notional_usd: 5,
+    order_type: "FOK",
+    ai_prob: 0.6,
+    market_prob: 0.52,
+    edge: 0.08,
+    confidence: "medium",
+    thesis_md: "The Raven Agent thesis covers market probability, counter-evidence, liquidity, position impact, and why this action is preferred now.",
+    sources: [
+      {
+        title: "Primary source",
+        url: "https://example.com/source",
+        retrieved_at_utc: generatedAtUtc
+      }
+    ],
+    stop_loss_pct: 0.3,
+    resolution_track_required: true,
+    ...overrides
+  };
+}
+
+function decisionSet(input: { runId?: string; decisions?: TradeDecision[] } = {}): TradeDecisionSet {
+  return {
+    run_id: input.runId ?? randomUUID(),
+    runtime: "raven-agent-test",
+    generated_at_utc: generatedAtUtc,
+    bankroll_usd: 500,
+    mode: "full",
+    decisions: input.decisions ?? [decision()],
+    artifacts: []
+  };
+}
+
+function positionReview(input: {
+  pos?: PublicPosition;
+  action?: PositionReviewResult["action"];
+  edgeValue?: number;
+  pulseCoverage?: PositionReviewResult["pulseCoverage"];
+} = {}): PositionReviewResult {
+  const pos = input.pos ?? position();
+  const dec = decision({
+    action: input.action ?? "hold",
+    side: input.action === "close" || input.action === "reduce" ? "SELL" : "BUY",
+    token_id: pos.token_id,
+    market_slug: pos.market_slug,
+    event_slug: pos.event_slug,
+    edge: input.edgeValue ?? 0.08
+  });
+  return {
+    position: pos,
+    action: input.action ?? "hold",
+    stillHasEdge: (input.edgeValue ?? 0.08) > 0,
+    edgeAssessment: (input.edgeValue ?? 0.08) > 0 ? "yes" : "no",
+    edgeValue: input.edgeValue ?? 0.08,
+    pulseCoverage: input.pulseCoverage ?? "supporting",
+    evidenceRefreshStatus: "fresh-supporting",
+    freshEvidence: [],
+    adverseSignals: [],
+    stopOrReduceTriggers: [],
+    pnlSnapshot: {
+      currentValueUsd: 10,
+      avgCost: 0.5,
+      currentPrice: 0.55,
+      unrealizedPnlPct: 0.1,
+      stopLossPct: 0.3
+    },
+    humanReviewFlag: false,
+    confidence: "medium",
+    reason: "Position retains a positive edge after refreshed review.",
+    reviewConclusion: "Hold because the edge remains positive and sources are current.",
+    suggestedExitPct: 0,
+    basis: "pulse-supports-current",
+    decision: dec
+  };
+}
+
+describe("raven agent loop artifacts", () => {
+  it("scores missing current-position review as revision required", () => {
+    const runId = randomUUID();
+    const pos = position();
+    const contextPack = buildAgentContextPack({
+      runId,
+      mode: "full",
+      overview: overview(),
+      positions: [pos],
+      pulse: pulse(),
+      generatedAtUtc
+    });
+    const decisions = decisionSet({ runId });
+    const report = evaluateRavenAgentIteration({
+      contextPack,
+      positionReview: buildPositionReviewArtifact({
+        runId,
+        positions: [pos],
+        positionReviews: [],
+        generatedAtUtc
+      }),
+      sourceResolutionAudit: buildSourceResolutionAudit({
+        runId,
+        decisionSet: decisions,
+        generatedAtUtc
+      }),
+      decisionSet: decisions
+    });
+
+    expect(report.overallScore).toBe(4);
+    expect(report.findings.some((finding) => finding.title === "Open position was not reviewed")).toBe(true);
+  });
+
+  it("marks clean live execution intents as dispatch-ready", () => {
+    const runId = randomUUID();
+    const contextPack = buildAgentContextPack({
+      runId,
+      mode: "full",
+      overview: overview(),
+      positions: [position()],
+      pulse: pulse(),
+      generatedAtUtc
+    });
+    const evaluatorReport = evaluateRavenAgentIteration({
+      contextPack,
+      positionReview: buildPositionReviewArtifact({
+        runId,
+        positions: [position()],
+        positionReviews: [positionReview()],
+        generatedAtUtc
+      }),
+      sourceResolutionAudit: buildSourceResolutionAudit({
+        runId,
+        decisionSet: decisionSet({ runId }),
+        generatedAtUtc
+      }),
+      decisionSet: decisionSet({ runId })
+    });
+    const gate = buildExecutionGateResult({
+      runId,
+      mode: "live",
+      contextPack,
+      evaluatorReport,
+      generatedAtUtc
+    });
+    const dispatchPlan = buildExecutionDispatchPlan({
+      runId,
+      decisions: [decision()],
+      executionGate: gate,
+      generatedAtUtc
+    });
+
+    expect(gate.decision).toBe("execute");
+    expect(dispatchPlan.readyToBroadcast).toBe(true);
+    expect(dispatchPlan.orders[0]?.dispatchStatus).toBe("ready");
+  });
+
+  it("writes the live dispatch artifact set", async () => {
+    const runId = randomUUID();
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "raven-agent-loop-"));
+    try {
+      const pos = position();
+      const contextPack = buildAgentContextPack({
+        runId,
+        mode: "full",
+        overview: overview(),
+        positions: [pos],
+        pulse: pulse(),
+        generatedAtUtc
+      });
+      const artifacts = buildRavenAgentIterationArtifacts({
+        contextPack,
+        decisionSet: decisionSet({ runId }),
+        positions: [pos],
+        positionReviews: [positionReview({ pos })],
+        mode: "live"
+      });
+      await writeRavenAgentIterationArtifacts({
+        archiveDir: tempDir,
+        artifacts
+      });
+
+      const dispatchPlan = JSON.parse(await readFile(path.join(tempDir, "execution-dispatch-plan.json"), "utf8")) as {
+        readyToBroadcast: boolean;
+      };
+      const feedback = await readFile(path.join(tempDir, "feedback-injection.md"), "utf8");
+      expect(dispatchPlan.readyToBroadcast).toBe(true);
+      expect(feedback).toContain("Raven Agent Feedback Injection");
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/services/orchestrator/src/runtime/raven-agent-loop.ts
+++ b/services/orchestrator/src/runtime/raven-agent-loop.ts
@@ -1,0 +1,733 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  type OverviewResponse,
+  type PublicPosition,
+  type TradeDecision,
+  type TradeDecisionSet
+} from "@autopoly/contracts";
+import type { PulseSnapshot } from "../pulse/market-pulse.js";
+import type { PositionReviewResult } from "./decision-metadata.js";
+
+export type EvaluatorType =
+  | "reasoning-quality"
+  | "decision-quality"
+  | "process-completeness"
+  | "execution-feasibility"
+  | "post-training-data";
+
+export type EvaluatorScore = 1 | 2 | 3 | 4 | 5;
+export type CriticalStateStatus = "verified" | "stale" | "conflict" | "missing";
+export type ExecutionGateMode = "live";
+export type ExecutionGateDecision = "execute" | "skip" | "blocked" | "diagnostic";
+
+export interface AgentContextPack {
+  runId: string;
+  generatedAtUtc: string;
+  mode: string;
+  status: OverviewResponse["status"];
+  bankrollUsd: number;
+  openPositions: number;
+  drawdownPct: number;
+  pulse: {
+    id: string;
+    title: string;
+    generatedAtUtc: string;
+    selectedCandidates: number;
+    tradeable: boolean;
+    riskFlags: string[];
+  };
+  positions: Array<{
+    id: string;
+    marketSlug: string;
+    tokenId: string;
+    outcomeLabel: string;
+    size: number;
+    avgCost: number;
+    currentPrice: number;
+    currentValueUsd: number;
+    unrealizedPnlPct: number;
+    stopLossPct: number;
+  }>;
+  nextRunChecklist: string[];
+}
+
+export interface PositionReviewArtifact {
+  runId: string;
+  generatedAtUtc: string;
+  positionsReviewed: number;
+  missingPositionReviewTokenIds: string[];
+  reviews: Array<{
+    tokenId: string;
+    marketSlug: string;
+    action: PositionReviewResult["action"] | "missing";
+    stillHasEdge: boolean | null;
+    edgeValue: number | null;
+    pulseCoverage: PositionReviewResult["pulseCoverage"] | "missing";
+    reason: string;
+    reviewConclusion: string;
+  }>;
+}
+
+export interface SourceResolutionAudit {
+  runId: string;
+  generatedAtUtc: string;
+  decisionsAudited: number;
+  rows: Array<{
+    marketSlug: string;
+    tokenId: string;
+    action: TradeDecision["action"];
+    sourceCount: number;
+    externalSourceCount: number;
+    hasResolutionTracking: boolean;
+    processStatus: CriticalStateStatus;
+    notes: string[];
+  }>;
+}
+
+export interface EvaluatorFinding {
+  id: string;
+  type: EvaluatorType;
+  score: EvaluatorScore;
+  title: string;
+  detail: string;
+  requiredResponse: string;
+  relatedMarketSlug?: string;
+  relatedTokenId?: string;
+}
+
+export interface EvaluatorReport {
+  runId: string;
+  generatedAtUtc: string;
+  overallScore: EvaluatorScore;
+  scoreCounts: Record<EvaluatorScore, number>;
+  findings: EvaluatorFinding[];
+  summary: string;
+}
+
+export interface FeedbackInjection {
+  runId: string;
+  generatedAtUtc: string;
+  markdown: string;
+  requiredFindingIds: string[];
+}
+
+export interface ExecutionGateResult {
+  runId: string;
+  generatedAtUtc: string;
+  mode: ExecutionGateMode;
+  decision: ExecutionGateDecision;
+  hardBlockReasons: string[];
+  softFeedbackCount: number;
+  criticalState: Record<string, CriticalStateStatus>;
+}
+
+export interface ExecutionDispatchPlan {
+  runId: string;
+  generatedAtUtc: string;
+  mode: ExecutionGateMode;
+  readyToBroadcast: boolean;
+  orders: Array<{
+    marketSlug: string;
+    tokenId: string;
+    action: TradeDecision["action"];
+    side: TradeDecision["side"];
+    requestedNotionalUsd: number;
+    dispatchStatus: "ready" | "skipped" | "blocked";
+    blockReason: string | null;
+  }>;
+}
+
+export interface LoopMetrics {
+  runId: string;
+  generatedAtUtc: string;
+  analysisCompletenessScore: number;
+  feedbackResponseScore: number;
+  decisionStability: number;
+  riskAlignment: number;
+  positionReviewQuality: number;
+  processCompletenessScore: number;
+  artifactQuality: number;
+  operatorInterventionNeeded: boolean;
+}
+
+export interface RavenAgentIterationArtifacts {
+  contextPack: AgentContextPack;
+  positionReview: PositionReviewArtifact;
+  sourceResolutionAudit: SourceResolutionAudit;
+  initialDecision: TradeDecisionSet;
+  evaluatorReport: EvaluatorReport;
+  feedbackInjection: FeedbackInjection;
+  revisedDecision: TradeDecisionSet;
+  executionGate: ExecutionGateResult;
+  executionDispatchPlan: ExecutionDispatchPlan;
+  loopMetrics: LoopMetrics;
+  runSummaryMarkdown: string;
+  transcriptSummaryMarkdown: string;
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function clampScore(value: number): EvaluatorScore {
+  if (value <= 1) return 1;
+  if (value === 2) return 2;
+  if (value === 3) return 3;
+  if (value === 4) return 4;
+  return 5;
+}
+
+function isExternalSource(url: string) {
+  return /^https?:\/\//i.test(url);
+}
+
+function finding(input: Omit<EvaluatorFinding, "id">, index: number): EvaluatorFinding {
+  return {
+    id: `finding-${String(index + 1).padStart(2, "0")}`,
+    ...input
+  };
+}
+
+export function buildAgentContextPack(input: {
+  runId: string;
+  mode: string;
+  overview: OverviewResponse;
+  positions: PublicPosition[];
+  pulse: PulseSnapshot;
+  nextRunChecklist?: string[];
+  generatedAtUtc?: string;
+}): AgentContextPack {
+  return {
+    runId: input.runId,
+    generatedAtUtc: input.generatedAtUtc ?? nowIso(),
+    mode: input.mode,
+    status: input.overview.status,
+    bankrollUsd: input.overview.total_equity_usd,
+    openPositions: input.overview.open_positions,
+    drawdownPct: input.overview.drawdown_pct,
+    pulse: {
+      id: input.pulse.id,
+      title: input.pulse.title,
+      generatedAtUtc: input.pulse.generatedAtUtc,
+      selectedCandidates: input.pulse.selectedCandidates,
+      tradeable: input.pulse.tradeable,
+      riskFlags: input.pulse.riskFlags
+    },
+    positions: input.positions.map((position) => ({
+      id: position.id,
+      marketSlug: position.market_slug,
+      tokenId: position.token_id,
+      outcomeLabel: position.outcome_label,
+      size: position.size,
+      avgCost: position.avg_cost,
+      currentPrice: position.current_price,
+      currentValueUsd: position.current_value_usd,
+      unrealizedPnlPct: position.unrealized_pnl_pct,
+      stopLossPct: position.stop_loss_pct
+    })),
+    nextRunChecklist: input.nextRunChecklist ?? []
+  };
+}
+
+export function buildPositionReviewArtifact(input: {
+  runId: string;
+  positions: PublicPosition[];
+  positionReviews?: PositionReviewResult[];
+  generatedAtUtc?: string;
+}): PositionReviewArtifact {
+  const reviewByToken = new Map((input.positionReviews ?? []).map((review) => [review.position.token_id, review]));
+  const missingPositionReviewTokenIds = input.positions
+    .filter((position) => !reviewByToken.has(position.token_id))
+    .map((position) => position.token_id);
+
+  return {
+    runId: input.runId,
+    generatedAtUtc: input.generatedAtUtc ?? nowIso(),
+    positionsReviewed: input.positionReviews?.length ?? 0,
+    missingPositionReviewTokenIds,
+    reviews: input.positions.map((position) => {
+      const review = reviewByToken.get(position.token_id);
+      if (!review) {
+        return {
+          tokenId: position.token_id,
+          marketSlug: position.market_slug,
+          action: "missing",
+          stillHasEdge: null,
+          edgeValue: null,
+          pulseCoverage: "missing",
+          reason: "No position review was produced for this open position.",
+          reviewConclusion: "Raven Agent must review this position before live execution."
+        };
+      }
+      return {
+        tokenId: position.token_id,
+        marketSlug: position.market_slug,
+        action: review.action,
+        stillHasEdge: review.stillHasEdge,
+        edgeValue: review.edgeValue,
+        pulseCoverage: review.pulseCoverage,
+        reason: review.reason,
+        reviewConclusion: review.reviewConclusion
+      };
+    })
+  };
+}
+
+export function buildSourceResolutionAudit(input: {
+  runId: string;
+  decisionSet: TradeDecisionSet;
+  generatedAtUtc?: string;
+}): SourceResolutionAudit {
+  return {
+    runId: input.runId,
+    generatedAtUtc: input.generatedAtUtc ?? nowIso(),
+    decisionsAudited: input.decisionSet.decisions.length,
+    rows: input.decisionSet.decisions.map((decision) => {
+      const externalSourceCount = decision.sources.filter((source) => isExternalSource(source.url)).length;
+      const notes: string[] = [];
+      if (decision.sources.length === 0) {
+        notes.push("No sources attached.");
+      }
+      if (externalSourceCount === 0) {
+        notes.push("No external source attached.");
+      }
+      if (decision.resolution_track_required && externalSourceCount === 0) {
+        notes.push("Resolution tracking is required but no external source is available.");
+      }
+      return {
+        marketSlug: decision.market_slug,
+        tokenId: decision.token_id,
+        action: decision.action,
+        sourceCount: decision.sources.length,
+        externalSourceCount,
+        hasResolutionTracking: decision.resolution_track_required,
+        processStatus: notes.length > 0 ? "missing" : "verified",
+        notes
+      };
+    })
+  };
+}
+
+export function evaluateRavenAgentIteration(input: {
+  contextPack: AgentContextPack;
+  positionReview: PositionReviewArtifact;
+  sourceResolutionAudit: SourceResolutionAudit;
+  decisionSet: TradeDecisionSet;
+}): EvaluatorReport {
+  const findings: Array<Omit<EvaluatorFinding, "id">> = [];
+
+  if (input.contextPack.status !== "running") {
+    findings.push({
+      type: "execution-feasibility",
+      score: 5,
+      title: "System is not running",
+      detail: `System status is ${input.contextPack.status}; live-money opens must not proceed.`,
+      requiredResponse: "Explain the paused/halted state and switch to diagnostic mode until the system is explicitly resumed."
+    });
+  }
+
+  if (!input.contextPack.pulse.tradeable || input.contextPack.pulse.riskFlags.length > 0) {
+    findings.push({
+      type: "process-completeness",
+      score: 5,
+      title: "Pulse is not live-tradeable",
+      detail: `Pulse risk flags: ${input.contextPack.pulse.riskFlags.join(", ") || "tradeable=false"}.`,
+      requiredResponse: "Do not open new live positions until pulse freshness and candidate quality are verified."
+    });
+  }
+
+  for (const tokenId of input.positionReview.missingPositionReviewTokenIds) {
+    findings.push({
+      type: "process-completeness",
+      score: 4,
+      title: "Open position was not reviewed",
+      detail: `Open position ${tokenId} has no hold/reduce/close/wait-resolution review.`,
+      requiredResponse: "Review this position with current edge, resolution source, order book, PnL, and sell rationale.",
+      relatedTokenId: tokenId
+    });
+  }
+
+  for (const review of input.positionReview.reviews) {
+    if (review.action === "hold" && review.edgeValue != null && review.edgeValue <= 0) {
+      findings.push({
+        type: "decision-quality",
+        score: 4,
+        title: "Hold decision has no positive edge",
+        detail: `${review.marketSlug} is marked hold while edge is ${review.edgeValue}.`,
+        requiredResponse: "Explain why this is not reduce/close, or revise the decision.",
+        relatedMarketSlug: review.marketSlug,
+        relatedTokenId: review.tokenId
+      });
+    }
+    if (review.action === "hold" && review.pulseCoverage === "none") {
+      findings.push({
+        type: "process-completeness",
+        score: 3,
+        title: "Hold decision lacks fresh pulse coverage",
+        detail: `${review.marketSlug} is held without fresh pulse coverage.`,
+        requiredResponse: "Find the correct resolution/source context or explain why holding is still justified.",
+        relatedMarketSlug: review.marketSlug,
+        relatedTokenId: review.tokenId
+      });
+    }
+  }
+
+  for (const row of input.sourceResolutionAudit.rows) {
+    if (row.processStatus !== "verified") {
+      findings.push({
+        type: "process-completeness",
+        score: row.hasResolutionTracking ? 4 : 3,
+        title: "Source or resolution audit is incomplete",
+        detail: `${row.marketSlug}: ${row.notes.join(" ")}`,
+        requiredResponse: "Use Query Code or source lookup to attach a current external source, or downgrade the decision.",
+        relatedMarketSlug: row.marketSlug,
+        relatedTokenId: row.tokenId
+      });
+    }
+  }
+
+  for (const decision of input.decisionSet.decisions) {
+    if (decision.thesis_md.trim().length < 80 && decision.action !== "skip") {
+      findings.push({
+        type: "reasoning-quality",
+        score: 3,
+        title: "Decision thesis is too thin",
+        detail: `${decision.market_slug} thesis has only ${decision.thesis_md.trim().length} characters.`,
+        requiredResponse: "Add thesis, counter-evidence, probability gap, and why the current action is better than hold.",
+        relatedMarketSlug: decision.market_slug,
+        relatedTokenId: decision.token_id
+      });
+    }
+    if (
+      decision.action === "open" &&
+      decision.liquidity_cap_usd != null &&
+      decision.notional_usd > decision.liquidity_cap_usd
+    ) {
+      findings.push({
+        type: "execution-feasibility",
+        score: 4,
+        title: "Open notional exceeds liquidity cap",
+        detail: `${decision.market_slug} requests $${decision.notional_usd} while cap is $${decision.liquidity_cap_usd}.`,
+        requiredResponse: "Revise size below liquidity cap before execution.",
+        relatedMarketSlug: decision.market_slug,
+        relatedTokenId: decision.token_id
+      });
+    }
+  }
+
+  if (input.decisionSet.decisions.length === 0) {
+    findings.push({
+      type: "post-training-data",
+      score: 4,
+      title: "No decision output",
+      detail: "Raven Agent produced no decisions, leaving no trainable decision trajectory.",
+      requiredResponse: "Produce at least one hold/skip decision with reasoning and sources."
+    });
+  }
+
+  const indexedFindings = findings.map((item, index) => finding(item, index));
+  const scoreCounts = {
+    1: 0,
+    2: 0,
+    3: 0,
+    4: 0,
+    5: 0
+  } satisfies Record<EvaluatorScore, number>;
+  for (const item of indexedFindings) {
+    scoreCounts[item.score] += 1;
+  }
+  const overallScore = clampScore(Math.max(1, ...indexedFindings.map((item) => item.score)));
+
+  return {
+    runId: input.contextPack.runId,
+    generatedAtUtc: nowIso(),
+    overallScore,
+    scoreCounts,
+    findings: indexedFindings,
+    summary: indexedFindings.length === 0
+      ? "Evaluator passed: no findings above score 1."
+      : `Evaluator produced ${indexedFindings.length} finding(s); max score ${overallScore}.`
+  };
+}
+
+export function buildFeedbackInjection(input: {
+  runId: string;
+  evaluatorReport: EvaluatorReport;
+  generatedAtUtc?: string;
+}): FeedbackInjection {
+  const requiredFindings = input.evaluatorReport.findings.filter((finding) => finding.score >= 3);
+  const markdown = [
+    "# Raven Agent Feedback Injection",
+    "",
+    `Run ID: ${input.runId}`,
+    `Generated: ${input.generatedAtUtc ?? nowIso()}`,
+    "",
+    requiredFindings.length === 0
+      ? "Evaluator found no item that requires a response. Continue, but keep the checklist visible."
+      : "Raven Agent must respond to each item below before the revised decision is accepted.",
+    "",
+    ...requiredFindings.flatMap((finding) => [
+      `## ${finding.id} · score ${finding.score} · ${finding.title}`,
+      "",
+      finding.detail,
+      "",
+      `Required response: ${finding.requiredResponse}`,
+      ""
+    ])
+  ].join("\n");
+
+  return {
+    runId: input.runId,
+    generatedAtUtc: input.generatedAtUtc ?? nowIso(),
+    markdown,
+    requiredFindingIds: requiredFindings.map((finding) => finding.id)
+  };
+}
+
+export function buildExecutionGateResult(input: {
+  runId: string;
+  mode: ExecutionGateMode;
+  contextPack: AgentContextPack;
+  evaluatorReport: EvaluatorReport;
+  criticalState?: Record<string, CriticalStateStatus>;
+  generatedAtUtc?: string;
+}): ExecutionGateResult {
+  const criticalState = input.criticalState ?? {
+    wallet: "verified",
+    positions: "verified",
+    pulse: input.contextPack.pulse.tradeable ? "verified" : "stale",
+    orderBook: "verified",
+    resolutionSources: input.evaluatorReport.findings.some((finding) => finding.type === "process-completeness" && finding.score >= 4)
+      ? "missing"
+      : "verified"
+  };
+  const hardBlockReasons = input.evaluatorReport.findings
+    .filter((finding) => finding.score >= 5)
+    .map((finding) => `${finding.id}: ${finding.title}`);
+  for (const [key, status] of Object.entries(criticalState)) {
+    if (status === "conflict" || status === "missing") {
+      hardBlockReasons.push(`critical-state:${key}:${status}`);
+    }
+  }
+
+  return {
+    runId: input.runId,
+    generatedAtUtc: input.generatedAtUtc ?? nowIso(),
+    mode: input.mode,
+    decision: hardBlockReasons.length > 0
+      ? "diagnostic"
+      : "execute",
+    hardBlockReasons,
+    softFeedbackCount: input.evaluatorReport.findings.filter((finding) => finding.score >= 2 && finding.score < 5).length,
+    criticalState
+  };
+}
+
+export function buildExecutionDispatchPlan(input: {
+  runId: string;
+  decisions: TradeDecision[];
+  executionGate: ExecutionGateResult;
+  generatedAtUtc?: string;
+}): ExecutionDispatchPlan {
+  const timestamp = input.generatedAtUtc ?? nowIso();
+  const readyToBroadcast = input.executionGate.decision === "execute" && input.executionGate.hardBlockReasons.length === 0;
+  return {
+    runId: input.runId,
+    generatedAtUtc: timestamp,
+    mode: "live",
+    readyToBroadcast,
+    orders: input.decisions.map((decision) => {
+      if (decision.action === "hold" || decision.action === "skip") {
+        return {
+          marketSlug: decision.market_slug,
+          tokenId: decision.token_id,
+          action: decision.action,
+          side: decision.side,
+          requestedNotionalUsd: decision.notional_usd,
+          dispatchStatus: "skipped",
+          blockReason: `No live order dispatch for ${decision.action}.`
+        };
+      }
+      return {
+        marketSlug: decision.market_slug,
+        tokenId: decision.token_id,
+        action: decision.action,
+        side: decision.side,
+        requestedNotionalUsd: decision.notional_usd,
+        dispatchStatus: readyToBroadcast ? "ready" : "blocked",
+        blockReason: readyToBroadcast ? null : input.executionGate.hardBlockReasons.join("; ") || "execution gate did not allow dispatch"
+      };
+    })
+  };
+}
+
+export function buildLoopMetrics(input: {
+  runId: string;
+  evaluatorReport: EvaluatorReport;
+  positionReview: PositionReviewArtifact;
+  sourceResolutionAudit: SourceResolutionAudit;
+  generatedAtUtc?: string;
+}): LoopMetrics {
+  const missingReviews = input.positionReview.missingPositionReviewTokenIds.length;
+  const incompleteSources = input.sourceResolutionAudit.rows.filter((row) => row.processStatus !== "verified").length;
+  const maxScore = input.evaluatorReport.overallScore;
+  return {
+    runId: input.runId,
+    generatedAtUtc: input.generatedAtUtc ?? nowIso(),
+    analysisCompletenessScore: Math.max(1, 6 - maxScore),
+    feedbackResponseScore: input.evaluatorReport.findings.length === 0 ? 5 : 3,
+    decisionStability: 3,
+    riskAlignment: input.evaluatorReport.findings.some((finding) => finding.type === "execution-feasibility" && finding.score >= 4) ? 2 : 4,
+    positionReviewQuality: missingReviews === 0 ? 5 : 2,
+    processCompletenessScore: incompleteSources === 0 ? 5 : 3,
+    artifactQuality: 4,
+    operatorInterventionNeeded: maxScore >= 5 || missingReviews > 0
+  };
+}
+
+export function buildRunSummaryMarkdown(input: {
+  contextPack: AgentContextPack;
+  evaluatorReport: EvaluatorReport;
+  executionGate: ExecutionGateResult;
+  executionDispatchPlan: ExecutionDispatchPlan;
+}) {
+  return [
+    "# Raven Agent Run Summary",
+    "",
+    `- Run ID: ${input.contextPack.runId}`,
+    `- Mode: ${input.executionGate.mode}`,
+    `- Gate decision: ${input.executionGate.decision}`,
+    `- Open positions: ${input.contextPack.openPositions}`,
+    `- Evaluator max score: ${input.evaluatorReport.overallScore}`,
+    `- Feedback items: ${input.evaluatorReport.findings.length}`,
+    `- Dispatch-ready orders: ${input.executionDispatchPlan.orders.filter((order) => order.dispatchStatus === "ready").length}`,
+    "",
+    "## Hard Block Reasons",
+    "",
+    input.executionGate.hardBlockReasons.length > 0
+      ? input.executionGate.hardBlockReasons.map((reason) => `- ${reason}`).join("\n")
+      : "- none",
+    "",
+    "## Evaluator Findings",
+    "",
+    input.evaluatorReport.findings.length > 0
+      ? input.evaluatorReport.findings.map((finding) => `- score ${finding.score}: ${finding.title}`).join("\n")
+      : "- none"
+  ].join("\n");
+}
+
+export function buildTranscriptSummaryMarkdown(input: {
+  evaluatorReport: EvaluatorReport;
+  feedbackInjection: FeedbackInjection;
+}) {
+  return [
+    "# Raven Agent Transcript Summary",
+    "",
+    "This first implementation stores the machine-readable decision artifacts and the feedback prompt that should be injected into the Raven Agent conversation.",
+    "",
+    "## Feedback Required",
+    "",
+    input.feedbackInjection.requiredFindingIds.length > 0
+      ? input.feedbackInjection.requiredFindingIds.map((id) => `- ${id}`).join("\n")
+      : "- none",
+    "",
+    "## Evaluator Summary",
+    "",
+    input.evaluatorReport.summary
+  ].join("\n");
+}
+
+export function buildRavenAgentIterationArtifacts(input: {
+  contextPack: AgentContextPack;
+  decisionSet: TradeDecisionSet;
+  positions: PublicPosition[];
+  positionReviews?: PositionReviewResult[];
+  mode?: ExecutionGateMode;
+}): RavenAgentIterationArtifacts {
+  const positionReview = buildPositionReviewArtifact({
+    runId: input.contextPack.runId,
+    positions: input.positions,
+    positionReviews: input.positionReviews
+  });
+  const sourceResolutionAudit = buildSourceResolutionAudit({
+    runId: input.contextPack.runId,
+    decisionSet: input.decisionSet
+  });
+  const evaluatorReport = evaluateRavenAgentIteration({
+    contextPack: input.contextPack,
+    positionReview,
+    sourceResolutionAudit,
+    decisionSet: input.decisionSet
+  });
+  const feedbackInjection = buildFeedbackInjection({
+    runId: input.contextPack.runId,
+    evaluatorReport
+  });
+  const revisedDecision = input.decisionSet;
+  const executionGate = buildExecutionGateResult({
+    runId: input.contextPack.runId,
+    mode: input.mode ?? "live",
+    contextPack: input.contextPack,
+    evaluatorReport
+  });
+  const executionDispatchPlan = buildExecutionDispatchPlan({
+    runId: input.contextPack.runId,
+    decisions: revisedDecision.decisions,
+    executionGate
+  });
+  const loopMetrics = buildLoopMetrics({
+    runId: input.contextPack.runId,
+    evaluatorReport,
+    positionReview,
+    sourceResolutionAudit
+  });
+  return {
+    contextPack: input.contextPack,
+    positionReview,
+    sourceResolutionAudit,
+    initialDecision: input.decisionSet,
+    evaluatorReport,
+    feedbackInjection,
+    revisedDecision,
+    executionGate,
+    executionDispatchPlan,
+    loopMetrics,
+    runSummaryMarkdown: buildRunSummaryMarkdown({
+      contextPack: input.contextPack,
+      evaluatorReport,
+      executionGate,
+      executionDispatchPlan
+    }),
+    transcriptSummaryMarkdown: buildTranscriptSummaryMarkdown({
+      evaluatorReport,
+      feedbackInjection
+    })
+  };
+}
+
+async function writeJson(filePath: string, value: unknown) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, JSON.stringify(value, null, 2), "utf8");
+}
+
+export async function writeRavenAgentIterationArtifacts(input: {
+  archiveDir: string;
+  artifacts: RavenAgentIterationArtifacts;
+}) {
+  await mkdir(input.archiveDir, { recursive: true });
+  await Promise.all([
+    writeJson(path.join(input.archiveDir, "context-pack.json"), input.artifacts.contextPack),
+    writeJson(path.join(input.archiveDir, "position-review.json"), input.artifacts.positionReview),
+    writeJson(path.join(input.archiveDir, "source-resolution-audit.json"), input.artifacts.sourceResolutionAudit),
+    writeJson(path.join(input.archiveDir, "initial-decision.json"), input.artifacts.initialDecision),
+    writeJson(path.join(input.archiveDir, "evaluator-report.json"), input.artifacts.evaluatorReport),
+    writeFile(path.join(input.archiveDir, "feedback-injection.md"), input.artifacts.feedbackInjection.markdown, "utf8"),
+    writeJson(path.join(input.archiveDir, "revised-decision.json"), input.artifacts.revisedDecision),
+    writeJson(path.join(input.archiveDir, "execution-gate.json"), input.artifacts.executionGate),
+    writeJson(path.join(input.archiveDir, "execution-dispatch-plan.json"), input.artifacts.executionDispatchPlan),
+    writeJson(path.join(input.archiveDir, "loop-metrics.json"), input.artifacts.loopMetrics),
+    writeFile(path.join(input.archiveDir, "run-summary.md"), input.artifacts.runSummaryMarkdown, "utf8"),
+    writeFile(path.join(input.archiveDir, "transcript-summary.md"), input.artifacts.transcriptSummaryMarkdown, "utf8")
+  ]);
+}


### PR DESCRIPTION
Addresses #6.

## What
Extracts the still-valuable part of the persistent-runtime WIP onto current `main` as a **library-only** change. **No live-money execution path is touched** — wiring it to a real runner/scheduler is a separate, separately-reviewed follow-up.

## Changes
- `services/orchestrator/src/runtime/raven-agent-loop.ts` — pure artifact/contract builders: context pack, position review, source-resolution audit, evaluator report, feedback injection, execution gate, execution-dispatch **plan** (JSON fields only), loop metrics, run/transcript summaries, `writeRavenAgentIterationArtifacts`. Imports only `node:fs/promises` + types — no `bullmq`/`Queue`/`ethers`/executor/redis.
- `raven-agent-loop.test.ts` — unit tests for the builders.
- `docs/internal/plan/2026-05-04-persistent-runtime-plan.md` (+ `.en.md`) — the design doc.

## Reconciled against current main (per the issue's "extract, don't merge the dirty worktree")
- **Dropped** the unused `entryPlans` param + `PulseEntryPlan` import (dead weight; no callers).
- **Updated** the test's `PositionReviewResult` fixture for fields main has since added (`evidenceRefreshStatus` / `freshEvidence` / `adverseSignals` / `stopOrReduceTriggers` / `pnlSnapshot`). The module only reads a subset, so it was already compatible.
- **Did NOT** bring `scripts/agent-persistent-runner.ts` (main already has a different, more-complete runner at that path + the `agent:persistent` script), nor the stale `paper-trading.test.ts` / `full-pulse.ts` edits (already fixed in main) — porting those would regress main.

## Scope
Library-only artifact/contract layer. No queue/broadcast/executor wiring; nothing dispatches.

## Test plan
- [x] `pnpm --filter @autopoly/orchestrator typecheck` — clean
- [x] `vitest run services/orchestrator/src/runtime/raven-agent-loop.test.ts` — 3/3 pass
- [x] Diff is exactly the 4 files above — no stale worktree changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)