### PR TITLE
chore(wc): 固定小组赛最终结果 + 取消结算定时任务

### DIFF
--- a/.github/workflows/wc-results.yml
+++ b/.github/workflows/wc-results.yml
@@ -1,5 +1,4 @@
-# Scheduled World Cup results refresh + publish — the always-on, cloud-native
-# replacement for the Mac /schedule routine. It runs the cheap, credential-free
+# World Cup results refresh + publish — runs the cheap, credential-free
 # settlement fetch (`pnpm wc:results`, market-blind: settled winner + final
 # score, no prices), and when the scores actually changed it builds and deploys
 # the site to forecasting-agent.com via the Vercel CLI using a VERCEL_TOKEN.
@@ -18,11 +17,11 @@
 name: World Cup results refresh
 
 on:
-  schedule:
-    # Twice daily, UTC. Timed after the day's late kickoffs settle on Polymarket.
-    # Group stage finishes late; adjust or add slots as the schedule demands.
-    - cron: "0 7 * * *"
-    - cron: "0 19 * * *"
+  # Group stage finished (2026-06-28); the final 72 results are frozen in
+  # results.generated.json, so the twice-daily cron is disabled. Run manually
+  # only — e.g. to republish forecasting-agent.com after a UI change:
+  # Actions -> "World Cup results refresh" -> Run workflow.
+  # (To re-enable a schedule for the knockout stage, restore a `schedule:` block.)
   workflow_dispatch: {}
 
 # Never let two runs deploy at once.
@@ -52,26 +51,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Refresh group-stage settlement (group stage is over, so this is now a
+      # no-op against the frozen results — kept so a manual run still self-checks
+      # the data before publishing).
       - name: Refresh settled results
         run: pnpm wc:results
 
-      - name: Detect score change
-        id: diff
-        run: |
-          if git diff --quiet -- apps/web/lib/world-cup/generated/results.generated.json; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "No score changes — skipping the deploy (no wasted build)."
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "Scores changed — will build + deploy."
-          fi
-
+      # This workflow is manual-only now (no cron), so every run deploys — the
+      # operator triggers it precisely when they want to republish current main
+      # (e.g. after a UI change). No score-change gate.
       - name: Install Vercel CLI
-        if: steps.diff.outputs.changed == 'true'
         run: npm install -g vercel@latest
 
       - name: Build + deploy to forecasting-agent.com
-        if: steps.diff.outputs.changed == 'true'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: team_2pB0XDZyHAZM66UPHg0fuAvA
@@ -83,7 +75,6 @@ jobs:
           bash scripts/world-cup/deploy-web.sh
 
       - name: Verify live site (real acceptance, not just a green CLI)
-        if: steps.diff.outputs.changed == 'true'
         run: |
           url="https://forecasting-agent.com/world-cup/groups"
           code=$(curl -sS -o /dev/null -w "%{http_code}" "$url")

--- a/apps/web/lib/world-cup/generated/performance.generated.json
+++ b/apps/web/lib/world-cup/generated/performance.generated.json
@@ -1,17 +1,54 @@
 {
- "generatedAt": "2026-06-20T16:42:28.189Z",
+ "generatedAt": "2026-06-29T01:55:31.346Z",
  "agg": {
-  "settled": 32,
-  "bestPickHit": 18,
-  "bestPickPct": 56,
-  "roiPct": 19,
-  "bets": 55,
-  "wins": 21,
-  "skips": 41,
-  "bssPct": -11.1,
-  "ecePct": 10.5
+  "settled": 72,
+  "bestPickHit": 46,
+  "bestPickPct": 64,
+  "roiPct": -10.7,
+  "bets": 132,
+  "wins": 49,
+  "skips": 84,
+  "bssPct": -7.7,
+  "ecePct": 6.7
  },
  "matches": [
+  {
+   "slug": "fifwc-alg-aut-2026-06-27",
+   "homeEn": "Algeria",
+   "awayEn": "Austria",
+   "score": "3-3",
+   "winner": "draw",
+   "our": [
+    0.33,
+    0.26,
+    0.41
+   ],
+   "mkt": [
+    0.25,
+    0.31,
+    0.44
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "no",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "no",
+     "retPct": 80.2,
+     "win": true
+    }
+   ]
+  },
   {
    "slug": "fifwc-arg-alg-2026-06-16",
    "homeEn": "Argentina",
@@ -34,6 +71,43 @@
      "side": "skip",
      "retPct": null,
      "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-arg-aut-2026-06-22",
+   "homeEn": "Argentina",
+   "awayEn": "Austria",
+   "score": "2-0",
+   "winner": "a",
+   "our": [
+    0.65,
+    0.22,
+    0.14
+   ],
+   "mkt": [
+    0.6,
+    0.23,
+    0.16
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "yes",
+     "retPct": 65.3,
+     "win": true
     },
     {
      "leg": "draw",
@@ -156,6 +230,80 @@
      "leg": "b",
      "side": "skip",
      "retPct": null,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-bel-irn-2026-06-21",
+   "homeEn": "Belgium",
+   "awayEn": "IR Iran",
+   "score": "0-0",
+   "winner": "draw",
+   "our": [
+    0.52,
+    0.24,
+    0.24
+   ],
+   "mkt": [
+    0.7,
+    0.19,
+    0.1
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "no",
+     "retPct": 239,
+     "win": true
+    },
+    {
+     "leg": "draw",
+     "side": "yes",
+     "retPct": 412.8,
+     "win": true
+    },
+    {
+     "leg": "b",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-bih-qat-2026-06-24",
+   "homeEn": "Bosnia-Herzegovina",
+   "awayEn": "Qatar",
+   "score": "3-1",
+   "winner": "a",
+   "our": [
+    0.54,
+    0.25,
+    0.22
+   ],
+   "mkt": [
+    0.59,
+    0.25,
+    0.16
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "no",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "yes",
+     "retPct": -100,
      "win": false
     }
    ]
@@ -309,6 +457,43 @@
    ]
   },
   {
+   "slug": "fifwc-cdr-uzb-2026-06-27",
+   "homeEn": "DR Congo",
+   "awayEn": "Uzbekistan",
+   "score": "3-1",
+   "winner": "a",
+   "our": [
+    0.31,
+    0.26,
+    0.43
+   ],
+   "mkt": [
+    0.4,
+    0.28,
+    0.32
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "no",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
+    }
+   ]
+  },
+  {
    "slug": "fifwc-che-bih-2026-06-18",
    "homeEn": "Switzerland",
    "awayEn": "Bosnia-Herzegovina",
@@ -342,6 +527,43 @@
      "side": "no",
      "retPct": 19.8,
      "win": true
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-che-can-2026-06-24",
+   "homeEn": "Switzerland",
+   "awayEn": "Canada",
+   "score": "2-1",
+   "winner": "a",
+   "our": [
+    0.4,
+    0.26,
+    0.33
+   ],
+   "mkt": [
+    0.44,
+    0.28,
+    0.27
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "no",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
     }
    ]
   },
@@ -383,6 +605,154 @@
    ]
   },
   {
+   "slug": "fifwc-col-cdr-2026-06-23",
+   "homeEn": "Colombia",
+   "awayEn": "DR Congo",
+   "score": "1-0",
+   "winner": "a",
+   "our": [
+    0.72,
+    0.18,
+    0.1
+   ],
+   "mkt": [
+    0.66,
+    0.21,
+    0.12
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "yes",
+     "retPct": 50.4,
+     "win": true
+    },
+    {
+     "leg": "draw",
+     "side": "no",
+     "retPct": 27.4,
+     "win": true
+    },
+    {
+     "leg": "b",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-col-prt-2026-06-27",
+   "homeEn": "Colombia",
+   "awayEn": "Portugal",
+   "score": "0-0",
+   "winner": "draw",
+   "our": [
+    0.36,
+    0.27,
+    0.37
+   ],
+   "mkt": [
+    0.27,
+    0.28,
+    0.45
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "no",
+     "retPct": 83.5,
+     "win": true
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-cvi-ksa-2026-06-26",
+   "homeEn": "Cabo Verde",
+   "awayEn": "Saudi Arabia",
+   "score": "0-0",
+   "winner": "draw",
+   "our": [
+    0.36,
+    0.26,
+    0.38
+   ],
+   "mkt": [
+    0.37,
+    0.28,
+    0.35
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-cze-mex-2026-06-24",
+   "homeEn": "Czechia",
+   "awayEn": "Mexico",
+   "score": "0-3",
+   "winner": "b",
+   "our": [
+    0.14,
+    0.22,
+    0.64
+   ],
+   "mkt": [
+    0.2,
+    0.26,
+    0.54
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "no",
+     "retPct": 25.8,
+     "win": true
+    },
+    {
+     "leg": "draw",
+     "side": "no",
+     "retPct": 36.1,
+     "win": true
+    },
+    {
+     "leg": "b",
+     "side": "yes",
+     "retPct": 83.5,
+     "win": true
+    }
+   ]
+  },
+  {
    "slug": "fifwc-cze-rsa-2026-06-18",
    "homeEn": "Czechia",
    "awayEn": "South Africa",
@@ -415,6 +785,154 @@
      "leg": "b",
      "side": "no",
      "retPct": 29,
+     "win": true
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-ecu-ger-2026-06-25",
+   "homeEn": "Ecuador",
+   "awayEn": "Germany",
+   "score": "2-1",
+   "winner": "a",
+   "our": [
+    0.39,
+    0.27,
+    0.34
+   ],
+   "mkt": [
+    0.2,
+    0.25,
+    0.55
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "yes",
+     "retPct": 387.8,
+     "win": true
+    },
+    {
+     "leg": "draw",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "no",
+     "retPct": 129.9,
+     "win": true
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-ecu-kor-2026-06-20",
+   "homeEn": "Ecuador",
+   "awayEn": "Curaçao",
+   "score": "0-0",
+   "winner": "draw",
+   "our": [
+    0.84,
+    0.12,
+    0.04
+   ],
+   "mkt": [
+    0.81,
+    0.13,
+    0.06
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-egy-irn-2026-06-26",
+   "homeEn": "Egypt",
+   "awayEn": "IR Iran",
+   "score": "1-1",
+   "winner": "draw",
+   "our": [
+    0.3,
+    0.27,
+    0.43
+   ],
+   "mkt": [
+    0.43,
+    0.31,
+    0.26
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "no",
+     "retPct": 77,
+     "win": true
+    },
+    {
+     "leg": "draw",
+     "side": "no",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-eng-gha-2026-06-23",
+   "homeEn": "England",
+   "awayEn": "Ghana",
+   "score": "0-0",
+   "winner": "draw",
+   "our": [
+    0.85,
+    0.12,
+    0.04
+   ],
+   "mkt": [
+    0.74,
+    0.17,
+    0.1
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "no",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "no",
+     "retPct": 10.5,
      "win": true
     }
    ]
@@ -494,6 +1012,80 @@
    ]
   },
   {
+   "slug": "fifwc-esp-ksa-2026-06-21",
+   "homeEn": "Spain",
+   "awayEn": "Saudi Arabia",
+   "score": "4-0",
+   "winner": "a",
+   "our": [
+    0.84,
+    0.13,
+    0.03
+   ],
+   "mkt": [
+    0.88,
+    0.09,
+    0.04
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "no",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-fra-irq-2026-06-22",
+   "homeEn": "France",
+   "awayEn": "Iraq",
+   "score": "3-0",
+   "winner": "a",
+   "our": [
+    0.78,
+    0.16,
+    0.07
+   ],
+   "mkt": [
+    0.86,
+    0.1,
+    0.04
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "no",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    }
+   ]
+  },
+  {
    "slug": "fifwc-fra-sen-2026-06-16",
    "homeEn": "France",
    "awayEn": "Senegal",
@@ -526,6 +1118,43 @@
      "leg": "b",
      "side": "yes",
      "retPct": -100,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-ger-civ-2026-06-20",
+   "homeEn": "Germany",
+   "awayEn": "Côte d'Ivoire",
+   "score": "2-1",
+   "winner": "a",
+   "our": [
+    0.64,
+    0.22,
+    0.15
+   ],
+   "mkt": [
+    0.62,
+    0.2,
+    0.17
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "skip",
+     "retPct": null,
      "win": false
     }
    ]
@@ -642,6 +1271,43 @@
    ]
   },
   {
+   "slug": "fifwc-hrv-gha-2026-06-27",
+   "homeEn": "Croatia",
+   "awayEn": "Ghana",
+   "score": "2-1",
+   "winner": "a",
+   "our": [
+    0.75,
+    0.19,
+    0.07
+   ],
+   "mkt": [
+    0.59,
+    0.25,
+    0.15
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "yes",
+     "retPct": 68.1,
+     "win": true
+    },
+    {
+     "leg": "draw",
+     "side": "no",
+     "retPct": 34.2,
+     "win": true
+    },
+    {
+     "leg": "b",
+     "side": "no",
+     "retPct": 18.3,
+     "win": true
+    }
+   ]
+  },
+  {
    "slug": "fifwc-irn-nzl-2026-06-15",
    "homeEn": "IR Iran",
    "awayEn": "New Zealand",
@@ -693,6 +1359,154 @@
     0.05,
     0.13,
     0.81
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "no",
+     "retPct": -100,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-jor-alg-2026-06-22",
+   "homeEn": "Jordan",
+   "awayEn": "Algeria",
+   "score": "1-2",
+   "winner": "b",
+   "our": [
+    0.26,
+    0.25,
+    0.49
+   ],
+   "mkt": [
+    0.14,
+    0.2,
+    0.65
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "no",
+     "retPct": -100,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-jor-arg-2026-06-27",
+   "homeEn": "Jordan",
+   "awayEn": "Argentina",
+   "score": "1-3",
+   "winner": "b",
+   "our": [
+    0.07,
+    0.18,
+    0.75
+   ],
+   "mkt": [
+    0.07,
+    0.11,
+    0.82
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "no",
+     "retPct": -100,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-jpn-swe-2026-06-25",
+   "homeEn": "Japan",
+   "awayEn": "Sweden",
+   "score": "1-1",
+   "winner": "draw",
+   "our": [
+    0.55,
+    0.24,
+    0.21
+   ],
+   "mkt": [
+    0.47,
+    0.27,
+    0.26
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "no",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "no",
+     "retPct": 37,
+     "win": true
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-kor-civ-2026-06-25",
+   "homeEn": "Curaçao",
+   "awayEn": "Côte d'Ivoire",
+   "score": "0-2",
+   "winner": "b",
+   "our": [
+    0.13,
+    0.2,
+    0.67
+   ],
+   "mkt": [
+    0.07,
+    0.14,
+    0.78
    ],
    "legs": [
     {
@@ -785,6 +1599,43 @@
      "leg": "b",
      "side": "skip",
      "retPct": null,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-mar-hai-2026-06-24",
+   "homeEn": "Morocco",
+   "awayEn": "Haiti",
+   "score": "4-2",
+   "winner": "a",
+   "our": [
+    0.63,
+    0.22,
+    0.15
+   ],
+   "mkt": [
+    0.73,
+    0.17,
+    0.09
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "no",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "yes",
+     "retPct": -100,
      "win": false
     }
    ]
@@ -901,6 +1752,302 @@
    ]
   },
   {
+   "slug": "fifwc-nld-swe-2026-06-20",
+   "homeEn": "Netherlands",
+   "awayEn": "Sweden",
+   "score": "5-1",
+   "winner": "a",
+   "our": [
+    0.59,
+    0.24,
+    0.18
+   ],
+   "mkt": [
+    0.59,
+    0.23,
+    0.17
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-nor-fra-2026-06-26",
+   "homeEn": "Norway",
+   "awayEn": "France",
+   "score": "1-4",
+   "winner": "b",
+   "our": [
+    0.24,
+    0.25,
+    0.51
+   ],
+   "mkt": [
+    0.23,
+    0.26,
+    0.51
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-nor-sen-2026-06-22",
+   "homeEn": "Norway",
+   "awayEn": "Senegal",
+   "score": "3-2",
+   "winner": "a",
+   "our": [
+    0.41,
+    0.26,
+    0.33
+   ],
+   "mkt": [
+    0.44,
+    0.27,
+    0.28
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "no",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-nzl-bel-2026-06-26",
+   "homeEn": "New Zealand",
+   "awayEn": "Belgium",
+   "score": "1-5",
+   "winner": "b",
+   "our": [
+    0.12,
+    0.21,
+    0.68
+   ],
+   "mkt": [
+    0.09,
+    0.16,
+    0.76
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "no",
+     "retPct": -100,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-nzl-egy-2026-06-21",
+   "homeEn": "New Zealand",
+   "awayEn": "Egypt",
+   "score": "1-3",
+   "winner": "b",
+   "our": [
+    0.23,
+    0.24,
+    0.54
+   ],
+   "mkt": [
+    0.2,
+    0.25,
+    0.56
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-pan-eng-2026-06-27",
+   "homeEn": "Panama",
+   "awayEn": "England",
+   "score": "0-2",
+   "winner": "b",
+   "our": [
+    0.12,
+    0.22,
+    0.66
+   ],
+   "mkt": [
+    0.09,
+    0.15,
+    0.75
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "no",
+     "retPct": -100,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-pan-hrv-2026-06-23",
+   "homeEn": "Panama",
+   "awayEn": "Croatia",
+   "score": "0-1",
+   "winner": "b",
+   "our": [
+    0.22,
+    0.24,
+    0.55
+   ],
+   "mkt": [
+    0.14,
+    0.24,
+    0.63
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "no",
+     "retPct": -100,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-par-aus-2026-06-25",
+   "homeEn": "Paraguay",
+   "awayEn": "Australia",
+   "score": "0-0",
+   "winner": "draw",
+   "our": [
+    0.41,
+    0.27,
+    0.32
+   ],
+   "mkt": [
+    0.44,
+    0.3,
+    0.26
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "no",
+     "retPct": 83.5,
+     "win": true
+    },
+    {
+     "leg": "draw",
+     "side": "no",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
+    }
+   ]
+  },
+  {
    "slug": "fifwc-prt-cdr-2026-06-17",
    "homeEn": "Portugal",
    "awayEn": "DR Congo",
@@ -933,6 +2080,43 @@
      "leg": "b",
      "side": "skip",
      "retPct": null,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-prt-uzb-2026-06-23",
+   "homeEn": "Portugal",
+   "awayEn": "Uzbekistan",
+   "score": "5-0",
+   "winner": "a",
+   "our": [
+    0.68,
+    0.2,
+    0.13
+   ],
+   "mkt": [
+    0.78,
+    0.14,
+    0.07
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "no",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "yes",
+     "retPct": -100,
      "win": false
     }
    ]
@@ -975,6 +2159,80 @@
    ]
   },
   {
+   "slug": "fifwc-rsa-kr-2026-06-24",
+   "homeEn": "South Africa",
+   "awayEn": "Korea Republic",
+   "score": "1-0",
+   "winner": "a",
+   "our": [
+    0.17,
+    0.23,
+    0.61
+   ],
+   "mkt": [
+    0.22,
+    0.28,
+    0.5
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "no",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "no",
+     "retPct": 38.9,
+     "win": true
+    },
+    {
+     "leg": "b",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-sco-bra-2026-06-24",
+   "homeEn": "Scotland",
+   "awayEn": "Brazil",
+   "score": "0-3",
+   "winner": "b",
+   "our": [
+    0.16,
+    0.23,
+    0.61
+   ],
+   "mkt": [
+    0.14,
+    0.19,
+    0.66
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "yes",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "no",
+     "retPct": -100,
+     "win": false
+    }
+   ]
+  },
+  {
    "slug": "fifwc-sco-mar-2026-06-19",
    "homeEn": "Scotland",
    "awayEn": "Morocco",
@@ -1007,6 +2265,43 @@
      "leg": "b",
      "side": "no",
      "retPct": -100,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-sen-irq-2026-06-26",
+   "homeEn": "Senegal",
+   "awayEn": "Iraq",
+   "score": "5-0",
+   "winner": "a",
+   "our": [
+    0.65,
+    0.22,
+    0.13
+   ],
+   "mkt": [
+    0.69,
+    0.2,
+    0.1
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "no",
+     "retPct": -100,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "skip",
+     "retPct": null,
      "win": false
     }
    ]
@@ -1049,6 +2344,80 @@
    ]
   },
   {
+   "slug": "fifwc-tun-jpn-2026-06-21",
+   "homeEn": "Tunisia",
+   "awayEn": "Japan",
+   "score": "0-4",
+   "winner": "b",
+   "our": [
+    0.12,
+    0.21,
+    0.67
+   ],
+   "mkt": [
+    0.16,
+    0.26,
+    0.57
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "no",
+     "retPct": 19.8,
+     "win": true
+    },
+    {
+     "leg": "draw",
+     "side": "no",
+     "retPct": 36.1,
+     "win": true
+    },
+    {
+     "leg": "b",
+     "side": "yes",
+     "retPct": 73.9,
+     "win": true
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-tun-nld-2026-06-25",
+   "homeEn": "Tunisia",
+   "awayEn": "Netherlands",
+   "score": "1-3",
+   "winner": "b",
+   "our": [
+    0.09,
+    0.18,
+    0.73
+   ],
+   "mkt": [
+    0.13,
+    0.22,
+    0.65
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "no",
+     "retPct": 15.6,
+     "win": true
+    },
+    {
+     "leg": "draw",
+     "side": "no",
+     "retPct": 29,
+     "win": true
+    },
+    {
+     "leg": "b",
+     "side": "yes",
+     "retPct": 50.4,
+     "win": true
+    }
+   ]
+  },
+  {
    "slug": "fifwc-tur-par-2026-06-19",
    "homeEn": "Türkiye",
    "awayEn": "Paraguay",
@@ -1076,6 +2445,117 @@
      "side": "no",
      "retPct": 43.9,
      "win": true
+    },
+    {
+     "leg": "b",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-tur-usa-2026-06-25",
+   "homeEn": "Türkiye",
+   "awayEn": "United States",
+   "score": "3-2",
+   "winner": "a",
+   "our": [
+    0.45,
+    0.26,
+    0.29
+   ],
+   "mkt": [
+    0.37,
+    0.26,
+    0.38
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "yes",
+     "retPct": 166.7,
+     "win": true
+    },
+    {
+     "leg": "draw",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "no",
+     "retPct": 62.6,
+     "win": true
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-ury-cvi-2026-06-21",
+   "homeEn": "Uruguay",
+   "awayEn": "Cabo Verde",
+   "score": "2-2",
+   "winner": "draw",
+   "our": [
+    0.68,
+    0.2,
+    0.12
+   ],
+   "mkt": [
+    0.68,
+    0.21,
+    0.12
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "b",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    }
+   ]
+  },
+  {
+   "slug": "fifwc-ury-esp-2026-06-26",
+   "homeEn": "Uruguay",
+   "awayEn": "Spain",
+   "score": "0-1",
+   "winner": "b",
+   "our": [
+    0.15,
+    0.23,
+    0.62
+   ],
+   "mkt": [
+    0.17,
+    0.24,
+    0.59
+   ],
+   "legs": [
+    {
+     "leg": "a",
+     "side": "skip",
+     "retPct": null,
+     "win": false
+    },
+    {
+     "leg": "draw",
+     "side": "skip",
+     "retPct": null,
+     "win": false
     },
     {
      "leg": "b",
@@ -1201,64 +2681,64 @@
   {
    "lo": 0,
    "hi": 0.1,
-   "n": 6,
-   "predPct": 5,
+   "n": 13,
+   "predPct": 6,
    "obsPct": 0
   },
   {
    "lo": 0.1,
    "hi": 0.2,
-   "n": 24,
-   "predPct": 16,
-   "obsPct": 21
+   "n": 49,
+   "predPct": 15,
+   "obsPct": 16
   },
   {
    "lo": 0.2,
    "hi": 0.3,
-   "n": 29,
+   "n": 68,
    "predPct": 24,
-   "obsPct": 31
+   "obsPct": 25
   },
   {
    "lo": 0.3,
    "hi": 0.4,
-   "n": 7,
+   "n": 19,
    "predPct": 35,
-   "obsPct": 14
+   "obsPct": 16
   },
   {
    "lo": 0.4,
    "hi": 0.5,
-   "n": 5,
-   "predPct": 44,
-   "obsPct": 80
+   "n": 13,
+   "predPct": 43,
+   "obsPct": 62
   },
   {
    "lo": 0.5,
    "hi": 0.6,
-   "n": 9,
-   "predPct": 56,
-   "obsPct": 44
+   "n": 16,
+   "predPct": 55,
+   "obsPct": 56
   },
   {
    "lo": 0.6,
    "hi": 0.7,
-   "n": 8,
-   "predPct": 64,
-   "obsPct": 63
+   "n": 22,
+   "predPct": 65,
+   "obsPct": 77
   },
   {
    "lo": 0.7,
    "hi": 0.8,
-   "n": 5,
-   "predPct": 73,
-   "obsPct": 60
+   "n": 10,
+   "predPct": 74,
+   "obsPct": 80
   },
   {
    "lo": 0.8,
    "hi": 0.9,
-   "n": 3,
-   "predPct": 83,
+   "n": 6,
+   "predPct": 84,
    "obsPct": 33
   }
  ]

--- a/apps/web/lib/world-cup/generated/results.generated.json
+++ b/apps/web/lib/world-cup/generated/results.generated.json
@@ -1,22 +1,22 @@
 {
- "generatedAt": "2026-06-20T09:32:16.127Z",
+ "generatedAt": "2026-06-29T01:55:31.157Z",
  "source": "polymarket-settlement",
  "note": "Market-blind: settled winner + final score only — no prices or implied probabilities.",
  "counts": {
-  "resolved": 32,
-  "pending": 40,
+  "resolved": 72,
+  "pending": 0,
   "total": 72
  },
  "results": {
   "fifwc-alg-aut-2026-06-27": {
    "event_slug": "fifwc-alg-aut-2026-06-27",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "draw",
+   "homeGoals": 3,
+   "awayGoals": 3,
+   "score": "3-3",
+   "settledAt": "2026-06-28T04:27:19Z",
+   "source": "exact_score"
   },
   "fifwc-arg-alg-2026-06-16": {
    "event_slug": "fifwc-arg-alg-2026-06-16",
@@ -30,13 +30,13 @@
   },
   "fifwc-arg-aut-2026-06-22": {
    "event_slug": "fifwc-arg-aut-2026-06-22",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "a",
+   "homeGoals": 2,
+   "awayGoals": 0,
+   "score": "2-0",
+   "settledAt": "2026-06-22T19:30:31Z",
+   "source": "exact_score"
   },
   "fifwc-aus-tur-2026-06-14": {
    "event_slug": "fifwc-aus-tur-2026-06-14",
@@ -70,23 +70,23 @@
   },
   "fifwc-bel-irn-2026-06-21": {
    "event_slug": "fifwc-bel-irn-2026-06-21",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "draw",
+   "homeGoals": 0,
+   "awayGoals": 0,
+   "score": "0-0",
+   "settledAt": "2026-06-21T21:26:34Z",
+   "source": "exact_score"
   },
   "fifwc-bih-qat-2026-06-24": {
    "event_slug": "fifwc-bih-qat-2026-06-24",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "a",
+   "homeGoals": 3,
+   "awayGoals": 1,
+   "score": "3-1",
+   "settledAt": "2026-06-24T21:30:16Z",
+   "source": "exact_score"
   },
   "fifwc-bra-hai-2026-06-19": {
    "event_slug": "fifwc-bra-hai-2026-06-19",
@@ -130,13 +130,13 @@
   },
   "fifwc-cdr-uzb-2026-06-27": {
    "event_slug": "fifwc-cdr-uzb-2026-06-27",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "a",
+   "homeGoals": 3,
+   "awayGoals": 1,
+   "score": "3-1",
+   "settledAt": "2026-06-28T02:00:10Z",
+   "source": "exact_score"
   },
   "fifwc-che-bih-2026-06-18": {
    "event_slug": "fifwc-che-bih-2026-06-18",
@@ -150,13 +150,13 @@
   },
   "fifwc-che-can-2026-06-24": {
    "event_slug": "fifwc-che-can-2026-06-24",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "a",
+   "homeGoals": 2,
+   "awayGoals": 1,
+   "score": "2-1",
+   "settledAt": "2026-06-24T21:19:47Z",
+   "source": "exact_score"
   },
   "fifwc-civ-ecu-2026-06-14": {
    "event_slug": "fifwc-civ-ecu-2026-06-14",
@@ -170,43 +170,43 @@
   },
   "fifwc-col-cdr-2026-06-23": {
    "event_slug": "fifwc-col-cdr-2026-06-23",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "a",
+   "homeGoals": 1,
+   "awayGoals": 0,
+   "score": "1-0",
+   "settledAt": "2026-06-24T04:16:05Z",
+   "source": "exact_score"
   },
   "fifwc-col-prt-2026-06-27": {
    "event_slug": "fifwc-col-prt-2026-06-27",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "draw",
+   "homeGoals": 0,
+   "awayGoals": 0,
+   "score": "0-0",
+   "settledAt": "2026-06-28T01:50:52Z",
+   "source": "exact_score"
   },
   "fifwc-cvi-ksa-2026-06-26": {
    "event_slug": "fifwc-cvi-ksa-2026-06-26",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "draw",
+   "homeGoals": 0,
+   "awayGoals": 0,
+   "score": "0-0",
+   "settledAt": "2026-06-27T02:26:20Z",
+   "source": "exact_score"
   },
   "fifwc-cze-mex-2026-06-24": {
    "event_slug": "fifwc-cze-mex-2026-06-24",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "b",
+   "homeGoals": 0,
+   "awayGoals": 3,
+   "score": "0-3",
+   "settledAt": "2026-06-25T03:15:17Z",
+   "source": "exact_score"
   },
   "fifwc-cze-rsa-2026-06-18": {
    "event_slug": "fifwc-cze-rsa-2026-06-18",
@@ -220,43 +220,43 @@
   },
   "fifwc-ecu-ger-2026-06-25": {
    "event_slug": "fifwc-ecu-ger-2026-06-25",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "a",
+   "homeGoals": 2,
+   "awayGoals": 1,
+   "score": "2-1",
+   "settledAt": "2026-06-25T22:16:04Z",
+   "source": "exact_score"
   },
   "fifwc-ecu-kor-2026-06-20": {
    "event_slug": "fifwc-ecu-kor-2026-06-20",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "draw",
+   "homeGoals": 0,
+   "awayGoals": 0,
+   "score": "0-0",
+   "settledAt": "2026-06-21T02:13:49Z",
+   "source": "exact_score"
   },
   "fifwc-egy-irn-2026-06-26": {
    "event_slug": "fifwc-egy-irn-2026-06-26",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "draw",
+   "homeGoals": 1,
+   "awayGoals": 1,
+   "score": "1-1",
+   "settledAt": "2026-06-27T05:30:19Z",
+   "source": "exact_score"
   },
   "fifwc-eng-gha-2026-06-23": {
    "event_slug": "fifwc-eng-gha-2026-06-23",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "draw",
+   "homeGoals": 0,
+   "awayGoals": 0,
+   "score": "0-0",
+   "settledAt": "2026-06-23T22:21:37Z",
+   "source": "exact_score"
   },
   "fifwc-eng-hrv-2026-06-17": {
    "event_slug": "fifwc-eng-hrv-2026-06-17",
@@ -280,23 +280,23 @@
   },
   "fifwc-esp-ksa-2026-06-21": {
    "event_slug": "fifwc-esp-ksa-2026-06-21",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "a",
+   "homeGoals": 4,
+   "awayGoals": 0,
+   "score": "4-0",
+   "settledAt": "2026-06-21T18:28:14Z",
+   "source": "espn"
   },
   "fifwc-fra-irq-2026-06-22": {
    "event_slug": "fifwc-fra-irq-2026-06-22",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "a",
+   "homeGoals": 3,
+   "awayGoals": 0,
+   "score": "3-0",
+   "settledAt": "2026-06-23T01:14:34Z",
+   "source": "exact_score"
   },
   "fifwc-fra-sen-2026-06-16": {
    "event_slug": "fifwc-fra-sen-2026-06-16",
@@ -310,13 +310,13 @@
   },
   "fifwc-ger-civ-2026-06-20": {
    "event_slug": "fifwc-ger-civ-2026-06-20",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "a",
+   "homeGoals": 2,
+   "awayGoals": 1,
+   "score": "2-1",
+   "settledAt": "2026-06-20T22:29:47Z",
+   "source": "exact_score"
   },
   "fifwc-ger-kor-2026-06-14": {
    "event_slug": "fifwc-ger-kor-2026-06-14",
@@ -350,13 +350,13 @@
   },
   "fifwc-hrv-gha-2026-06-27": {
    "event_slug": "fifwc-hrv-gha-2026-06-27",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "a",
+   "homeGoals": 2,
+   "awayGoals": 1,
+   "score": "2-1",
+   "settledAt": "2026-06-27T23:29:49Z",
+   "source": "exact_score"
   },
   "fifwc-irn-nzl-2026-06-15": {
    "event_slug": "fifwc-irn-nzl-2026-06-15",
@@ -380,43 +380,43 @@
   },
   "fifwc-jor-alg-2026-06-22": {
    "event_slug": "fifwc-jor-alg-2026-06-22",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "b",
+   "homeGoals": 1,
+   "awayGoals": 2,
+   "score": "1-2",
+   "settledAt": "2026-06-23T05:18:16Z",
+   "source": "exact_score"
   },
   "fifwc-jor-arg-2026-06-27": {
    "event_slug": "fifwc-jor-arg-2026-06-27",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "b",
+   "homeGoals": 1,
+   "awayGoals": 3,
+   "score": "1-3",
+   "settledAt": "2026-06-28T04:14:20Z",
+   "source": "exact_score"
   },
   "fifwc-jpn-swe-2026-06-25": {
    "event_slug": "fifwc-jpn-swe-2026-06-25",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "draw",
+   "homeGoals": 1,
+   "awayGoals": 1,
+   "score": "1-1",
+   "settledAt": "2026-06-26T01:16:32Z",
+   "source": "exact_score"
   },
   "fifwc-kor-civ-2026-06-25": {
    "event_slug": "fifwc-kor-civ-2026-06-25",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "b",
+   "homeGoals": 0,
+   "awayGoals": 2,
+   "score": "0-2",
+   "settledAt": "2026-06-25T22:18:53Z",
+   "source": "exact_score"
   },
   "fifwc-kr-cze-2026-06-11": {
    "event_slug": "fifwc-kr-cze-2026-06-11",
@@ -440,13 +440,13 @@
   },
   "fifwc-mar-hai-2026-06-24": {
    "event_slug": "fifwc-mar-hai-2026-06-24",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "a",
+   "homeGoals": 4,
+   "awayGoals": 2,
+   "score": "4-2",
+   "settledAt": "2026-06-25T00:19:16Z",
+   "source": "espn"
   },
   "fifwc-mex-kr-2026-06-18": {
    "event_slug": "fifwc-mex-kr-2026-06-18",
@@ -480,83 +480,83 @@
   },
   "fifwc-nld-swe-2026-06-20": {
    "event_slug": "fifwc-nld-swe-2026-06-20",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "a",
+   "homeGoals": 5,
+   "awayGoals": 1,
+   "score": "5-1",
+   "settledAt": "2026-06-20T19:16:05Z",
+   "source": "espn"
   },
   "fifwc-nor-fra-2026-06-26": {
    "event_slug": "fifwc-nor-fra-2026-06-26",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "b",
+   "homeGoals": 1,
+   "awayGoals": 4,
+   "score": "1-4",
+   "settledAt": "2026-06-26T21:19:25Z",
+   "source": "espn"
   },
   "fifwc-nor-sen-2026-06-22": {
    "event_slug": "fifwc-nor-sen-2026-06-22",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "a",
+   "homeGoals": 3,
+   "awayGoals": 2,
+   "score": "3-2",
+   "settledAt": "2026-06-23T02:19:46Z",
+   "source": "exact_score"
   },
   "fifwc-nzl-bel-2026-06-26": {
    "event_slug": "fifwc-nzl-bel-2026-06-26",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "b",
+   "homeGoals": 1,
+   "awayGoals": 5,
+   "score": "1-5",
+   "settledAt": "2026-06-27T05:25:49Z",
+   "source": "espn"
   },
   "fifwc-nzl-egy-2026-06-21": {
    "event_slug": "fifwc-nzl-egy-2026-06-21",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "b",
+   "homeGoals": 1,
+   "awayGoals": 3,
+   "score": "1-3",
+   "settledAt": "2026-06-22T03:18:16Z",
+   "source": "exact_score"
   },
   "fifwc-pan-eng-2026-06-27": {
    "event_slug": "fifwc-pan-eng-2026-06-27",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "b",
+   "homeGoals": 0,
+   "awayGoals": 2,
+   "score": "0-2",
+   "settledAt": "2026-06-27T23:26:20Z",
+   "source": "exact_score"
   },
   "fifwc-pan-hrv-2026-06-23": {
    "event_slug": "fifwc-pan-hrv-2026-06-23",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "b",
+   "homeGoals": 0,
+   "awayGoals": 1,
+   "score": "0-1",
+   "settledAt": "2026-06-24T01:08:37Z",
+   "source": "exact_score"
   },
   "fifwc-par-aus-2026-06-25": {
    "event_slug": "fifwc-par-aus-2026-06-25",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "draw",
+   "homeGoals": 0,
+   "awayGoals": 0,
+   "score": "0-0",
+   "settledAt": "2026-06-26T04:14:52Z",
+   "source": "exact_score"
   },
   "fifwc-prt-cdr-2026-06-17": {
    "event_slug": "fifwc-prt-cdr-2026-06-17",
@@ -570,13 +570,13 @@
   },
   "fifwc-prt-uzb-2026-06-23": {
    "event_slug": "fifwc-prt-uzb-2026-06-23",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "a",
+   "homeGoals": 5,
+   "awayGoals": 0,
+   "score": "5-0",
+   "settledAt": "2026-06-23T19:14:17Z",
+   "source": "espn"
   },
   "fifwc-qat-che-2026-06-13": {
    "event_slug": "fifwc-qat-che-2026-06-13",
@@ -590,23 +590,23 @@
   },
   "fifwc-rsa-kr-2026-06-24": {
    "event_slug": "fifwc-rsa-kr-2026-06-24",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "a",
+   "homeGoals": 1,
+   "awayGoals": 0,
+   "score": "1-0",
+   "settledAt": "2026-06-25T03:15:17Z",
+   "source": "exact_score"
   },
   "fifwc-sco-bra-2026-06-24": {
    "event_slug": "fifwc-sco-bra-2026-06-24",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "b",
+   "homeGoals": 0,
+   "awayGoals": 3,
+   "score": "0-3",
+   "settledAt": "2026-06-25T00:30:16Z",
+   "source": "exact_score"
   },
   "fifwc-sco-mar-2026-06-19": {
    "event_slug": "fifwc-sco-mar-2026-06-19",
@@ -620,13 +620,13 @@
   },
   "fifwc-sen-irq-2026-06-26": {
    "event_slug": "fifwc-sen-irq-2026-06-26",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "a",
+   "homeGoals": 5,
+   "awayGoals": 0,
+   "score": "5-0",
+   "settledAt": "2026-06-26T21:37:49Z",
+   "source": "espn"
   },
   "fifwc-swe-tun-2026-06-14": {
    "event_slug": "fifwc-swe-tun-2026-06-14",
@@ -640,23 +640,23 @@
   },
   "fifwc-tun-jpn-2026-06-21": {
    "event_slug": "fifwc-tun-jpn-2026-06-21",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "b",
+   "homeGoals": 0,
+   "awayGoals": 4,
+   "score": "0-4",
+   "settledAt": "2026-06-21T06:15:40Z",
+   "source": "espn"
   },
   "fifwc-tun-nld-2026-06-25": {
    "event_slug": "fifwc-tun-nld-2026-06-25",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "b",
+   "homeGoals": 1,
+   "awayGoals": 3,
+   "score": "1-3",
+   "settledAt": "2026-06-26T01:13:08Z",
+   "source": "exact_score"
   },
   "fifwc-tur-par-2026-06-19": {
    "event_slug": "fifwc-tur-par-2026-06-19",
@@ -670,33 +670,33 @@
   },
   "fifwc-tur-usa-2026-06-25": {
    "event_slug": "fifwc-tur-usa-2026-06-25",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "a",
+   "homeGoals": 3,
+   "awayGoals": 2,
+   "score": "3-2",
+   "settledAt": "2026-06-26T04:22:38Z",
+   "source": "exact_score"
   },
   "fifwc-ury-cvi-2026-06-21": {
    "event_slug": "fifwc-ury-cvi-2026-06-21",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "draw",
+   "homeGoals": 2,
+   "awayGoals": 2,
+   "score": "2-2",
+   "settledAt": "2026-06-22T00:30:32Z",
+   "source": "exact_score"
   },
   "fifwc-ury-esp-2026-06-26": {
    "event_slug": "fifwc-ury-esp-2026-06-26",
-   "status": "pending",
-   "winner": null,
-   "homeGoals": null,
-   "awayGoals": null,
-   "score": null,
-   "settledAt": null,
-   "source": null
+   "status": "resolved",
+   "winner": "b",
+   "homeGoals": 0,
+   "awayGoals": 1,
+   "score": "0-1",
+   "settledAt": "2026-06-27T02:20:10Z",
+   "source": "exact_score"
   },
   "fifwc-usa-aus-2026-06-19": {
    "event_slug": "fifwc-usa-aus-2026-06-19",


### PR DESCRIPTION
小组赛 72 场全部结束,把最终结果固定进仓库,并取消定时刷新。

## 改了什么
1. **固定最终数据**:`results.generated.json` + `performance.generated.json` 提交为最终 72 场(此前 committed 一直停在 32 场,靠 CI 构建时重抓——现在落盘为权威终值:准确率 46/72、收益率 −10.7%、BSS −7.7%、Calibration 6.7%)。
2. **取消定时任务**:删 `wc-results.yml` 的 `schedule`(两个 cron),仅留 `workflow_dispatch`。
3. **顺带**:既然只手动触发,去掉"比分变化才部署"的闸门 → 手动跑必部署,`gh workflow run wc-results.yml --ref main` 仍是一键重新发布 forecasting-agent.com 的按钮。

## 验收
- 数据经独立核验:ESPN 自动对 63/72(0 不符)+ 9 个 agent web 核验 9/9,**全 72 场零偏差**
- `pnpm --filter @autopoly/web build` 绿
- workflow YAML 合法,触发器仅剩 workflow_dispatch,无遗留 if 闸门
- 线上 forecasting-agent.com 当前已是最终 72 场数据(本次为落盘固化,不改变线上)