### PR TITLE
test(web): unit tests for prediction-access rules, public-run-pulse, format

### DIFF
--- a/apps/web/lib/prediction-access-rules.ts
+++ b/apps/web/lib/prediction-access-rules.ts
@@ -1,0 +1,46 @@
+// Pure access-control policy rules — env + input only, no DB/auth imports.
+//
+// Extracted from prediction-access.ts so the gating rules (who is an admin, who
+// gets auto-activated, how booleans are read from env) can be unit-tested
+// directly. prediction-access.ts (which imports next-auth + the DB) re-imports
+// these; importing that module into a test runner fails on next-auth's
+// `next/server` resolution, hence this dependency-free split.
+
+export function readBooleanEnv(name: string, fallback: boolean): boolean {
+  const value = process.env[name]?.trim().toLowerCase();
+  if (!value) {
+    return fallback;
+  }
+  return ["1", "true", "yes", "on"].includes(value);
+}
+
+function readCsvEnv(name: string): string[] {
+  return (process.env[name] ?? "")
+    .split(",")
+    .map((item) => item.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function normalizeEmail(value: string | null | undefined): string | null {
+  const normalized = value?.trim().toLowerCase();
+  return normalized || null;
+}
+
+export function emailDomain(value: string | null): string | null {
+  const atIndex = value?.lastIndexOf("@") ?? -1;
+  return atIndex >= 0 ? value!.slice(atIndex + 1).toLowerCase() : null;
+}
+
+// Auto-activation policy: everyone is auto-activated when invites are not
+// required; otherwise only emails whose domain is in the allowlist.
+export function shouldAutoActivate(email: string | null): boolean {
+  if (!readBooleanEnv("PREDICTION_INVITE_REQUIRED", true)) {
+    return true;
+  }
+  const domain = emailDomain(email);
+  return Boolean(domain && readCsvEnv("PREDICTION_AUTO_ACTIVATE_EMAIL_DOMAINS").includes(domain));
+}
+
+export function isAdminEmail(email: string | null): boolean {
+  return Boolean(email && readCsvEnv("PREDICTION_ADMIN_EMAILS").includes(email));
+}

--- a/apps/web/lib/prediction-access.test.ts
+++ b/apps/web/lib/prediction-access.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { emailDomain, isAdminEmail, normalizeEmail, shouldAutoActivate } from "./prediction-access-rules.js";
+
+const ENV_KEYS = [
+  "PREDICTION_ADMIN_EMAILS",
+  "PREDICTION_INVITE_REQUIRED",
+  "PREDICTION_AUTO_ACTIVATE_EMAIL_DOMAINS"
+];
+
+describe("prediction-access rules", () => {
+  afterEach(() => {
+    for (const k of ENV_KEYS) delete process.env[k];
+  });
+
+  describe("normalizeEmail", () => {
+    it("trims + lowercases, mapping blank to null", () => {
+      expect(normalizeEmail("  Foo@Bar.COM ")).toBe("foo@bar.com");
+      expect(normalizeEmail("")).toBeNull();
+      expect(normalizeEmail("   ")).toBeNull();
+      expect(normalizeEmail(null)).toBeNull();
+      expect(normalizeEmail(undefined)).toBeNull();
+    });
+  });
+
+  describe("emailDomain", () => {
+    it("returns the lowercased domain after the last @", () => {
+      expect(emailDomain("foo@bar.com")).toBe("bar.com");
+      expect(emailDomain("weird@a@c.com")).toBe("c.com");
+    });
+    it("returns null when there is no @ or no input", () => {
+      expect(emailDomain("nodomain")).toBeNull();
+      expect(emailDomain(null)).toBeNull();
+    });
+  });
+
+  describe("isAdminEmail (PREDICTION_ADMIN_EMAILS allowlist)", () => {
+    it("matches an email in the allowlist (env values lowercased)", () => {
+      process.env.PREDICTION_ADMIN_EMAILS = "admin@x.com, Boss@Y.com";
+      expect(isAdminEmail("admin@x.com")).toBe(true);
+      expect(isAdminEmail("boss@y.com")).toBe(true);
+      expect(isAdminEmail("nobody@z.com")).toBe(false);
+      expect(isAdminEmail(null)).toBe(false);
+    });
+    it("is false when the allowlist is unset", () => {
+      expect(isAdminEmail("admin@x.com")).toBe(false);
+    });
+  });
+
+  describe("shouldAutoActivate (gating: who skips the invite)", () => {
+    it("auto-activates everyone when invites are NOT required", () => {
+      process.env.PREDICTION_INVITE_REQUIRED = "false";
+      expect(shouldAutoActivate("anyone@anywhere.com")).toBe(true);
+      expect(shouldAutoActivate(null)).toBe(true);
+    });
+    it("when invites ARE required, only auto-activates allowlisted email domains", () => {
+      // default for PREDICTION_INVITE_REQUIRED is true (unset)
+      process.env.PREDICTION_AUTO_ACTIVATE_EMAIL_DOMAINS = "team.com, x.com";
+      expect(shouldAutoActivate("a@team.com")).toBe(true);
+      expect(shouldAutoActivate("a@x.com")).toBe(true);
+      expect(shouldAutoActivate("a@outsider.com")).toBe(false);
+      expect(shouldAutoActivate(null)).toBe(false);
+    });
+    it("requires an invite (no auto-activate) when no allowlist domains are set", () => {
+      expect(shouldAutoActivate("a@team.com")).toBe(false);
+    });
+  });
+});

--- a/apps/web/lib/prediction-access.ts
+++ b/apps/web/lib/prediction-access.ts
@@ -2,6 +2,13 @@ import { createHash, randomUUID } from "node:crypto";
 import { appUsers, getDb, hasDatabaseUrl, inviteCodes, predictionUsageEvents } from "@autopoly/db";
 import { and, eq, gte, sql } from "drizzle-orm";
 import { auth, isOidcConfigured } from "../auth";
+import {
+  emailDomain,
+  isAdminEmail,
+  normalizeEmail,
+  readBooleanEnv,
+  shouldAutoActivate
+} from "./prediction-access-rules.js";
 
 export type PredictionAccessMode =
   | "disabled"
@@ -47,14 +54,6 @@ interface ConsumeQuotaResult {
   error?: string;
 }
 
-function readBooleanEnv(name: string, fallback: boolean): boolean {
-  const value = process.env[name]?.trim().toLowerCase();
-  if (!value) {
-    return fallback;
-  }
-  return ["1", "true", "yes", "on"].includes(value);
-}
-
 function readLimitEnv(name: string, fallback: number): number | null {
   const raw = process.env[name]?.trim();
   if (!raw) {
@@ -93,35 +92,6 @@ export function isPredictionAccessConfigured(): boolean {
 
 export function isPredictionAuthRequired(): boolean {
   return readBooleanEnv("PREDICTION_AUTH_REQUIRED", false);
-}
-
-function normalizeEmail(value: string | null | undefined): string | null {
-  const normalized = value?.trim().toLowerCase();
-  return normalized || null;
-}
-
-function emailDomain(value: string | null): string | null {
-  const atIndex = value?.lastIndexOf("@") ?? -1;
-  return atIndex >= 0 ? value!.slice(atIndex + 1).toLowerCase() : null;
-}
-
-function readCsvEnv(name: string): string[] {
-  return (process.env[name] ?? "")
-    .split(",")
-    .map((item) => item.trim().toLowerCase())
-    .filter(Boolean);
-}
-
-function shouldAutoActivate(email: string | null): boolean {
-  if (!readBooleanEnv("PREDICTION_INVITE_REQUIRED", true)) {
-    return true;
-  }
-  const domain = emailDomain(email);
-  return Boolean(domain && readCsvEnv("PREDICTION_AUTO_ACTIVATE_EMAIL_DOMAINS").includes(domain));
-}
-
-function isAdminEmail(email: string | null): boolean {
-  return Boolean(email && readCsvEnv("PREDICTION_ADMIN_EMAILS").includes(email));
 }
 
 function hashInviteCode(value: string): string {

--- a/apps/web/lib/public-run-pulse.test.ts
+++ b/apps/web/lib/public-run-pulse.test.ts
@@ -1,0 +1,95 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  extractDecisionEventSlug,
+  extractDecisionSide,
+  extractDecisionSources,
+  extractPulseExcerpt,
+  isExecutedTrade,
+  toDisplayPath
+} from "./public-run-pulse.js";
+
+// Cast helper: these transforms accept the loose artifact-decision shape.
+const dec = (obj: unknown) => obj as never;
+
+describe("public-run-pulse transforms", () => {
+  describe("toDisplayPath (must not leak absolute server paths)", () => {
+    it("slices from the runtime-artifacts/ marker", () => {
+      expect(toDisplayPath("/Users/someone/repo/runtime-artifacts/pulse/x.json")).toBe("runtime-artifacts/pulse/x.json");
+    });
+    it("makes a cwd-absolute path repo-relative", () => {
+      const abs = path.join(process.cwd(), "some/where.json");
+      expect(toDisplayPath(abs)).toBe("some/where.json");
+    });
+    it("passes a relative path through and maps null to null", () => {
+      expect(toDisplayPath("docs/notes.md")).toBe("docs/notes.md");
+      expect(toDisplayPath(null)).toBeNull();
+      expect(toDisplayPath(undefined)).toBeNull();
+    });
+  });
+
+  describe("extractPulseExcerpt (bounds exposed content)", () => {
+    it("drops blank lines and caps at maxLines", () => {
+      expect(extractPulseExcerpt("a\n\n b \n\nc", 2)).toBe("a\n b ");
+    });
+    it("trims surrounding whitespace and keeps order", () => {
+      expect(extractPulseExcerpt("\n\nfirst\nsecond\n\n", 14)).toBe("first\nsecond");
+    });
+    it("returns empty string for blank content", () => {
+      expect(extractPulseExcerpt("   \n  \n")).toBe("");
+    });
+  });
+
+  describe("isExecutedTrade", () => {
+    it("is true when notional filled > 0 regardless of status", () => {
+      expect(isExecutedTrade("pending", 5)).toBe(true);
+    });
+    it("is true for filled/matched statuses (case-insensitive) even at 0 notional", () => {
+      expect(isExecutedTrade("filled", 0)).toBe(true);
+      expect(isExecutedTrade("MATCHED", 0)).toBe(true);
+    });
+    it("is false for a non-terminal status with 0 notional", () => {
+      expect(isExecutedTrade("pending", 0)).toBe(false);
+    });
+  });
+
+  describe("extractDecisionSide", () => {
+    it("only SELL maps to SELL; everything else defaults to BUY", () => {
+      expect(extractDecisionSide(dec({ side: "SELL" }))).toBe("SELL");
+      expect(extractDecisionSide(dec({ side: "BUY" }))).toBe("BUY");
+      expect(extractDecisionSide(dec({}))).toBe("BUY");
+      expect(extractDecisionSide(null)).toBe("BUY");
+    });
+  });
+
+  describe("extractDecisionEventSlug", () => {
+    it("prefers eventSlug, then event_slug, then falls back to the market slug", () => {
+      expect(extractDecisionEventSlug(dec({ eventSlug: "e", marketSlug: "m" }))).toBe("e");
+      expect(extractDecisionEventSlug(dec({ event_slug: "e2", marketSlug: "m" }))).toBe("e2");
+      expect(extractDecisionEventSlug(dec({ marketSlug: "m" }))).toBe("m");
+      expect(extractDecisionEventSlug(dec({}))).toBe("");
+    });
+  });
+
+  describe("extractDecisionSources (sanitizes outbound sources)", () => {
+    it("drops sources without a url and defaults a missing title", () => {
+      const out = extractDecisionSources(
+        dec({
+          sources: [
+            { title: "Reuters", url: "https://r.com", retrieved_at_utc: "2026-01-01", note: "n" },
+            { url: "https://nourl-title.com" },
+            { title: "no url here" }
+          ]
+        })
+      );
+      expect(out).toHaveLength(2);
+      expect(out[0]).toEqual({ title: "Reuters", url: "https://r.com", retrieved_at_utc: "2026-01-01", note: "n" });
+      expect(out[1]).toEqual({ title: "Untitled source", url: "https://nourl-title.com", retrieved_at_utc: null, note: null });
+    });
+    it("returns [] when sources is missing or not an array", () => {
+      expect(extractDecisionSources(dec({}))).toEqual([]);
+      expect(extractDecisionSources(dec({ sources: "nope" }))).toEqual([]);
+      expect(extractDecisionSources(null)).toEqual([]);
+    });
+  });
+});

--- a/apps/web/lib/public-run-pulse.ts
+++ b/apps/web/lib/public-run-pulse.ts
@@ -542,3 +542,13 @@ export async function getPublicRunDetailWithPulse(runId: string): Promise<Public
     }
   };
 }
+
+// Exported for unit testing — pure, privacy/mapping-relevant transforms.
+export {
+  toDisplayPath,
+  extractPulseExcerpt,
+  isExecutedTrade,
+  extractDecisionSide,
+  extractDecisionEventSlug,
+  extractDecisionSources
+};

--- a/apps/web/lib/research/format.test.ts
+++ b/apps/web/lib/research/format.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { formatDuration, pct, pp, signedPoints } from "./format.js";
+
+describe("research/format", () => {
+  describe("pct", () => {
+    it("formats a 0-1 probability as a percentage with 1 decimal by default", () => {
+      expect(pct(0.1)).toBe("10.0%");
+      expect(pct(0.6667)).toBe("66.7%");
+      expect(pct(1)).toBe("100.0%");
+      expect(pct(0)).toBe("0.0%");
+    });
+    it("respects the digits argument", () => {
+      expect(pct(0.1234, 0)).toBe("12%");
+      expect(pct(0.1234, 2)).toBe("12.34%");
+    });
+    it("returns N/A for null / undefined / non-finite", () => {
+      expect(pct(null)).toBe("N/A");
+      expect(pct(undefined)).toBe("N/A");
+      expect(pct(Number.NaN)).toBe("N/A");
+      expect(pct(Number.POSITIVE_INFINITY)).toBe("N/A");
+    });
+  });
+
+  describe("pp", () => {
+    it("formats a signed percentage-point delta", () => {
+      expect(pp(0.045)).toBe("+4.5pp");
+      expect(pp(-0.032)).toBe("-3.2pp");
+      expect(pp(-0.57)).toBe("-57.0pp");
+    });
+    it("does not prefix + for zero", () => {
+      expect(pp(0)).toBe("0.0pp");
+    });
+    it("returns N/A for null / undefined / non-finite", () => {
+      expect(pp(null)).toBe("N/A");
+      expect(pp(undefined)).toBe("N/A");
+      expect(pp(Number.NaN)).toBe("N/A");
+    });
+  });
+
+  describe("signedPoints", () => {
+    it("signs already-in-points weights", () => {
+      expect(signedPoints(4)).toBe("+4.0pp");
+      expect(signedPoints(-14)).toBe("-14.0pp");
+      expect(signedPoints(0)).toBe("0.0pp");
+    });
+    it("respects digits", () => {
+      expect(signedPoints(3.25, 2)).toBe("+3.25pp");
+    });
+  });
+
+  describe("formatDuration", () => {
+    it("renders sub-second as ms and >=1s as seconds", () => {
+      expect(formatDuration(420)).toBe("420ms");
+      expect(formatDuration(999)).toBe("999ms");
+      expect(formatDuration(1000)).toBe("1.0s");
+      expect(formatDuration(1500)).toBe("1.5s");
+    });
+    it("returns empty string for 0 / undefined / negative", () => {
+      expect(formatDuration(0)).toBe("");
+      expect(formatDuration(undefined)).toBe("");
+      expect(formatDuration(-5)).toBe("");
+    });
+  });
+});


### PR DESCRIPTION
From the repo-health audit — `apps/web` was near-untested (**1 test file across 53 source files**), the biggest gap vs the 80%-coverage standard, on code that handles **access control + public data exposure**. This is the first incremental batch (1 → 4 test files).

## What
- **`prediction-access` (gating).** Extracted the pure access-control rules into a new **dep-free `prediction-access-rules.ts`** (`normalizeEmail`, `emailDomain`, `isAdminEmail`, `shouldAutoActivate`, `readBooleanEnv`) and unit-tested them. The extraction was necessary: `prediction-access.ts` imports next-auth, which can't load in the vitest node runner (`next/server` resolution fails). Tests cover the admin allowlist + the invite/auto-activation gating policy (who skips the invite).
- **`public-run-pulse` (mapping).** Exported + tested the pure privacy/mapping transforms: `toDisplayPath` (**must not leak absolute server paths**), `extractPulseExcerpt` (bounds exposed content), `isExecutedTrade`, `extractDecisionSide`, `extractDecisionEventSlug`, `extractDecisionSources` (sanitizes outbound sources — drops url-less entries, defaults titles).
- **`research/format`.** Full coverage of `pct` / `pp` / `signedPoints` / `formatDuration`.

## Why the prediction-access split
`prediction-access.ts` is next-auth/DB-coupled; the access-control *rules* are pure (env + input). Splitting them into a dedicated module makes the policy testable without the IO layer — better separation, not just testability.

## Test plan
- [x] `pnpm --filter @autopoly/web typecheck` — clean
- [x] New tests: **31 passing** across the 3 files
- [x] Full suite: **82 files / 713 tests pass** (+31; no regressions)
- No behavior change — pure extraction + added tests.

Note: this is a *first increment*; `replay`/`use-research-stream` and the React components remain untested and are good follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)