### PR TITLE
feat(wc): always-visible methodology link on knockout list

### DIFF
--- a/apps/web/components/world-cup/fifa8-model-guide.tsx
+++ b/apps/web/components/world-cup/fifa8-model-guide.tsx
@@ -47,18 +47,25 @@ export function Fifa8ModelGuide({
 
   return (
     <div className={styles.kgWrap}>
-      <button
-        type="button"
-        className={styles.kgTrigger}
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-        aria-controls={panelId}
-      >
-        <span className={styles.kgTriggerIcon} aria-hidden>
-          ⓘ
-        </span>
-        {open ? t(locale, "kgHide") : t(locale, "kgTrigger")}
-      </button>
+      <div className={styles.kgBar}>
+        <button
+          type="button"
+          className={styles.kgTrigger}
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          aria-controls={panelId}
+        >
+          <span className={styles.kgTriggerIcon} aria-hidden>
+            ⓘ
+          </span>
+          {open ? t(locale, "kgHide") : t(locale, "kgTrigger")}
+        </button>
+        {/* Always-visible deep link — the full illustrated methodology page,
+            so it is reachable in one click without opening the quick guide. */}
+        <a className={styles.kgMethodLink} href={withLocale("/world-cup/knockout/how-it-works", locale)}>
+          {t(locale, "kgFullMethod")}
+        </a>
+      </div>
 
       {open ? (
         <div id={panelId} className={styles.kgPanel}>
@@ -78,9 +85,6 @@ export function Fifa8ModelGuide({
             })}
           </ul>
           <p className={styles.kgFooter}>{t(locale, "kgFooter")}</p>
-          <a className={styles.kgMethodLink} href={withLocale("/world-cup/knockout/how-it-works", locale)}>
-            {t(locale, "kgFullMethod")}
-          </a>
         </div>
       ) : null}
     </div>

--- a/apps/web/components/world-cup/world-cup.module.css
+++ b/apps/web/components/world-cup/world-cup.module.css
@@ -2786,6 +2786,14 @@
   margin: 0 0 22px;
 }
 
+/* Row holding the quick-guide toggle + the always-visible methodology deep link. */
+.kgBar {
+  display: flex;
+  align-items: center;
+  gap: 8px 16px;
+  flex-wrap: wrap;
+}
+
 .kgTrigger {
   display: inline-flex;
   align-items: center;
@@ -2886,7 +2894,7 @@
 
 .kgMethodLink {
   display: inline-block;
-  margin: 12px 0 0;
+  margin: 0;
   font-size: 13px;
   font-weight: 700;
   color: #1d4ed8;

--- a/docs/internal/wc-copy-polish-log.md
+++ b/docs/internal/wc-copy-polish-log.md
@@ -21,3 +21,10 @@ Goal: maximum information density + zero confusion for a first-time visitor.
   1. The methodology page is only reachable via the ⓘ tooltip (which a visitor may never open). Consider a subtle always-visible "怎么预测的? →" link from the knockout-list intro straight to `/how-it-works`.
   2. The 9-model comparison table on mobile — density vs readability (still pending from iter 1).
   3. Detail-page evidence-card sentences — tighten any wordy ones.
+
+## 2026-06-30 ~13:25 HKT — iteration 3
+- **Shipped (PR #52):** de-leaked the knockout **detail page** for zh. The per-model rationale prose (headline + method note) is generated English-only, and 7 of the 8 displayed top-driver labels were unmapped — so a zh visitor saw "United States are a slight favourite…" and "Attack vs defence". Fix: render the English rationale prose only on `en` (zh already has the localized group header + driver line carrying the verdict + reason), and map every displayed top-driver label to an i18n key (攻防对比 / 机会创造状态 / 体能负荷 / 整体质量 / 突破防线 / 传球结构 / 模型一致度). Verified live: zh fully localized, en unchanged.
+- **Next direction (iteration 4):**
+  1. **Bilingual per-model rationale (bigger, engine-level):** the rich per-model reasoning sentence is hidden on zh (only the driver line remains). To give zh the same density as en, the engine would need to emit Chinese headline/methodNote and the archive be regenerated — flag for the user (touches the forecasting pipeline, market-blind regen).
+  2. Still pending: an always-visible "怎么预测的? →" link from the knockout-list intro to /how-it-works (currently only via the ⓘ tooltip).
+  3. The 9-model comparison table on the LIST card — mobile density (still unexamined).


### PR DESCRIPTION
The how-it-works methodology page (which explains the per-model names shown on every card) was buried two clicks deep — open the ⓘ guide, then click a link inside. Surface that link as an always-visible sibling of the ⓘ trigger so it's one click from the list intro. Reuses the existing kgFullMethod key (no new i18n); desktop + mobile verified, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)