### PR TITLE
docs(dev-reference): pulse/forecast/autopoly/raven naming glossary

### DIFF
--- a/docs/diagrams/dev-reference.en.md
+++ b/docs/diagrams/dev-reference.en.md
@@ -2,9 +2,20 @@
 
 > Chinese version: [dev-reference.md](dev-reference.md) — authoritative source
 >
-> Last updated: 2026-04-23
+> Last updated: 2026-06-15
 
 The main README only keeps the Agent-facing natural-language workflow. When you need to run pnpm directly, or want to debug dependencies / deployment shapes, look here.
+
+## Naming (pulse / forecast / autopoly / raven)
+
+A few names look different but mean the same thing. Spelled out here so each new maintainer doesn't have to rediscover it:
+
+- **`forecast:*` = the user-facing command names; `pulse` = the engine's internal codename. They are the same forecasting engine.** The CLI uses `forecast:live` / `forecast:recommend` / `forecast:positions`, while `services/orchestrator/src/pulse/`, `scripts/pulse-*.ts`, and the archive paths `runtime-artifacts/pulse/…` and `runtime-artifacts/reports/pulse/…` still say `pulse`. The `pulse:*` commands are kept as **compatibility aliases** for `forecast:*` (see `package.json`).
+  - **Why it isn't fully renamed (kept on purpose):** a full rename would touch 12 files under `src/pulse/` + 13 `pulse-*` scripts + 12 sites that write `runtime-artifacts/pulse` archive paths — and changing the archive paths would orphan existing archives and move where live runs write. **High risk, low reward.** So read it as "engine codename = pulse, user-facing command = forecast" and don't chase literal uniformity.
+- **Three-layer product / package naming (accreted history, each internally consistent):**
+  - `predict-raven` = the repository (GitHub repo / local dir).
+  - `@autopoly/*` = the npm workspace scope (legacy; every package uses it, no functional impact).
+  - `raven` = the product codename (`apps/raven-managed`, `raven-agent-loop`, etc.).
 
 ## Monorepo Structure
 

--- a/docs/diagrams/dev-reference.md
+++ b/docs/diagrams/dev-reference.md
@@ -2,9 +2,20 @@
 
 > 英文版：[dev-reference.en.md](dev-reference.en.md)（待同步翻译）
 >
-> 最后更新：2026-04-23
+> 最后更新：2026-06-15
 
 本仓库主 README 只保留面向 Agent 的自然语言工作流。需要直接用 pnpm 手动操作、或者排查依赖/部署形态时，翻这份。
+
+## 命名说明（pulse / forecast / autopoly / raven）
+
+仓库里有几组"看着不一样、其实指同一个东西"的名字，先在这里说清，免得每个新接手的人重新踩坑：
+
+- **`forecast:*` = 面向用户的命令名；`pulse` = 引擎内部代号。两者是同一套预测引擎。** CLI 用 `forecast:live` / `forecast:recommend` / `forecast:positions`；而 `services/orchestrator/src/pulse/`、`scripts/pulse-*.ts`、归档路径 `runtime-artifacts/pulse/…` 和 `runtime-artifacts/reports/pulse/…` 仍叫 `pulse`。`pulse:*` 命令保留为 `forecast:*` 的**兼容别名**（见 `package.json`）。
+  - **为什么不全量改名（有意保留）：** 全量重命名要动 12 个 `src/pulse/` 文件 + 13 个 `pulse-*` 脚本 + 12 处写 `runtime-artifacts/pulse` 的归档路径——改归档路径会让已有归档"失联"、并改变实盘运行的写入位置，**风险高、收益低**。所以内部一律读作"引擎代号 = pulse，对外命令名 = forecast"，不再追求字面统一。
+- **三层产品 / 包命名（历史累积，各自内部自洽）：**
+  - `predict-raven` = 仓库名（GitHub repo / 本地目录）。
+  - `@autopoly/*` = npm workspace scope（历史遗留；所有子包都用这个 scope，不影响功能）。
+  - `raven` = 产品代号（`apps/raven-managed`、`raven-agent-loop` 等）。
 
 ## Monorepo 结构
 


### PR DESCRIPTION
From the repo-health audit — the half-finished `pulse`→`forecast` rename (CLI says `forecast:*`, internals still say `pulse`) was flagged as recurring onboarding confusion.

## Decision: document, don't risk-rename
A *full* internal rename would touch **12 files under `src/pulse/` + 13 `pulse-*` scripts + 12 sites that write `runtime-artifacts/pulse` archive paths**. Renaming the artifact paths would orphan existing archives and change where live (real-money) runs write — **high risk, low reward**. So the internal `pulse` codename is kept on purpose, and this PR resolves the *actual* problem (the confusion) cheaply by writing it down.

## Changes (docs only)
`docs/diagrams/dev-reference.md` (+ EN mirror) gain a **Naming** section:
- `forecast:*` (user-facing CLI) and `pulse` (engine internal codename: `src/pulse/`, `pulse-*.ts`, `runtime-artifacts/pulse/…`) are the **same engine**; `pulse:*` are compatibility aliases.
- Explicit "why not fully renamed" note (the surface + the real-money archive-path risk).
- The three-layer naming: `predict-raven` (repo) / `@autopoly` (npm scope, legacy) / `raven` (product codename).

## Not done (deliberately)
The mechanical full rename of dirs/symbols/artifact-paths. If you do want it, it's a separate, dedicated, higher-risk PR (especially the artifact-path migration) — happy to scope it on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)