### PR TITLE
feat(raven): zh/en locale toggle + Chinese engine output (opt-in)

### DIFF
--- a/apps/raven/app/api/forecasts/route.ts
+++ b/apps/raven/app/api/forecasts/route.ts
@@ -19,7 +19,8 @@ const CreateSchema = z.object({
   question: z.string().trim().min(8, "question too short").max(400, "question too long"),
   maxRounds: z.number().int().min(1).max(6).optional(),
   fresh: z.boolean().optional(),
-  provider: z.enum(["claude", "deepseek"]).optional()
+  provider: z.enum(["claude", "deepseek"]).optional(),
+  language: z.enum(["en", "zh"]).optional()
 });
 
 export async function POST(req: Request) {
@@ -42,7 +43,8 @@ export async function POST(req: Request) {
     const job = startForecast(parsed.data.question, {
       maxRounds: parsed.data.maxRounds,
       fresh: parsed.data.fresh,
-      provider
+      provider,
+      language: parsed.data.language
     });
     return NextResponse.json({ eventId: job.eventId, status: job.status, provider: job.provider });
   } catch (error) {

--- a/apps/raven/app/forecast/[id]/decorate.ts
+++ b/apps/raven/app/forecast/[id]/decorate.ts
@@ -2,16 +2,19 @@
 // (01…NN in reading order across iterations), arrows/labels and anchor hrefs.
 // Semantics ported verbatim from the design handoff's Report renderVals().
 
+import type { Entry } from "../../../lib/i18n";
+import { SIDE_LABEL_TEMPLATES } from "../../../lib/i18n/verdict";
 import { arrowFor, cap, diamondsFor, dirFor } from "../../../lib/vm/format";
 import type { DossierVM, EvidenceVM, IterationVM, NetDir, Side } from "../../../lib/vm/types";
 
 // "Support" is relative to the forecast's lean: on a NO-leaning run (the demo)
-// supporting evidence pushes NO; on a YES-leaning run it pushes YES.
-export function sideLabelFor(side: Side, leanYes: boolean): string {
-  if (side === "neutral") return "No directional weight";
-  const lean = leanYes ? "YES" : "NO";
-  const against = leanYes ? "NO" : "YES";
-  return side === "support" ? `Supports the forecast (pushes ${lean})` : `Cuts against the forecast (pushes ${against})`;
+// supporting evidence pushes NO; on a YES-leaning run it pushes YES. Returns a
+// locale Entry (both languages baked) so components render it with t().
+export function sideLabelFor(side: Side, leanYes: boolean): Entry {
+  if (side === "neutral") return SIDE_LABEL_TEMPLATES.neutral;
+  const dir = side === "support" ? (leanYes ? "YES" : "NO") : leanYes ? "NO" : "YES";
+  const tpl = SIDE_LABEL_TEMPLATES[side];
+  return { en: tpl.en.replaceAll("{dir}", dir), zh: tpl.zh.replaceAll("{dir}", dir) };
 }
 
 export interface DecoratedEvidence extends EvidenceVM {
@@ -20,9 +23,9 @@ export interface DecoratedEvidence extends EvidenceVM {
   dir: NetDir;
   deltaAbs: string; // "12%"
   valDiamonds: string;
-  valueLabel: string;
-  credLabel: string;
-  sideLabel: string;
+  valueLabel: string; // "High" | "Med" | "Low" — localized via tierWord()
+  credLabel: string; // "High" | "Med" | "Low" — localized via tierWord()
+  sideLabel: Entry; // rendered with t() at the component layer
   href: string; // "#ev-01"
 }
 
@@ -31,7 +34,7 @@ export interface DecoratedIteration extends Omit<IterationVM, "evidence"> {
 }
 
 export interface DecoratedCore extends DecoratedEvidence {
-  rank: string;
+  rank: string; // English rank key — localized via rankEntry() + t() in the view
 }
 
 export interface DecoratedDossier {

--- a/apps/raven/app/forecast/[id]/evidence-book.tsx
+++ b/apps/raven/app/forecast/[id]/evidence-book.tsx
@@ -1,17 +1,23 @@
+"use client";
+
 // "The evidence, in order" book — per-iteration headers, globally numbered
 // evidence rows (#ev-NN anchors) and the CSS-only hover preview popover.
 // Layout and copy verbatim from the design handoff ("Raven Report.dc.html").
 
 import { ArrowIcon, ShieldIcon, SrcIcon } from "../../../components/icons";
+import { sourcesLabel, useLocale, useT } from "../../../lib/i18n";
+import { SRC_TYPE_LABELS, V } from "../../../lib/i18n/verdict";
 import type { DossierMeta } from "../../../lib/vm/types";
 import { netArrowFor, type DecoratedEvidence, type DecoratedIteration } from "./decorate";
 import { CredPill, DomChip, ValuePill } from "./pills";
 
 export function EvidenceBook({ iterations, meta }: { iterations: DecoratedIteration[]; meta: DossierMeta }) {
+  const t = useT();
+  const { locale } = useLocale();
   const legend = [
-    { n: meta.nSupport, label: "supporting", color: "var(--pos)" },
-    { n: meta.nCounter, label: "counter", color: "var(--neg)" },
-    { n: meta.nNeutral, label: "neutral", color: "var(--faint)" }
+    { n: meta.nSupport, label: V.legendSupporting, color: "var(--pos)" },
+    { n: meta.nCounter, label: V.legendCounter, color: "var(--neg)" },
+    { n: meta.nNeutral, label: V.legendNeutral, color: "var(--faint)" }
   ];
   return (
     <div className="rp-book" style={{ borderTop: "1px solid var(--line)", background: "var(--bg2)" }}>
@@ -34,16 +40,16 @@ export function EvidenceBook({ iterations, meta }: { iterations: DecoratedIterat
             color: "var(--faint)"
           }}
         >
-          The evidence, in order — {meta.sources} sources
+          {t(V.evidenceInOrder, { src: sourcesLabel(meta.sources, locale) })}
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 14, fontFamily: "var(--fm)", fontSize: 10.5 }}>
           {legend.map((l) => (
             <span
-              key={l.label}
+              key={l.label.en}
               style={{ display: "inline-flex", alignItems: "center", gap: 5, color: "var(--muted)" }}
             >
               <span style={{ width: 9, height: 3, borderRadius: 2, background: l.color }} />
-              {l.n} {l.label}
+              {l.n} {t(l.label)}
             </span>
           ))}
         </div>
@@ -69,7 +75,7 @@ export function EvidenceBook({ iterations, meta }: { iterations: DecoratedIterat
                 color: "var(--faint)"
               }}
             >
-              Iteration
+              {t(V.iteration)}
             </span>
             <span style={{ fontFamily: "var(--fd)", fontWeight: 600, fontSize: 20, color: "var(--accent)" }}>
               {it.n}
@@ -97,6 +103,7 @@ export function EvidenceBook({ iterations, meta }: { iterations: DecoratedIterat
 }
 
 function EvidenceRow({ e }: { e: DecoratedEvidence }) {
+  const t = useT();
   return (
     <div
       className="ev"
@@ -113,7 +120,7 @@ function EvidenceRow({ e }: { e: DecoratedEvidence }) {
         <span
           className={`sd-${e.side}`}
           style={{ width: 3, alignSelf: "stretch", borderRadius: 2, opacity: 0.85 }}
-          title={e.sideLabel}
+          title={t(e.sideLabel)}
         />
         <span
           style={{
@@ -147,7 +154,7 @@ function EvidenceRow({ e }: { e: DecoratedEvidence }) {
                 padding: "1px 5px"
               }}
             >
-              ↻ Revises a prior source
+              {t(V.revisesPrior)}
             </span>
           ) : null}
         </div>
@@ -168,7 +175,7 @@ function EvidenceRow({ e }: { e: DecoratedEvidence }) {
               }}
             >
               <SrcIcon type="official" className="ic10" />
-              Verified
+              {t(V.verified)}
             </span>
           ) : (
             <span
@@ -185,7 +192,7 @@ function EvidenceRow({ e }: { e: DecoratedEvidence }) {
               }}
             >
               <ShieldIcon />
-              Unverified
+              {t(V.unverified)}
             </span>
           )}
           <span style={{ width: 1, height: 11, background: "var(--line2)" }} />
@@ -212,6 +219,7 @@ function EvidenceRow({ e }: { e: DecoratedEvidence }) {
 }
 
 function EvidencePopover({ e }: { e: DecoratedEvidence }) {
+  const t = useT();
   const openStyle = {
     textDecoration: "none",
     display: "inline-flex",
@@ -248,7 +256,7 @@ function EvidencePopover({ e }: { e: DecoratedEvidence }) {
             color: "var(--accent)"
           }}
         >
-          Preview
+          {t(V.preview)}
         </span>
         <CredPill e={e} variant="pop" />
       </div>
@@ -289,15 +297,15 @@ function EvidencePopover({ e }: { e: DecoratedEvidence }) {
           }}
         >
           <SrcIcon type={e.srcType} />
-          {e.srcLabel}
+          {t(SRC_TYPE_LABELS[e.srcType])}
         </span>
         {e.url ? (
           <a href={e.url} target="_blank" rel="noopener noreferrer" style={openStyle}>
-            Open {e.dom} <ArrowIcon style={{ width: 10, height: 10 }} />
+            {t(V.openSource, { dom: e.dom })} <ArrowIcon style={{ width: 10, height: 10 }} />
           </a>
         ) : (
           <span style={openStyle}>
-            Open {e.dom} <ArrowIcon style={{ width: 10, height: 10 }} />
+            {t(V.openSource, { dom: e.dom })} <ArrowIcon style={{ width: 10, height: 10 }} />
           </span>
         )}
       </div>

--- a/apps/raven/app/forecast/[id]/page.tsx
+++ b/apps/raven/app/forecast/[id]/page.tsx
@@ -12,6 +12,8 @@ import type { CSSProperties, ReactNode } from "react";
 import { RvShell } from "../../../components/chrome/rv-shell";
 import { ArrowIcon, IconDefs } from "../../../components/icons";
 import { useForecast } from "../../../lib/client/use-forecast";
+import { confidenceLabel, sourcesLabel, useLocale, useT, verdictLabel } from "../../../lib/i18n";
+import { rankEntry, STATUS_LABELS, V } from "../../../lib/i18n/verdict";
 import { cap, credWord } from "../../../lib/vm/format";
 import type { DossierVM } from "../../../lib/vm/types";
 import { decorateDossier, percentOf, roundUpTen } from "./decorate";
@@ -61,6 +63,7 @@ function CenterNote({ children }: { children: ReactNode }) {
 }
 
 function NotFound() {
+  const t = useT();
   return (
     <CenterNote>
       <div
@@ -72,10 +75,10 @@ function NotFound() {
           color: "var(--muted)"
         }}
       >
-        Forecast not found
+        {t(V.notFound)}
       </div>
       <Link href="/" style={{ fontFamily: "var(--fm)", fontSize: 11, color: "var(--accent)", textDecoration: "none" }}>
-        ← Back to 01 · Ask
+        {t(V.backToAsk)}
       </Link>
     </CenterNote>
   );
@@ -85,6 +88,7 @@ export default function ReportPage() {
   const params = useParams<{ id: string }>();
   const id = params?.id ?? "";
   const { data, error } = useForecast(id);
+  const t = useT();
 
   if (!data) {
     const notFound = error === "not found" || error === "invalid id";
@@ -95,10 +99,12 @@ export default function ReportPage() {
         ) : (
           <CenterNote>
             <div style={{ fontFamily: "var(--fm)", fontSize: 11, letterSpacing: ".08em", color: "var(--muted)" }}>
-              Loading dossier…
+              {t(V.loadingDossier)}
             </div>
             {error ? (
-              <div style={{ fontFamily: "var(--fm)", fontSize: 10, color: "var(--faint)" }}>{error} — retrying</div>
+              <div style={{ fontFamily: "var(--fm)", fontSize: 10, color: "var(--faint)" }}>
+                {t(V.retrying, { err: error })}
+              </div>
             ) : null}
           </CenterNote>
         )}
@@ -134,9 +140,9 @@ export default function ReportPage() {
                 }}
               />
               <span>
-                This forecast is still running —{" "}
+                {t(V.stillRunning)}{" "}
                 <Link href={`/forecast/${id}/research`} style={{ color: "var(--accent)" }}>
-                  watch it live
+                  {t(V.watchLive)}
                 </Link>
               </span>
             </div>
@@ -155,6 +161,8 @@ export default function ReportPage() {
 }
 
 function Report({ id, dossier }: { id: string; dossier: DossierVM }) {
+  const t = useT();
+  const { locale } = useLocale();
   const meta = dossier.meta;
   const { iterations, byIdx, core, counter } = decorateDossier(dossier);
 
@@ -184,7 +192,8 @@ function Report({ id, dossier }: { id: string; dossier: DossierVM }) {
           className="rv-hdr-meta"
           style={{ fontFamily: "var(--fm)", fontSize: 10, letterSpacing: ".05em", color: "var(--muted)" }}
         >
-          {dossier.status.toUpperCase()} · {meta.duration} · {meta.sources} SOURCES
+          {t(STATUS_LABELS[dossier.status]).toUpperCase()} · {meta.duration} ·{" "}
+          {sourcesLabel(meta.sources, locale).toUpperCase()}
         </span>
       }
     >
@@ -220,9 +229,9 @@ function Report({ id, dossier }: { id: string; dossier: DossierVM }) {
                 }}
               />
               <span>
-                This forecast is still running —{" "}
+                {t(V.stillRunning)}{" "}
                 <Link href={`/forecast/${id}/research`} className="lnk" style={{ color: "var(--accent)" }}>
-                  watch it live
+                  {t(V.watchLive)}
                 </Link>
               </span>
             </div>
@@ -241,7 +250,7 @@ function Report({ id, dossier }: { id: string; dossier: DossierVM }) {
                 color: "var(--neg)"
               }}
             >
-              This run aborted — the dossier below is partial.
+              {t(V.runAborted)}
             </div>
           ) : null}
 
@@ -269,7 +278,7 @@ function Report({ id, dossier }: { id: string; dossier: DossierVM }) {
                 </div>
                 <div style={{ paddingBottom: 9 }}>
                   <div style={{ fontFamily: "var(--fd)", fontStyle: "italic", fontWeight: 500, fontSize: 27, lineHeight: 1 }}>
-                    {meta.verdict}
+                    {verdictLabel(meta.verdict, locale)}
                   </div>
                   {meta.quip ? (
                     <div style={{ fontSize: 14, lineHeight: 1.4, color: "var(--muted)", marginTop: 7, maxWidth: "22ch" }}>
@@ -357,7 +366,9 @@ function Report({ id, dossier }: { id: string; dossier: DossierVM }) {
                       back a real coverage claim. */}
                   <span />
                   <span style={{ color: "var(--faint)" }}>
-                    started as a <span style={{ color: "var(--muted)" }}>{meta.prior}</span> prior
+                    {t(V.priorNotePre)}
+                    <span style={{ color: "var(--muted)" }}>{meta.prior}</span>
+                    {t(V.priorNotePost)}
                   </span>
                 </div>
               </div>
@@ -381,9 +392,14 @@ function Report({ id, dossier }: { id: string; dossier: DossierVM }) {
                     color: "var(--faint)"
                   }}
                 >
-                  Confidence
+                  {t(V.confidence)}
                 </div>
-                <div style={{ display: "flex", gap: 3 }} title={`Overall confidence in this inference: ${cap(meta.confidence)}`}>
+                <div
+                  style={{ display: "flex", gap: 3 }}
+                  title={t(V.confTooltip, {
+                    conf: locale === "zh" ? confidenceLabel(meta.confidence, locale) : cap(meta.confidence)
+                  })}
+                >
                   {[0, 1, 2].map((i) => (
                     <span
                       key={i}
@@ -397,7 +413,7 @@ function Report({ id, dossier }: { id: string; dossier: DossierVM }) {
                   ))}
                 </div>
                 <span style={{ fontFamily: "var(--fm)", fontSize: 11, fontWeight: 600, color: confColor }}>
-                  {meta.confidence.toUpperCase()}
+                  {confidenceLabel(meta.confidence, locale).toUpperCase()}
                 </span>
                 <span
                   style={{
@@ -416,7 +432,7 @@ function Report({ id, dossier }: { id: string; dossier: DossierVM }) {
 
             {/* hero right */}
             <div className="rp-hero-right">
-              <div style={{ ...KICKER_ACCENT, marginBottom: 9 }}>The why</div>
+              <div style={{ ...KICKER_ACCENT, marginBottom: 9 }}>{t(V.theWhy)}</div>
               <p style={{ margin: "0 0 20px", fontFamily: "var(--fd)", fontSize: 16, lineHeight: 1.46 }}>{meta.why}</p>
 
               <div
@@ -429,7 +445,7 @@ function Report({ id, dossier }: { id: string; dossier: DossierVM }) {
                   marginBottom: 11
                 }}
               >
-                Three core signals
+                {t(V.coreSignals)}
               </div>
               {core.map((c) => (
                 <a
@@ -460,7 +476,7 @@ function Report({ id, dossier }: { id: string; dossier: DossierVM }) {
                         borderRadius: 4
                       }}
                     >
-                      {c.rank}
+                      {t(rankEntry(c.rank))}
                     </span>
                     <span
                       className={`mv-${c.dir}`}
@@ -499,7 +515,7 @@ function Report({ id, dossier }: { id: string; dossier: DossierVM }) {
                           color: "var(--neg)"
                         }}
                       >
-                        Strongest counter-signal
+                        {t(V.strongestCounter)}
                       </span>
                       <span
                         className={`mv-${counter.dir}`}
@@ -534,7 +550,7 @@ function Report({ id, dossier }: { id: string; dossier: DossierVM }) {
 
           {/* summary */}
           <div className="rp-summary" style={{ borderTop: "1px solid var(--line)" }}>
-            <div style={{ ...KICKER_ACCENT, marginBottom: 12 }}>Raven's summary</div>
+            <div style={{ ...KICKER_ACCENT, marginBottom: 12 }}>{t(V.ravensSummary)}</div>
             {dossier.summaryParagraphs.map((p, i) => {
               const dropCap = i === 0 && /^[A-Za-z]/.test(p);
               const body = dropCap ? p.slice(1) : p;
@@ -584,7 +600,7 @@ function Report({ id, dossier }: { id: string; dossier: DossierVM }) {
                   paddingTop: 2
                 }}
               >
-                Open risk
+                {t(V.openRisk)}
               </span>
               <p style={{ margin: 0, fontSize: 13.5, lineHeight: 1.55, color: "var(--muted)" }}>{meta.openUnc}</p>
             </div>
@@ -609,30 +625,35 @@ function Report({ id, dossier }: { id: string; dossier: DossierVM }) {
               }}
             >
               <ArrowIcon className="rf-chev srcic" style={{ transition: "transform .18s", width: 12, height: 12 }} />
-              Resolution &amp; framing
+              {t(V.resolutionFraming)}
               <span style={{ marginLeft: "auto", textTransform: "none", letterSpacing: 0, color: "var(--faint)", fontSize: 11 }}>
-                Normalized question · criteria · prior · assumptions
+                {t(V.resolutionHint)}
               </span>
             </summary>
             <div className="rf-body">
               <div style={{ gridColumn: "1 / -1" }}>
-                <div style={{ ...RF_KICKER, color: "var(--accent)" }}>Normalized question</div>
+                <div style={{ ...RF_KICKER, color: "var(--accent)" }}>{t(V.normalizedQuestion)}</div>
                 <p style={{ margin: 0, fontFamily: "var(--fd)", fontSize: 15, lineHeight: 1.5 }}>{meta.normQ}</p>
               </div>
               <div>
-                <div style={RF_KICKER}>Resolution criteria{meta.resDate ? ` · ${meta.resDate}` : ""}</div>
+                <div style={RF_KICKER}>
+                  {t(V.resolutionCriteria)}
+                  {meta.resDate ? ` · ${meta.resDate}` : ""}
+                </div>
                 <p style={RF_BODY}>{meta.criteria}</p>
               </div>
               <div>
-                <div style={RF_KICKER}>Prior · {meta.prior}</div>
+                <div style={RF_KICKER}>
+                  {t(V.prior)} · {meta.prior}
+                </div>
                 <p style={RF_BODY}>{meta.priorWhy}</p>
               </div>
               <div>
-                <div style={RF_KICKER}>Assumptions</div>
+                <div style={RF_KICKER}>{t(V.assumptions)}</div>
                 <p style={RF_BODY}>{meta.assumptions}</p>
               </div>
               <div>
-                <div style={RF_KICKER}>Settlement source</div>
+                <div style={RF_KICKER}>{t(V.settlementSource)}</div>
                 <p style={RF_BODY}>{meta.settlement}</p>
               </div>
             </div>

--- a/apps/raven/app/forecast/[id]/pills.tsx
+++ b/apps/raven/app/forecast/[id]/pills.tsx
@@ -1,9 +1,13 @@
+"use client";
+
 // Shared evidence chips/pills for the Verdict screen — domain, credibility
 // (shield) and value (violet diamonds). Styles verbatim from the handoff;
 // "core" adds the hero-card letter-spacing, "pop" is the popover-size variant.
 
 import type { CSSProperties } from "react";
 import { ShieldIcon, SrcIcon } from "../../../components/icons";
+import { tierWord, useLocale, useT } from "../../../lib/i18n";
+import { V } from "../../../lib/i18n/verdict";
 import type { DecoratedEvidence } from "./decorate";
 
 type PillVariant = "core" | "row" | "pop";
@@ -36,6 +40,8 @@ export function DomChip({ e }: { e: DecoratedEvidence }) {
 }
 
 export function CredPill({ e, variant = "row" }: { e: DecoratedEvidence; variant?: PillVariant }) {
+  const t = useT();
+  const { locale } = useLocale();
   return (
     <span
       className={`cred-${e.cred} bd-${e.cred}`}
@@ -46,15 +52,17 @@ export function CredPill({ e, variant = "row" }: { e: DecoratedEvidence; variant
         border: "1px solid",
         ...(variant === "core" ? { letterSpacing: ".02em" } : {})
       }}
-      title="How trustworthy the source is"
+      title={t(V.credTooltip)}
     >
       <ShieldIcon />
-      {e.credLabel} credibility
+      {t(V.credPill, { tier: tierWord(e.credLabel, locale) })}
     </span>
   );
 }
 
 export function ValuePill({ e, variant = "row" }: { e: DecoratedEvidence; variant?: PillVariant }) {
+  const t = useT();
+  const { locale } = useLocale();
   return (
     <span
       style={{
@@ -66,10 +74,10 @@ export function ValuePill({ e, variant = "row" }: { e: DecoratedEvidence; varian
         background: "color-mix(in srgb,var(--val) 11%,transparent)",
         ...(variant === "core" ? { letterSpacing: ".02em" } : {})
       }}
-      title="How much this source adds to the forecast"
+      title={t(V.valueTooltip)}
     >
       <span style={{ letterSpacing: 1 }}>{e.valDiamonds}</span>
-      {e.valueLabel} value
+      {t(V.valuePill, { tier: tierWord(e.valueLabel, locale) })}
     </span>
   );
 }

--- a/apps/raven/app/forecast/[id]/research/page.tsx
+++ b/apps/raven/app/forecast/[id]/research/page.tsx
@@ -32,6 +32,8 @@ import { useAnnotations } from "../../../../components/research/use-annotations"
 import { useStaggeredReveal } from "../../../../components/research/use-reveal";
 import { VerdictDigest } from "../../../../components/research/verdict-digest";
 import { useForecast } from "../../../../lib/client/use-forecast";
+import { useLocale, useT } from "../../../../lib/i18n";
+import { RS } from "../../../../lib/i18n/ui";
 import { GTA6_DEMO, GTA6_DEMO_ID } from "../../../../lib/demo/gta6";
 import type { AnalystStance } from "../../../../lib/server/analyst";
 import { formatElapsed } from "../../../../lib/vm/format";
@@ -66,6 +68,8 @@ export default function ResearchPage() {
   const id = typeof rawId === "string" ? rawId : Array.isArray(rawId) ? (rawId[0] ?? "") : "";
   const isDemo = id === GTA6_DEMO_ID;
 
+  const { locale } = useLocale();
+  const t = useT();
   const { data, error, refresh } = useForecast(id);
   const ann = useAnnotations(id, data?.analyst, refresh);
 
@@ -87,7 +91,7 @@ export default function ResearchPage() {
   }, [isDemo]);
 
   const blocks: BlockVM[] = useMemo(() => {
-    if (isDemo) return buildDemoBlocks(GTA6_DEMO);
+    if (isDemo) return buildDemoBlocks(GTA6_DEMO, locale);
     if (!dossier) return [];
     // Framing persisted but round 1 still running: show a round-1 placeholder
     // block so the feed reads "researching" instead of sitting empty.
@@ -97,18 +101,19 @@ export default function ResearchPage() {
         {
           n: "01",
           reasoningId: "r1",
-          status: `running · ${p} → ${p} so far`,
-          move: "— 0% so far",
+          status: t(RS.statusRunningSpan, { from: p, to: p }),
+          span: `${p} → ${p}`,
+          move: t(RS.moveSoFar, { arrow: "—", net: "0%" }),
           moveDir: "flat",
-          note: `Question framed — starting from a ${p} base-rate prior. Round 1 is gathering its first evidence.`,
+          note: t(RS.placeholderNote, { p }),
           evidence: [],
-          reading: readingFromJob(job),
+          reading: readingFromJob(job, locale),
           analystFolded: 0
         }
       ];
     }
-    return buildLiveBlocks(dossier.iterations, running, readingFromJob(job));
-  }, [isDemo, dossier, running, job]);
+    return buildLiveBlocks(dossier.iterations, running, readingFromJob(job, locale), locale);
+  }, [isDemo, dossier, running, job, locale, t]);
 
   const maxRounds = isDemo ? 3 : Math.max(1, dossier?.maxRounds ?? job?.maxRounds ?? 3);
   const nextRound = nextRoundFor(blocks.length, maxRounds);
@@ -118,8 +123,8 @@ export default function ResearchPage() {
   // --- Manus-style plan checklist + progressive reveal ---
   const prior = dossier?.meta.prior ?? null;
   const planSteps = useMemo(
-    () => buildPlanSteps({ framing, blocks, maxRounds, running, complete, prior }),
-    [framing, blocks, maxRounds, running, complete, prior]
+    () => buildPlanSteps({ framing, blocks, maxRounds, running, complete, prior, locale }),
+    [framing, blocks, maxRounds, running, complete, prior, locale]
   );
   const revealIds = useMemo(() => blocks.flatMap((b) => [`it${b.n}`, ...b.evidence.map((e) => e.id)]), [blocks]);
   const { visible, animated } = useStaggeredReveal(revealIds, !isDemo && running);
@@ -144,14 +149,14 @@ export default function ResearchPage() {
       setTrail([]);
       return;
     }
-    const r = readingFromJob(job);
+    const r = readingFromJob(job, locale);
     if (!r.domain) return;
     setTrail((cur) => {
       const last = cur[cur.length - 1];
       if (last?.domain === r.domain) return cur;
       return [...cur.slice(-3), r];
     });
-  }, [isDemo, running, job, blocks.length]);
+  }, [isDemo, running, job, blocks.length, locale]);
   const liveReads = isDemo ? DEMO_TRAIL : trail;
 
   // Gentle auto-follow: when new items stream in and the reader is already
@@ -180,13 +185,13 @@ export default function ResearchPage() {
 
   const activeStep = planSteps.find((s) => s.state === "active");
   let dockTone: DockTone = "live";
-  let dockLabel = activeStep ? `${activeStep.label}${activeStep.sub ? ` — ${activeStep.sub}` : ""}` : "Working…";
+  let dockLabel = activeStep ? `${activeStep.label}${activeStep.sub ? ` — ${activeStep.sub}` : ""}` : t(RS.dockWorking);
   if (complete && dossier) {
     dockTone = "complete";
-    dockLabel = `Forecast complete — P(YES) ${dossier.meta.prob}`;
+    dockLabel = t(RS.dockComplete, { p: dossier.meta.prob });
   } else if (aborted) {
     dockTone = "error";
-    dockLabel = "Run aborted — partial evidence kept";
+    dockLabel = t(RS.dockAborted);
   }
   const dockElapsed = isDemo
     ? demoElapsed(now, demoT0)
@@ -199,19 +204,19 @@ export default function ResearchPage() {
   let headerText: string | null = null;
   let headerLive = false;
   if (isDemo) {
-    headerText = `LIVE · ITERATION 2 OF 3 · ${demoElapsed(now, demoT0)} · 08 SOURCES`;
+    headerText = t(RS.headerLive, { cur: 2, max: 3, elapsed: demoElapsed(now, demoT0), n: "08" });
     headerLive = true;
   } else if (running && job) {
     const cur = Math.min(Math.max(blocks.length, 1), maxRounds);
     const elapsed = formatElapsed(job.startedAtUtc, now ?? Date.parse(job.startedAtUtc));
-    headerText = `LIVE · ITERATION ${cur} OF ${maxRounds} · ${elapsed} · ${String(sourcesShown).padStart(2, "0")} SOURCES`;
+    headerText = t(RS.headerLive, { cur, max: maxRounds, elapsed, n: String(sourcesShown).padStart(2, "0") });
     headerLive = true;
   } else if (dossier && dossier.status === "complete") {
-    headerText = `COMPLETE · ${dossier.meta.duration} · ${dossier.meta.sources.padStart(2, "0")} SOURCES`;
+    headerText = t(RS.headerComplete, { dur: dossier.meta.duration, n: dossier.meta.sources.padStart(2, "0") });
   } else if (aborted) {
-    headerText = "RUN ABORTED";
+    headerText = t(RS.headerAborted);
   } else if (job?.status === "unforecastable") {
-    headerText = "UNFORECASTABLE";
+    headerText = t(RS.headerUnforecastable);
   }
   const headerRight = headerText ? (
     <span
@@ -246,32 +251,32 @@ export default function ResearchPage() {
   // --- status strip content ---
   const question = isDemo
     ? GTA6_DEMO.meta.question
-    : (dossier?.meta.question ?? job?.question ?? "Framing the question…");
+    : (dossier?.meta.question ?? job?.question ?? t(RS.framingQuestion));
   const nowLine: NowLine | null = isDemo
     ? DEMO_NOW
     : running && dossier
       ? {
-          bold: `research round ${Math.min(Math.max(blocks.length, 1), maxRounds)}`,
-          rest: " — gathering evidence and updating the estimate."
+          bold: t(RS.nowRoundBold, { n: Math.min(Math.max(blocks.length, 1), maxRounds) }),
+          rest: t(RS.nowRoundRest)
         }
       : null;
   let quant: QuantVM | null = null;
   if (isDemo) {
-    quant = { nowPct: 18, priorPct: 38, label: "P(YES) · provisional" };
+    quant = { nowPct: 18, priorPct: 38, label: t(RS.quantProvisional) };
   } else if (dossier && dossier.currentProb !== null && dossier.priorProb !== null) {
     quant = {
       nowPct: Math.round(dossier.currentProb * 100),
       priorPct: Math.round(dossier.priorProb * 100),
-      label: complete ? "P(YES) · final" : "P(YES) · provisional"
+      label: complete ? t(RS.quantFinal) : t(RS.quantProvisional)
     };
   }
 
   // --- analyst desk data ---
-  const markSummary = `${ann.keptCount} kept · ${ann.doubtedCount} doubted · ${ann.notes.length} notes`;
+  const markSummary = t(RS.markSummary, { k: ann.keptCount, d: ann.doubtedCount, n: ann.notes.length });
   const leanYes = (dossier?.currentProb ?? dossier?.priorProb ?? 0) >= 0.5;
   const queued = useMemo(
-    () => buildQueued(ann.notes, blocks, dossier?.iterations ?? [], nextRound, complete, leanYes),
-    [ann.notes, blocks, dossier, nextRound, complete, leanYes]
+    () => buildQueued(ann.notes, blocks, dossier?.iterations ?? [], nextRound, complete, leanYes, locale),
+    [ann.notes, blocks, dossier, nextRound, complete, leanYes, locale]
   );
 
   const onToggleNote = (evidenceId: string) => {
@@ -300,13 +305,12 @@ export default function ResearchPage() {
   if (!isDemo && !data) {
     notice = error ? (
       /not found/i.test(error) ? (
-        <NoticeCard tone="info" title="Forecast not found">
-          There's no run with this id — it may have been cleared when the server restarted. Ask a new question from
-          the Ask screen.
+        <NoticeCard tone="info" title={t(RS.notFoundTitle)}>
+          {t(RS.notFoundBody)}
         </NoticeCard>
       ) : (
-        <NoticeCard tone="error" title="Couldn't load this run">
-          {error} — retrying automatically.
+        <NoticeCard tone="error" title={t(RS.loadFailTitle)}>
+          {t(RS.loadFailBody, { err: error })}
         </NoticeCard>
       )
     ) : (
@@ -315,28 +319,20 @@ export default function ResearchPage() {
   } else if (!isDemo && data && !dossier) {
     if (job?.status === "unforecastable") {
       notice = (
-        <NoticeCard tone="info" title="This question is too vague to forecast" log={job.log.slice(-6)}>
-          {job.question ? (
-            <>
-              Raven couldn't pin <i>“{job.question}”</i> down to a checkable yes-or-no outcome with a deadline.{" "}
-            </>
-          ) : (
-            <>Raven couldn't pin the question down to a checkable yes-or-no outcome with a deadline. </>
-          )}
-          Rephrase it with a concrete event and date — “Will … happen by …?” — and ask again.
+        <NoticeCard tone="info" title={t(RS.vagueTitle)} log={job.log.slice(-6)}>
+          {job.question ? t(RS.vagueBodyQuoted, { q: job.question }) : t(RS.vagueBodyPlain)} {t(RS.vagueBodyTail)}
         </NoticeCard>
       );
     } else if (job?.status === "error") {
       notice = (
-        <NoticeCard tone="error" title="The run aborted" log={job.log.slice(-8)}>
-          The engine stopped before finishing this run. The last log lines may explain why.
+        <NoticeCard tone="error" title={t(RS.abortedTitle)} log={job.log.slice(-8)}>
+          {t(RS.abortedBodyTerminal)}
         </NoticeCard>
       );
     } else if (!job) {
       notice = (
-        <NoticeCard tone="info" title="Forecast not found">
-          There's no run with this id — it may have been cleared when the server restarted. Ask a new question from
-          the Ask screen.
+        <NoticeCard tone="info" title={t(RS.notFoundTitle)}>
+          {t(RS.notFoundBody)}
         </NoticeCard>
       );
     }
@@ -359,18 +355,17 @@ export default function ResearchPage() {
           <div>
             <RavenMessage provider={providerLabel} time={startedAt}>
               <p style={{ margin: 0, fontSize: 13.5, lineHeight: 1.6, color: "var(--muted)" }}>
-                On it. I&apos;ll pin this down to a checkable yes-or-no question with a base-rate prior, then research
-                it in up to {maxRounds} rounds — each round deliberately hunts for evidence that cuts against the
-                current lean. <b style={{ color: "var(--text)" }}>Circle what holds up, strike what you doubt</b>, or
-                queue a hypothesis; I fold analyst pushback into the next round.
+                {t(RS.planIntroA, { n: maxRounds })}
+                <b style={{ color: "var(--text)" }}>{t(RS.planIntroBold)}</b>
+                {t(RS.planIntroB)}
               </p>
               <div style={{ marginTop: 15 }}>
                 <PlanList steps={planSteps} />
               </div>
             </RavenMessage>
             {aborted && (
-              <NoticeCard tone="error" title="The run aborted" inline log={job?.status === "error" ? job.log.slice(-6) : undefined}>
-                The engine stopped before this run finished. Everything it gathered so far is shown below.
+              <NoticeCard tone="error" title={t(RS.abortedTitle)} inline log={job?.status === "error" ? job.log.slice(-6) : undefined}>
+                {t(RS.abortedBodyInline)}
               </NoticeCard>
             )}
             {framing ? (

--- a/apps/raven/app/layout.tsx
+++ b/apps/raven/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { IBM_Plex_Mono, Newsreader } from "next/font/google";
+import { LocaleProvider } from "../lib/i18n";
 import "./globals.css";
 
 const newsreader = Newsreader({
@@ -26,7 +27,9 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={`${newsreader.variable} ${plexMono.variable}`}>
-      <body>{children}</body>
+      <body>
+        <LocaleProvider>{children}</LocaleProvider>
+      </body>
     </html>
   );
 }

--- a/apps/raven/app/page.tsx
+++ b/apps/raven/app/page.tsx
@@ -1,14 +1,17 @@
 "use client";
 
 // Screen 01 · Ask — glow hero, ask bar, example chip, latest-dossier card and
-// the three-step explainer. Layout + copy verbatim from the design handoff
-// ("Raven Home.dc.html"); submission wired to the real forecast API.
+// the three-step explainer. Layout from the design handoff
+// ("Raven Home.dc.html"); submission wired to the real forecast API. All
+// user-facing copy lives in the HOME i18n dictionary (lib/i18n/home.ts).
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { RvShell } from "../components/chrome/rv-shell";
 import { GTA6_DEMO, GTA6_DEMO_ID } from "../lib/demo/gta6";
+import { confidenceLabel, sourcesLabel, useLocale, useT, verdictLabel } from "../lib/i18n";
+import { HOME } from "../lib/i18n/home";
 import { cap, credWord } from "../lib/vm/format";
 import type { RunListItem } from "../lib/vm/types";
 import "./home.css";
@@ -44,22 +47,12 @@ const DEMO_CARD: LatestCard = {
   resDate: GTA6_DEMO.meta.resDate
 };
 
+// Dictionary entries per explainer card; rendered through t() so the cards
+// follow the active locale.
 const STEPS = [
-  {
-    kicker: "01 · FRAME",
-    title: "The question is pinned down",
-    body: "Normalized into something checkable — exact date, exact resolution criteria — and given an honest base-rate prior."
-  },
-  {
-    kicker: "02 · RESEARCH",
-    title: "Adversarial rounds",
-    body: "Gather evidence, weigh its credibility and value, then hunt for whatever would prove the current lean wrong. You can push back mid-run."
-  },
-  {
-    kicker: "03 · VERDICT",
-    title: "A number you can audit",
-    body: "One probability with its confidence band — and every source that moved it, in reading order, line by line."
-  }
+  { kicker: HOME.step1Kicker, title: HOME.step1Title, body: HOME.step1Body },
+  { kicker: HOME.step2Kicker, title: HOME.step2Title, body: HOME.step2Body },
+  { kicker: HOME.step3Kicker, title: HOME.step3Title, body: HOME.step3Body }
 ] as const;
 
 // "Very unlikely" + "A third delay…" → "Very unlikely — a third delay…"
@@ -85,6 +78,8 @@ function toCard(run: RunListItem): LatestCard {
 
 export default function HomePage() {
   const router = useRouter();
+  const t = useT();
+  const { locale } = useLocale();
   const inputRef = useRef<HTMLInputElement>(null);
   const [q, setQ] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -132,11 +127,13 @@ export default function HomePage() {
       const res = await fetch("/api/forecasts", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ question })
+        // `language` makes the engine write its reasoning/evidence in the
+        // reader's locale.
+        body: JSON.stringify({ question, language: locale })
       });
       const body = (await res.json().catch(() => null)) as { eventId?: string; error?: string } | null;
       if (!res.ok || !body?.eventId) {
-        throw new Error(body?.error ?? `request failed (${res.status})`);
+        throw new Error(body?.error ?? t(HOME.requestFailed, { status: res.status }));
       }
       router.push(`/forecast/${body.eventId}/research`);
     } catch (err) {
@@ -158,7 +155,7 @@ export default function HomePage() {
           className="rv-hdr-meta"
           style={{ fontFamily: "var(--fm)", fontSize: 10, letterSpacing: ".08em", color: "var(--faint)" }}
         >
-          RESEARCH PREVIEW
+          {t(HOME.researchPreview)}
         </span>
       }
     >
@@ -180,7 +177,7 @@ export default function HomePage() {
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           src="/raven-mascot.png"
-          alt="Raven, a hooded crow holding a glowing orb"
+          alt={t(HOME.mascotAlt)}
           style={{
             position: "relative",
             width: 136,
@@ -202,7 +199,7 @@ export default function HomePage() {
             textAlign: "center"
           }}
         >
-          Raven <span style={{ color: "var(--accent)" }}>Forecasting Engine</span>
+          Raven <span style={{ color: "var(--accent)" }}>{t(HOME.heroTitleAccent)}</span>
         </h1>
         <p
           style={{
@@ -215,8 +212,7 @@ export default function HomePage() {
             textAlign: "center"
           }}
         >
-          Ask a hard yes-or-no question about the future. Raven frames it precisely, researches it in adversarial
-          rounds, and returns a probability — with every source that moved it laid out in reading order.
+          {t(HOME.heroLede)}
         </p>
 
         <form
@@ -242,8 +238,8 @@ export default function HomePage() {
             ref={inputRef}
             value={q}
             onChange={(e) => setQ(e.target.value)}
-            placeholder="Will … happen by …?"
-            aria-label="Forecast question"
+            placeholder={t(HOME.askPlaceholder)}
+            aria-label={t(HOME.askAriaLabel)}
             style={{
               flex: 1,
               minWidth: 0,
@@ -276,7 +272,7 @@ export default function HomePage() {
               opacity: submitting ? 0.7 : 1
             }}
           >
-            {submitting ? "Framing…" : "Forecast it"}
+            {submitting ? t(HOME.submitBusy) : t(HOME.submitIdle)}
           </button>
         </form>
         {submitError ? (
@@ -308,7 +304,7 @@ export default function HomePage() {
           }}
         >
           <span style={{ fontFamily: "var(--fm)", fontSize: 10.5, letterSpacing: ".04em", color: "var(--faint)" }}>
-            Works best with a deadline and a checkable outcome — try
+            {t(HOME.hintPrefix)}
           </span>
           <button
             type="button"
@@ -325,7 +321,7 @@ export default function HomePage() {
               cursor: "pointer"
             }}
           >
-            Will the GTA 6 launch slip past November 19, 2026?
+            {t(HOME.exampleChip)}
           </button>
         </div>
 
@@ -340,7 +336,7 @@ export default function HomePage() {
               marginBottom: 10
             }}
           >
-            Latest dossier
+            {t(HOME.latestDossier)}
           </div>
           {liveRuns.map((r) => (
             <Link
@@ -371,7 +367,7 @@ export default function HomePage() {
                 }}
               />
               <span style={{ overflow: "hidden", whiteSpace: "nowrap", textOverflow: "ellipsis" }}>
-                LIVE — {r.question}
+                {t(HOME.liveRun, { question: r.question })}
               </span>
             </Link>
           ))}
@@ -418,7 +414,7 @@ export default function HomePage() {
                 {latest.question}
               </div>
               <div style={{ fontSize: 13.5, color: "var(--muted)", marginTop: 5, fontStyle: "italic" }}>
-                {verdictLine(latest.verdict, latest.quip)}
+                {verdictLine(verdictLabel(latest.verdict, locale), latest.quip)}
               </div>
               <div
                 style={{
@@ -431,12 +427,12 @@ export default function HomePage() {
                   flexWrap: "wrap"
                 }}
               >
-                <span>{latest.sources} sources</span>
+                <span>{sourcesLabel(latest.sources, locale)}</span>
                 <span>{latest.duration}</span>
                 <span style={{ color: `var(--cred-${credWord(latest.confidence)})` }}>
-                  {cap(latest.confidence)} confidence
+                  {t(HOME.confidenceMeta, { level: cap(confidenceLabel(latest.confidence, locale)) })}
                 </span>
-                {latest.resDate ? <span>resolves {latest.resDate}</span> : null}
+                {latest.resDate ? <span>{t(HOME.resolvesOn, { date: latest.resDate })}</span> : null}
               </div>
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
@@ -457,7 +453,7 @@ export default function HomePage() {
                   borderRadius: 8
                 }}
               >
-                Read the dossier
+                {t(HOME.readDossier)}
               </Link>
               <Link
                 href={`/forecast/${latest.id}/research`}
@@ -476,7 +472,7 @@ export default function HomePage() {
                   borderRadius: 8
                 }}
               >
-                Watch the run
+                {t(HOME.watchRun)}
               </Link>
             </div>
           </div>
@@ -485,7 +481,7 @@ export default function HomePage() {
         <div className="rv-home-steps">
           {STEPS.map((s) => (
             <div
-              key={s.kicker}
+              key={s.kicker.en}
               style={{
                 border: "1px solid var(--line)",
                 borderRadius: 13,
@@ -502,10 +498,10 @@ export default function HomePage() {
                   color: "var(--accent)"
                 }}
               >
-                {s.kicker}
+                {t(s.kicker)}
               </div>
-              <div style={{ fontFamily: "var(--fd)", fontWeight: 600, fontSize: 16, marginTop: 9 }}>{s.title}</div>
-              <p style={{ margin: "6px 0 0", fontSize: 13, lineHeight: 1.55, color: "var(--muted)" }}>{s.body}</p>
+              <div style={{ fontFamily: "var(--fd)", fontWeight: 600, fontSize: 16, marginTop: 9 }}>{t(s.title)}</div>
+              <p style={{ margin: "6px 0 0", fontSize: 13, lineHeight: 1.55, color: "var(--muted)" }}>{t(s.body)}</p>
             </div>
           ))}
         </div>

--- a/apps/raven/components/chrome/rv-shell.tsx
+++ b/apps/raven/components/chrome/rv-shell.tsx
@@ -2,28 +2,32 @@
 
 // Shared chrome for all three screens: the .rv theme root, header bar,
 // three-step tab nav, and footer — layout and copy from the design handoff.
+// Also mounts the LocaleProvider and the 中文/EN toggle (persisted like the
+// theme choice).
 
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
+import { useLocale, useT } from "../../lib/i18n";
+import { CHROME } from "../../lib/i18n/ui";
 import { GTA6_DEMO_ID } from "../../lib/demo/gta6";
 
 type Screen = "ask" | "research" | "verdict";
 
 const THEME_KEY = "raven-theme";
 
-export function RvShell({
-  active,
-  forecastId,
-  headerRight,
-  showFooter = true,
-  children
-}: {
+interface ShellProps {
   active: Screen;
   forecastId?: string;
   headerRight?: React.ReactNode;
   showFooter?: boolean;
   children: React.ReactNode;
-}) {
+}
+
+// LocaleProvider is mounted once in app/layout.tsx so page components outside
+// this shell's subtree share the same locale context.
+export function RvShell({ active, forecastId, headerRight, showFooter = true, children }: ShellProps) {
+  const t = useT();
+  const { locale, setLocale } = useLocale();
   const [theme, setTheme] = useState<"dark" | "light">("dark");
   useEffect(() => {
     try {
@@ -34,8 +38,8 @@ export function RvShell({
     }
   }, []);
   const toggleTheme = useCallback(() => {
-    setTheme((t) => {
-      const next = t === "dark" ? "light" : "dark";
+    setTheme((cur) => {
+      const next = cur === "dark" ? "light" : "dark";
       try {
         localStorage.setItem(THEME_KEY, next);
       } catch {
@@ -47,9 +51,9 @@ export function RvShell({
 
   const fid = forecastId ?? GTA6_DEMO_ID;
   const tabs: Array<{ key: Screen; label: string; href: string }> = [
-    { key: "ask", label: "01 · Ask", href: "/" },
-    { key: "research", label: "02 · Research", href: `/forecast/${fid}/research` },
-    { key: "verdict", label: "03 · Verdict", href: `/forecast/${fid}` }
+    { key: "ask", label: t(CHROME.navAsk), href: "/" },
+    { key: "research", label: t(CHROME.navResearch), href: `/forecast/${fid}/research` },
+    { key: "verdict", label: t(CHROME.navVerdict), href: `/forecast/${fid}` }
   ];
 
   return (
@@ -92,8 +96,8 @@ export function RvShell({
           {headerRight}
           <button
             type="button"
-            onClick={toggleTheme}
-            title={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}
+            onClick={() => setLocale(locale === "zh" ? "en" : "zh")}
+            title={t(CHROME.langSwitchTitle)}
             style={{
               cursor: "pointer",
               background: "none",
@@ -106,15 +110,33 @@ export function RvShell({
               padding: "4px 10px"
             }}
           >
-            {theme === "dark" ? "LIGHT" : "DARK"}
+            {t(CHROME.langSwitch)}
+          </button>
+          <button
+            type="button"
+            onClick={toggleTheme}
+            title={theme === "dark" ? t(CHROME.themeToLight) : t(CHROME.themeToDark)}
+            style={{
+              cursor: "pointer",
+              background: "none",
+              border: "1px solid var(--line2)",
+              borderRadius: 20,
+              color: "var(--faint)",
+              fontFamily: "var(--fm)",
+              fontSize: 9,
+              letterSpacing: ".1em",
+              padding: "4px 10px"
+            }}
+          >
+            {theme === "dark" ? t(CHROME.themeLight) : t(CHROME.themeDark)}
           </button>
         </div>
       </header>
 
       <nav className="rv-nav">
-        {tabs.map((t) => (
-          <Link key={t.key} href={t.href} className={`nvl${t.key === active ? " on" : ""}`}>
-            {t.label}
+        {tabs.map((tab) => (
+          <Link key={tab.key} href={tab.href} className={`nvl${tab.key === active ? " on" : ""}`}>
+            {tab.label}
           </Link>
         ))}
       </nav>
@@ -124,10 +146,10 @@ export function RvShell({
       {showFooter && (
         <footer className="rv-ftr">
           <span style={{ fontFamily: "var(--fm)", fontSize: 10, color: "var(--faint)" }}>
-            Raven is a research instrument — probabilities with sources, not advice.
+            {t(CHROME.footerInstrument)}
           </span>
           <span style={{ fontFamily: "var(--fm)", fontSize: 10, color: "var(--faint)" }}>
-            No prediction-market or betting data is used as evidence.
+            {t(CHROME.footerMarketBlind)}
           </span>
         </footer>
       )}

--- a/apps/raven/components/research/analyst-desk.tsx
+++ b/apps/raven/components/research/analyst-desk.tsx
@@ -3,13 +3,15 @@
 // The sticky right rail: hypothesis composer (textarea + 3-way stance control
 // + queue button) and the queued-notes list with per-note status tags.
 
+import { useT, type Entry } from "../../lib/i18n";
+import { RP } from "../../lib/i18n/research-parts";
 import type { AnalystStance } from "../../lib/server/analyst";
 import type { QueuedVM } from "./research-vm";
 
-const STANCES: Array<{ key: AnalystStance; label: string }> = [
-  { key: "yes", label: "PUSHES YES" },
-  { key: "no", label: "PUSHES NO" },
-  { key: "question", label: "QUESTION" }
+const STANCES: Array<{ key: AnalystStance; label: Entry }> = [
+  { key: "yes", label: RP.stanceYes },
+  { key: "no", label: RP.stanceNo },
+  { key: "question", label: RP.stanceQuestion }
 ];
 
 export function AnalystDesk({
@@ -35,6 +37,7 @@ export function AnalystDesk({
   queued: readonly QueuedVM[];
   onRemove: (noteId: string) => void;
 }) {
+  const t = useT();
   return (
     <div className="rvp-rail">
       <div style={{ background: "var(--bg2)", border: "1px solid var(--line)", borderRadius: 14, padding: "18px 18px 16px" }}>
@@ -48,28 +51,30 @@ export function AnalystDesk({
               color: "var(--accent)"
             }}
           >
-            Analyst desk
+            {t(RP.deskTitle)}
           </div>
           <span style={{ fontFamily: "var(--fm)", fontSize: 9.5, color: "var(--faint)" }}>{markSummary}</span>
         </div>
         <p style={{ margin: "8px 0 0", fontSize: 12.5, lineHeight: 1.5, color: "var(--muted)" }}>
           {complete ? (
             <>
-              Queue a hypothesis or a lead. The run is complete, so notes are{" "}
-              <b style={{ color: "var(--text)" }}>saved with the dossier</b>.
+              {t(RP.deskHelpDonePre)}
+              <b style={{ color: "var(--text)" }}>{t(RP.deskHelpDoneBold)}</b>
+              {t(RP.deskHelpDonePost)}
             </>
           ) : (
             <>
-              Queue a hypothesis or a lead. Raven treats each one as a claim to test in{" "}
-              <b style={{ color: "var(--text)" }}>iteration {nextRound}</b>.
+              {t(RP.deskHelpRunPre)}
+              <b style={{ color: "var(--text)" }}>{t(RP.deskHelpRunBold, { n: nextRound })}</b>
+              {t(RP.deskHelpRunPost)}
             </>
           )}
         </p>
         <textarea
           value={composerText}
           onChange={(e) => onComposerText(e.target.value)}
-          placeholder="e.g. Check retailer supply-chain listings — physical stock timelines would confirm the date better than press."
-          aria-label="Queue a hypothesis or a lead"
+          placeholder={t(RP.deskPlaceholder)}
+          aria-label={t(RP.deskComposerAria)}
           style={{
             width: "100%",
             marginTop: 12,
@@ -86,7 +91,7 @@ export function AnalystDesk({
             padding: "10px 12px"
           }}
         />
-        <div role="radiogroup" aria-label="How this note pushes the forecast" style={{ display: "flex", gap: 6, marginTop: 10 }}>
+        <div role="radiogroup" aria-label={t(RP.deskStanceAria)} style={{ display: "flex", gap: 6, marginTop: 10 }}>
           {STANCES.map((s) => {
             const on = stance === s.key;
             return (
@@ -109,7 +114,7 @@ export function AnalystDesk({
                   padding: "7px 4px"
                 }}
               >
-                {s.label}
+                {t(s.label)}
               </button>
             );
           })}
@@ -134,7 +139,7 @@ export function AnalystDesk({
             borderRadius: 9
           }}
         >
-          {complete ? "Save note for the dossier" : `Queue for iteration ${nextRound}`}
+          {complete ? t(RP.deskSubmitSave) : t(RP.deskSubmitQueue, { n: nextRound })}
         </button>
       </div>
 
@@ -149,7 +154,7 @@ export function AnalystDesk({
             marginBottom: 9
           }}
         >
-          Queued · {String(queued.length).padStart(2, "0")}
+          {t(RP.deskQueuedHeading, { nn: String(queued.length).padStart(2, "0") })}
         </div>
         {queued.length > 0 ? (
           queued.map((n) => (
@@ -193,8 +198,8 @@ export function AnalystDesk({
                 <button
                   type="button"
                   onClick={() => onRemove(n.id)}
-                  title="Remove"
-                  aria-label="Remove this note"
+                  title={t(RP.deskRemoveTitle)}
+                  aria-label={t(RP.deskRemoveAria)}
                   style={{
                     border: "none",
                     background: "none",
@@ -223,7 +228,7 @@ export function AnalystDesk({
               color: "var(--faint)"
             }}
           >
-            Nothing queued yet. Your circles, strikes and notes land here — and in Raven's next research round.
+            {t(RP.deskQueuedEmpty)}
           </div>
         )}
       </div>

--- a/apps/raven/components/research/annotation.tsx
+++ b/apps/raven/components/research/annotation.tsx
@@ -7,8 +7,16 @@
 // while keeping the stroke width constant.
 
 import type { CSSProperties } from "react";
+import { useT, type Entry } from "../../lib/i18n";
+import { RP } from "../../lib/i18n/research-parts";
 
 export type Mark = "keep" | "doubt";
+
+// Subject words used in the toolbar aria-labels ("evidence" | "reasoning").
+const SUBJECT_WORDS: Record<string, Entry> = {
+  evidence: RP.subjectEvidence,
+  reasoning: RP.subjectReasoning
+};
 type OverlayVariant = "note" | "evidence";
 
 function overlaySvgStyle(variant: OverlayVariant): CSSProperties {
@@ -44,6 +52,7 @@ function badgeStyle(color: string, rotate: string, variant: OverlayVariant): CSS
 }
 
 export function MarkOverlay({ mark, variant }: { mark: Mark; variant: OverlayVariant }) {
+  const t = useT();
   if (mark === "keep") {
     return (
       <>
@@ -74,7 +83,7 @@ export function MarkOverlay({ mark, variant }: { mark: Mark; variant: OverlayVar
             opacity="0.4"
           />
         </svg>
-        <span style={badgeStyle("var(--pos)", "rotate(-3deg)", variant)}>KEPT</span>
+        <span style={badgeStyle("var(--pos)", "rotate(-3deg)", variant)}>{t(RP.annoKept)}</span>
       </>
     );
   }
@@ -103,7 +112,7 @@ export function MarkOverlay({ mark, variant }: { mark: Mark; variant: OverlayVar
           strokeLinecap="round"
         />
       </svg>
-      <span style={badgeStyle("var(--neg)", "rotate(2deg)", variant)}>DOUBTED</span>
+      <span style={badgeStyle("var(--neg)", "rotate(2deg)", variant)}>{t(RP.annoDoubted)}</span>
     </>
   );
 }
@@ -134,6 +143,8 @@ export function AnnoBar({
   onDoubt: () => void;
   onNote?: () => void;
 }) {
+  const t = useT();
+  const subjectWord = SUBJECT_WORDS[subject] ? t(SUBJECT_WORDS[subject]) : subject;
   return (
     <div
       className="anno-bar"
@@ -143,20 +154,20 @@ export function AnnoBar({
         type="button"
         className="abtn"
         onClick={onKeep}
-        aria-label={`Keep this ${subject}`}
+        aria-label={t(RP.annoKeepAria, { subject: subjectWord })}
         aria-pressed={mark === "keep"}
         style={{ ...ABTN, color: "var(--pos)" }}
       >
         <svg viewBox="0 0 20 14" style={{ width: 14, height: 10 }} aria-hidden="true">
           <ellipse cx="10" cy="7" rx="8.5" ry="5.5" fill="none" stroke="currentColor" strokeWidth="1.6" />
         </svg>
-        KEEP
+        {t(RP.annoKeep)}
       </button>
       <button
         type="button"
         className="abtn"
         onClick={onDoubt}
-        aria-label={`Doubt this ${subject}`}
+        aria-label={t(RP.annoDoubtAria, { subject: subjectWord })}
         aria-pressed={mark === "doubt"}
         style={{ ...ABTN, color: "var(--neg)" }}
       >
@@ -164,17 +175,17 @@ export function AnnoBar({
           <ellipse cx="10" cy="7" rx="8.5" ry="5.5" fill="none" stroke="currentColor" strokeWidth="1.6" />
           <path d="M3 12 L17 2" stroke="currentColor" strokeWidth="1.5" />
         </svg>
-        DOUBT
+        {t(RP.annoDoubt)}
       </button>
       {onNote && (
         <button
           type="button"
           className="abtn"
           onClick={onNote}
-          aria-label="Attach a note"
+          aria-label={t(RP.annoNoteAria)}
           style={{ ...ABTN, color: "var(--muted)" }}
         >
-          + NOTE
+          {t(RP.annoNote)}
         </button>
       )}
     </div>

--- a/apps/raven/components/research/evidence-card.tsx
+++ b/apps/raven/components/research/evidence-card.tsx
@@ -4,6 +4,8 @@
 // with side bar, index, source + credibility + value pills, analysis text,
 // attached "Your note" strips and the inline note composer.
 
+import { tierWord, useLocale, useT } from "../../lib/i18n";
+import { RP } from "../../lib/i18n/research-parts";
 import type { AnalystNote } from "../../lib/server/analyst";
 import { ShieldIcon, SrcIcon } from "../icons";
 import { AnnoBar, MarkOverlay, type Mark } from "./annotation";
@@ -32,11 +34,13 @@ export function EvidenceCard({
   onNoteSubmit: () => void;
   animated?: boolean; // just streamed in — play the entrance animation
 }) {
+  const t = useT();
+  const { locale } = useLocale();
   return (
     <div
       className={`anno${animated ? " rv-reveal" : ""}`}
       tabIndex={0}
-      aria-label={`Evidence ${ev.idx}: ${ev.title}`}
+      aria-label={t(RP.evAria, { idx: ev.idx, title: ev.title })}
       style={{
         position: "relative",
         marginTop: 14,
@@ -87,7 +91,7 @@ export function EvidenceCard({
                   padding: "1px 5px"
                 }}
               >
-                ↻ Revises a prior source
+                {t(RP.evRevises)}
               </span>
             )}
           </div>
@@ -107,7 +111,7 @@ export function EvidenceCard({
             </span>
             <span
               className={`cred-${ev.cred} bd-${ev.cred}`}
-              title="How trustworthy the source is"
+              title={t(RP.evCredTitle)}
               style={{
                 display: "inline-flex",
                 alignItems: "center",
@@ -121,10 +125,10 @@ export function EvidenceCard({
               }}
             >
               <ShieldIcon />
-              {ev.credLabel} credibility
+              {t(RP.evCredPill, { tier: tierWord(ev.credLabel, locale) })}
             </span>
             <span
-              title="How much this source adds to the forecast"
+              title={t(RP.evValueTitle)}
               style={{
                 display: "inline-flex",
                 alignItems: "center",
@@ -140,7 +144,7 @@ export function EvidenceCard({
               }}
             >
               <span style={{ letterSpacing: 1 }}>{ev.valDiamonds}</span>
-              {ev.valueLabel} value
+              {t(RP.evValuePill, { tier: tierWord(ev.valueLabel, locale) })}
             </span>
           </div>
           <p style={{ margin: "9px 0 0", fontSize: 12.5, lineHeight: 1.55, color: "var(--muted)" }}>
@@ -170,7 +174,7 @@ export function EvidenceCard({
                   whiteSpace: "nowrap"
                 }}
               >
-                Your note
+                {t(RP.evYourNote)}
               </span>
               <span style={{ fontSize: 12.5, lineHeight: 1.45, color: "var(--text)" }}>{n.text}</span>
             </div>
@@ -183,8 +187,8 @@ export function EvidenceCard({
                 onKeyDown={(e) => {
                   if (e.key === "Enter") onNoteSubmit();
                 }}
-                placeholder="Attach a note to this evidence…"
-                aria-label="Attach a note to this evidence"
+                placeholder={t(RP.evNotePlaceholder)}
+                aria-label={t(RP.evNoteAria)}
                 autoFocus
                 style={{
                   flex: 1,
@@ -216,7 +220,7 @@ export function EvidenceCard({
                   borderRadius: 8
                 }}
               >
-                ADD
+                {t(RP.evAdd)}
               </button>
             </div>
           )}

--- a/apps/raven/components/research/iteration-block.tsx
+++ b/apps/raven/components/research/iteration-block.tsx
@@ -6,6 +6,8 @@
 // Finished rounds fold to a one-line receipt (Manus-style) while a newer
 // round is running; click the receipt to expand.
 
+import { sourcesLabel, useLocale, useT } from "../../lib/i18n";
+import { RS } from "../../lib/i18n/ui";
 import type { AnalystNote } from "../../lib/server/analyst";
 import { AnnoBar, MarkOverlay, type Mark } from "./annotation";
 import { EvidenceCard } from "./evidence-card";
@@ -29,9 +31,11 @@ function FoldChevron({ open }: { open: boolean }) {
 
 // One-line receipt for a folded (completed) iteration.
 function FoldedRow({ block, onToggle }: { block: BlockVM; onToggle?: () => void }) {
+  const t = useT();
+  const { locale } = useLocale();
   const n = block.evidence.length;
   return (
-    <section style={{ marginTop: 18 }} aria-label={`Iteration ${block.n} (folded)`}>
+    <section style={{ marginTop: 18 }} aria-label={t(RS.foldedAria, { n: block.n })}>
       <button
         type="button"
         className="rvp-fold"
@@ -61,7 +65,7 @@ function FoldedRow({ block, onToggle }: { block: BlockVM; onToggle?: () => void 
             color: "var(--faint)"
           }}
         >
-          Iteration
+          {t(RS.iterationWord)}
         </span>
         <span style={{ fontFamily: "var(--fd)", fontWeight: 600, fontSize: 15, color: "var(--accent)" }}>{block.n}</span>
         <span
@@ -75,7 +79,7 @@ function FoldedRow({ block, onToggle }: { block: BlockVM; onToggle?: () => void 
             minWidth: 0
           }}
         >
-          {block.status} · {n} source{n === 1 ? "" : "s"}
+          {block.status} · {sourcesLabel(n, locale)}
         </span>
         <span
           className={`mv-${block.moveDir}`}
@@ -94,9 +98,10 @@ function FoldedRow({ block, onToggle }: { block: BlockVM; onToggle?: () => void 
 // Small "already read" rows shown above the live shimmer — the trail of
 // sources the engine visited this round (Manus-style activity lines).
 function ReadTrail({ reads }: { reads: readonly ReadingVM[] }) {
+  const t = useT();
   if (reads.length === 0) return null;
   return (
-    <div style={{ marginTop: 12, display: "grid", gap: 6 }} aria-label="Sources visited this round">
+    <div style={{ marginTop: 12, display: "grid", gap: 6 }} aria-label={t(RS.trailAria)}>
       {reads.map((r, i) => (
         <div
           key={`${r.domain}-${i}`}
@@ -104,7 +109,7 @@ function ReadTrail({ reads }: { reads: readonly ReadingVM[] }) {
         >
           <CheckCircle size={11} />
           <span>
-            Read <b style={{ color: "var(--muted)", fontWeight: 600 }}>{r.domain}</b>
+            {t(RS.readWord)} <b style={{ color: "var(--muted)", fontWeight: 600 }}>{r.domain}</b>
           </span>
         </div>
       ))}
@@ -141,13 +146,14 @@ export function IterationBlock({
   onToggleCollapse?: () => void;
   recentReads?: readonly ReadingVM[]; // sources visited so far this round (live block only)
 }) {
+  const t = useT();
   const rMark = marks[block.reasoningId];
   if (collapsed) return <FoldedRow block={block} onToggle={onToggleCollapse} />;
   return (
     <section
       className={animatedIds?.has(`it${block.n}`) ? "rv-reveal" : undefined}
       style={{ marginTop: 26 }}
-      aria-label={`Iteration ${block.n}`}
+      aria-label={`${t(RS.iterationWord)} ${block.n}`}
     >
       <div
         style={{
@@ -167,7 +173,7 @@ export function IterationBlock({
             color: "var(--faint)"
           }}
         >
-          Iteration
+          {t(RS.iterationWord)}
         </span>
         <span style={{ fontFamily: "var(--fd)", fontWeight: 600, fontSize: 20, color: "var(--accent)" }}>
           {block.n}
@@ -185,7 +191,7 @@ export function IterationBlock({
             className="rvp-fold"
             onClick={onToggleCollapse}
             aria-expanded={true}
-            aria-label={`Fold iteration ${block.n}`}
+            aria-label={t(RS.foldAria, { n: block.n })}
             style={{
               background: "none",
               border: "none",
@@ -203,7 +209,7 @@ export function IterationBlock({
       <div
         className="anno"
         tabIndex={0}
-        aria-label={`Raven's reasoning — iteration ${block.n}`}
+        aria-label={`${t(RS.reasoningLabel)} — ${block.n}`}
         style={{ position: "relative", marginTop: 12, padding: "11px 13px", borderRadius: 10, outline: "none" }}
       >
         {rMark && <MarkOverlay mark={rMark} variant="note" />}
@@ -223,11 +229,11 @@ export function IterationBlock({
               color: "var(--faint)"
             }}
           >
-            Raven's reasoning
+            {t(RS.reasoningLabel)}
           </span>
           {block.analystFolded > 0 && (
             <span
-              title="Your queued notes were injected into this round's research prompt"
+              title={t(RS.pushbackTitle)}
               style={{
                 fontFamily: "var(--fm)",
                 fontSize: 8.5,
@@ -241,7 +247,7 @@ export function IterationBlock({
                 padding: "1px 6px"
               }}
             >
-              ↳ analyst pushback folded in ({block.analystFolded})
+              {t(RS.pushbackChip, { n: block.analystFolded })}
             </span>
           )}
         </div>
@@ -292,7 +298,7 @@ export function IterationBlock({
             <div style={{ fontFamily: "var(--fm)", fontSize: 11, color: "var(--muted)" }}>
               {block.reading.domain ? (
                 <>
-                  Reading <b style={{ color: "var(--text)" }}>{block.reading.domain}</b>
+                  {t(RS.readingWord)} <b style={{ color: "var(--text)" }}>{block.reading.domain}</b>
                   {block.reading.text}
                 </>
               ) : (

--- a/apps/raven/components/research/plan.tsx
+++ b/apps/raven/components/research/plan.tsx
@@ -5,6 +5,8 @@
 // and PlanList renders the live checklist — steps check off as the run
 // advances, joined by a dashed connector.
 
+import { useT } from "../../lib/i18n";
+import { RS } from "../../lib/i18n/ui";
 import type { PlanStepVM } from "./research-vm";
 
 export function RavenMessage({
@@ -16,8 +18,9 @@ export function RavenMessage({
   time: string | null;
   children: React.ReactNode;
 }) {
+  const t = useT();
   return (
-    <section style={{ marginTop: 24 }} aria-label="Raven's message">
+    <section style={{ marginTop: 24 }} aria-label={t(RS.messageAria)}>
       <div style={{ display: "flex", alignItems: "center", gap: 9 }}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
@@ -105,8 +108,9 @@ function StepMarker({ state }: { state: PlanStepVM["state"] }) {
 }
 
 export function PlanList({ steps, compact = false }: { steps: readonly PlanStepVM[]; compact?: boolean }) {
+  const t = useT();
   return (
-    <ol style={{ listStyle: "none", margin: 0, padding: 0 }} aria-label="Run plan">
+    <ol style={{ listStyle: "none", margin: 0, padding: 0 }} aria-label={t(RS.planAria)}>
       {steps.map((s, i) => (
         <li key={s.key} className="pl-row" style={{ display: "grid", gridTemplateColumns: "15px 1fr", columnGap: 11 }}>
           <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>

--- a/apps/raven/components/research/progress-dock.tsx
+++ b/apps/raven/components/research/progress-dock.tsx
@@ -6,6 +6,8 @@
 
 import Link from "next/link";
 import { useState } from "react";
+import { useT } from "../../lib/i18n";
+import { RS } from "../../lib/i18n/ui";
 import { PlanList } from "./plan";
 import { planStepNo, type PlanStepVM } from "./research-vm";
 
@@ -47,6 +49,7 @@ export function ProgressDock({
   ctaHref: string | null; // dossier link, shown when the run is complete
   elapsed?: string | null; // live run clock, e.g. "05m 12s"
 }) {
+  const t = useT();
   const [expanded, setExpanded] = useState(false);
   const stepNo = planStepNo(steps);
 
@@ -99,14 +102,14 @@ export function ProgressDock({
               padding: "7px 12px"
             }}
           >
-            Read the dossier →
+            {t(RS.dockCta)}
           </Link>
         )}
         <button
           type="button"
           onClick={() => setExpanded((v) => !v)}
           aria-expanded={expanded}
-          aria-label={expanded ? "Hide the run plan" : "Show the run plan"}
+          aria-label={expanded ? t(RS.dockHidePlan) : t(RS.dockShowPlan)}
           style={{
             flex: "none",
             cursor: "pointer",

--- a/apps/raven/components/research/research-vm.ts
+++ b/apps/raven/components/research/research-vm.ts
@@ -3,6 +3,8 @@
 // list, reading line, queue rows and axis numbers the components render.
 
 import type { JobInfo } from "../../lib/client/use-forecast";
+import { render, sourcesLabel, type Locale } from "../../lib/i18n";
+import { RS } from "../../lib/i18n/ui";
 import type { AnalystNote, AnalystStance } from "../../lib/server/analyst";
 import { arrowFor, cap, diamondsFor, dirFor, domainOf } from "../../lib/vm/format";
 import type { DossierVM, EvidenceVM, IterationVM, NetDir } from "../../lib/vm/types";
@@ -29,7 +31,8 @@ export interface ReadingVM {
 export interface BlockVM {
   n: string;
   reasoningId: string; // mark id for the reasoning paragraph ("r1", "r2", …)
-  status: string;
+  status: string; // localized "complete · 38% → 30%" line
+  span: string; // raw "{from} → {to}" (locale-independent, reused by the plan)
   move: string;
   moveDir: NetDir;
   note: string;
@@ -72,7 +75,7 @@ export const DEMO_TRAIL: ReadingVM[] = [
   { domain: "resetera.com", text: "" }
 ];
 
-export function buildDemoBlocks(demo: DossierVM): BlockVM[] {
+export function buildDemoBlocks(demo: DossierVM, locale: Locale): BlockVM[] {
   const it1 = demo.iterations[0];
   const it2 = demo.iterations[1];
   if (!it1 || !it2) return [];
@@ -80,7 +83,8 @@ export function buildDemoBlocks(demo: DossierVM): BlockVM[] {
     {
       n: "01",
       reasoningId: "r1",
-      status: "complete · 38% → 30%",
+      status: render(RS.statusCompleteSpan, locale, { from: "38%", to: "30%" }),
+      span: "38% → 30%",
       move: "▼ 8%",
       moveDir: "down",
       note: it1.note,
@@ -91,8 +95,9 @@ export function buildDemoBlocks(demo: DossierVM): BlockVM[] {
     {
       n: "02",
       reasoningId: "r2",
-      status: "running · 30% → 18% so far",
-      move: "▼ 12% so far",
+      status: render(RS.statusRunningSpan, locale, { from: "30%", to: "18%" }),
+      span: "30% → 18%",
+      move: render(RS.moveSoFar, locale, { arrow: "▼", net: "12%" }),
       moveDir: "down",
       note: DEMO_IT2_NOTE,
       evidence: it2.evidence.slice(0, 2).map((e, i) => decorateEvidence(e, i + 5)),
@@ -104,18 +109,25 @@ export function buildDemoBlocks(demo: DossierVM): BlockVM[] {
 
 // --- live runs ---
 
-export function buildLiveBlocks(iterations: IterationVM[], running: boolean, reading: ReadingVM | null): BlockVM[] {
+export function buildLiveBlocks(
+  iterations: IterationVM[],
+  running: boolean,
+  reading: ReadingVM | null,
+  locale: Locale
+): BlockVM[] {
   let k = 0;
   return iterations.map((it, i) => {
     const isRunning = running && i === iterations.length - 1;
     const netArrow = it.netDir === "down" ? "▼" : it.netDir === "up" ? "▲" : "—";
     const round = Number.parseInt(it.n, 10);
     const evidence = it.evidence.map((e) => decorateEvidence(e, k++));
+    const spanVars = { from: it.from, to: it.to };
     return {
       n: it.n,
       reasoningId: `r${Number.isFinite(round) && round > 0 ? round : i + 1}`,
-      status: isRunning ? `running · ${it.from} → ${it.to} so far` : `complete · ${it.from} → ${it.to}`,
-      move: isRunning ? `${netArrow} ${it.net} so far` : `${netArrow} ${it.net}`,
+      status: isRunning ? render(RS.statusRunningSpan, locale, spanVars) : render(RS.statusCompleteSpan, locale, spanVars),
+      span: `${it.from} → ${it.to}`,
+      move: isRunning ? render(RS.moveSoFar, locale, { arrow: netArrow, net: it.net }) : `${netArrow} ${it.net}`,
       moveDir: it.netDir,
       note: it.note,
       evidence,
@@ -127,11 +139,14 @@ export function buildLiveBlocks(iterations: IterationVM[], running: boolean, rea
 
 // Derive the "Reading <domain> — …" status from the engine's last log line;
 // fall back to a per-provider generic when the line carries no URL.
-export function readingFromJob(job: Pick<JobX, "log" | "provider"> | null): ReadingVM {
+export function readingFromJob(job: Pick<JobX, "log" | "provider"> | null, locale: Locale): ReadingVM {
   const lastLine = job?.log[job.log.length - 1] ?? "";
   const urlMatch = lastLine.match(/https?:\/\/[^\s"'<>)\]]+/);
-  if (urlMatch) return { domain: domainOf(urlMatch[0]), text: " — weighing what it changes…" };
-  return { domain: null, text: job?.provider === "deepseek" ? "weighing evidence…" : "searching for new evidence…" };
+  if (urlMatch) return { domain: domainOf(urlMatch[0]), text: render(RS.readingTailWeighing, locale) };
+  return {
+    domain: null,
+    text: job?.provider === "deepseek" ? render(RS.readingTailEvidence, locale) : render(RS.readingTailSearching, locale)
+  };
 }
 
 export function nextRoundFor(shownIterations: number, maxRounds: number): number {
@@ -159,14 +174,18 @@ export function buildPlanSteps(args: {
   running: boolean;
   complete: boolean;
   prior: string | null;
+  locale: Locale;
 }): PlanStepVM[] {
-  const { framing, blocks, maxRounds, running, complete, prior } = args;
+  const { framing, blocks, maxRounds, running, complete, prior, locale } = args;
   const frameActive = framing || (running && blocks.length === 0);
   const steps: PlanStepVM[] = [
     {
       key: "frame",
-      label: "Frame the question",
-      sub: !frameActive && prior ? `checkable yes/no · prior ${prior}` : "resolution criteria + base-rate prior",
+      label: render(RS.frameLabel, locale),
+      sub:
+        !frameActive && prior
+          ? render(RS.frameSubDone, locale, { prior })
+          : render(RS.frameSubPending, locale),
       state: frameActive ? "active" : "done"
     }
   ];
@@ -176,26 +195,27 @@ export function buildPlanSteps(args: {
     if (!block) {
       steps.push({
         key: `round-${k}`,
-        label: `Research round ${k}`,
-        sub: k === 1 ? "gather the first evidence" : "hunt for evidence that cuts the other way",
+        label: render(RS.roundLabel, locale, { k }),
+        sub: render(k === 1 ? RS.roundSubFirst : RS.roundSubLater, locale),
         state: "pending"
       });
       continue;
     }
     const live = running && k === blocks.length;
-    const span = block.status.replace(/^(complete|running) · /, "");
     const n = block.evidence.length;
     steps.push({
       key: `round-${k}`,
-      label: `Research round ${k}`,
-      sub: live ? `gathering evidence · ${span}` : `${n} source${n === 1 ? "" : "s"} · ${span}`,
+      label: render(RS.roundLabel, locale, { k }),
+      sub: live
+        ? render(RS.roundSubLive, locale, { span: block.span })
+        : render(RS.roundSubDone, locale, { sources: sourcesLabel(n, locale), span: block.span }),
       state: live ? "active" : "done"
     });
   }
   steps.push({
     key: "verdict",
-    label: "Weigh signals, deliver the verdict",
-    sub: complete ? "dossier ready" : "P(YES) + confidence + open risks",
+    label: render(RS.verdictLabel, locale),
+    sub: complete ? render(RS.verdictSubDone, locale) : render(RS.verdictSubPending, locale),
     state: complete ? "done" : "pending"
   });
   return steps;
@@ -228,9 +248,9 @@ export interface QueuedVM {
 // Dot colors are lean-relative (green = pushes toward the current lean,
 // red = pushes against it), matching the evidence side encoding. On the
 // NO-leaning demo, "Pushes NO" is green — same as the design.
-function stanceMeta(stance: AnalystStance, leanYes: boolean): { label: string; dot: string } {
-  if (stance === "question") return { label: "Open question", dot: "var(--val)" };
-  const label = stance === "yes" ? "Pushes YES" : "Pushes NO";
+function stanceMeta(stance: AnalystStance, leanYes: boolean, locale: Locale): { label: string; dot: string } {
+  if (stance === "question") return { label: render(RS.stanceQuestion, locale), dot: "var(--val)" };
+  const label = stance === "yes" ? render(RS.stancePushYes, locale) : render(RS.stancePushNo, locale);
   const towardLean = (stance === "yes") === leanYes;
   return { label, dot: towardLean ? "var(--pos)" : "var(--neg)" };
 }
@@ -241,20 +261,21 @@ export function buildQueued(
   allIterations: readonly IterationVM[],
   nextRound: number,
   complete: boolean,
-  leanYes: boolean
+  leanYes: boolean,
+  locale: Locale
 ): QueuedVM[] {
   const shown = blocks.flatMap((b) => b.evidence);
   const targetLabelFor = (targetId: string | null): string => {
-    if (!targetId) return "General";
+    if (!targetId) return render(RS.targetGeneral, locale);
     const row = shown.find((e) => e.id === targetId);
-    if (row) return `on evidence ${row.idx}`;
+    if (row) return render(RS.targetOnEvidence, locale, { idx: row.idx });
     const anywhere = allIterations.flatMap((it) => it.evidence).find((e) => e.id === targetId);
     return anywhere ? anywhere.dom : targetId;
   };
   return [...notes]
     .sort((a, b) => (a.createdAtUtc < b.createdAtUtc ? 1 : a.createdAtUtc > b.createdAtUtc ? -1 : 0))
     .map((n) => {
-      const meta = stanceMeta(n.stance, leanYes);
+      const meta = stanceMeta(n.stance, leanYes, locale);
       const folded = n.consumedRound !== null && n.consumedRound !== undefined;
       return {
         id: n.id,
@@ -263,10 +284,10 @@ export function buildQueued(
         dotColor: meta.dot,
         targetLabel: targetLabelFor(n.targetId),
         tagText: folded
-          ? `FOLDED INTO IT ${String(n.consumedRound).padStart(2, "0")}`
+          ? render(RS.tagFolded, locale, { n: String(n.consumedRound).padStart(2, "0") })
           : complete
-            ? "SAVED"
-            : `QUEUED · IT ${nextRound}`,
+            ? render(RS.tagSaved, locale)
+            : render(RS.tagQueued, locale, { n: nextRound }),
         tagColor: folded || complete ? "var(--verified)" : "var(--accent)",
         removable: !folded
       };

--- a/apps/raven/components/research/state-cards.tsx
+++ b/apps/raven/components/research/state-cards.tsx
@@ -6,11 +6,14 @@
 // progress dock (plan.tsx / progress-dock.tsx).
 
 import Link from "next/link";
+import { useT } from "../../lib/i18n";
+import { RP } from "../../lib/i18n/research-parts";
 import { ShimmerBar } from "./shimmer";
 
 // Shown while the engine is still framing (job running, dossier not yet
 // written): a full-width shimmer skeleton in place of the iteration feed.
 export function FramingBlock() {
+  const t = useT();
   return (
     <div
       style={{
@@ -36,8 +39,9 @@ export function FramingBlock() {
       />
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{ fontFamily: "var(--fm)", fontSize: 11, color: "var(--muted)" }}>
-          Now: <b style={{ color: "var(--text)" }}>framing</b> — normalizing the question, pinning resolution
-          criteria, setting a base-rate prior
+          {t(RP.framingNow)}
+          <b style={{ color: "var(--text)" }}>{t(RP.framingBold)}</b>
+          {t(RP.framingRest)}
         </div>
         <ShimmerBar style={{ marginTop: 12 }} />
         <ShimmerBar style={{ marginTop: 6, width: "84%" }} />
@@ -60,6 +64,7 @@ export function NoticeCard({
   inline?: boolean; // rendered inside the feed (above iterations) vs centered
   children: React.ReactNode;
 }) {
+  const t = useT();
   return (
     <div
       style={{
@@ -119,7 +124,7 @@ export function NoticeCard({
             textDecoration: "none"
           }}
         >
-          ← Back to Ask
+          {t(RP.backToAsk)}
         </Link>
       )}
     </div>
@@ -127,10 +132,11 @@ export function NoticeCard({
 }
 
 export function LoadingBlock() {
+  const t = useT();
   return (
-    <div style={{ maxWidth: 640, margin: "48px auto 0" }} role="status" aria-label="Loading the run">
+    <div style={{ maxWidth: 640, margin: "48px auto 0" }} role="status" aria-label={t(RP.loadingAria)}>
       <div style={{ fontFamily: "var(--fm)", fontSize: 11, color: "var(--muted)", marginBottom: 12 }}>
-        Loading the run…
+        {t(RP.loadingText)}
       </div>
       <ShimmerBar />
       <ShimmerBar style={{ marginTop: 6, width: "78%" }} />

--- a/apps/raven/components/research/status-strip.tsx
+++ b/apps/raven/components/research/status-strip.tsx
@@ -5,6 +5,8 @@
 // Layout classes (rvp-strip / rvp-quant / rvp-numblock / rvp-num) live in
 // research.css so the mobile breakpoint can restack them.
 
+import { useT } from "../../lib/i18n";
+import { RP } from "../../lib/i18n/research-parts";
 import { arrowFor, dirFor } from "../../lib/vm/format";
 import { axisScaleFor } from "./research-vm";
 
@@ -28,6 +30,7 @@ export function StatusStrip({
   now: NowLine | null;
   quant: QuantVM | null;
 }) {
+  const t = useT();
   return (
     <div className="rvp-strip">
       <div>
@@ -57,7 +60,8 @@ export function StatusStrip({
               }}
             />
             <span>
-              Now: <b style={{ color: "var(--text)" }}>{now.bold}</b>
+              {t(RP.stripNow)}
+              <b style={{ color: "var(--text)" }}>{now.bold}</b>
               {now.rest}
             </span>
           </div>
@@ -69,6 +73,7 @@ export function StatusStrip({
 }
 
 function QuantBlock({ quant }: { quant: QuantVM }) {
+  const t = useT();
   const { nowPct, priorPct, label } = quant;
   const d = nowPct - priorPct;
   const scale = axisScaleFor(priorPct, nowPct);
@@ -103,7 +108,7 @@ function QuantBlock({ quant }: { quant: QuantVM }) {
           </span>
         </div>
         <div style={{ fontFamily: "var(--fm)", fontSize: 10, color: "var(--faint)", marginTop: 6 }}>
-          from the {priorPct}% prior
+          {t(RP.stripFromPrior, { prior: priorPct })}
         </div>
       </div>
       <div style={{ width: 190, paddingBottom: 4, flex: "none" }}>
@@ -177,8 +182,8 @@ function QuantBlock({ quant }: { quant: QuantVM }) {
             marginTop: 6
           }}
         >
-          <span style={{ color: "var(--accent)" }}>now {nowPct}%</span>
-          <span>prior {priorPct}%</span>
+          <span style={{ color: "var(--accent)" }}>{t(RP.stripAxisNow, { n: nowPct })}</span>
+          <span>{t(RP.stripAxisPrior, { n: priorPct })}</span>
         </div>
       </div>
     </div>

--- a/apps/raven/components/research/verdict-digest.tsx
+++ b/apps/raven/components/research/verdict-digest.tsx
@@ -5,6 +5,8 @@
 // document-attachment card linking to the full dossier (Screen 03).
 
 import Link from "next/link";
+import { confidenceLabel, sourcesLabel, useLocale, useT, verdictLabel } from "../../lib/i18n";
+import { RS } from "../../lib/i18n/ui";
 import type { DossierVM } from "../../lib/vm/types";
 import { arrowFor, dirFor } from "../../lib/vm/format";
 import { RavenMessage } from "./plan";
@@ -32,6 +34,8 @@ function StatChip({ children, className }: { children: React.ReactNode; classNam
 }
 
 export function VerdictDigest({ id, dossier }: { id: string; dossier: DossierVM }) {
+  const t = useT();
+  const { locale } = useLocale();
   const m = dossier.meta;
   const deltaPts =
     dossier.currentProb !== null && dossier.priorProb !== null
@@ -44,7 +48,7 @@ export function VerdictDigest({ id, dossier }: { id: string; dossier: DossierVM 
       <RavenMessage provider={dossier.provider} time={m.duration}>
         <p style={{ margin: 0, fontSize: 13.5, lineHeight: 1.6, color: "var(--muted)" }}>
           <b style={{ color: "var(--text)" }}>
-            Forecast complete — P(YES) {m.prob}, {m.verdict.toLowerCase()}.
+            {t(RS.digestLead, { p: m.prob, verdict: locale === "zh" ? verdictLabel(m.verdict, locale) : m.verdict.toLowerCase() })}
           </b>{" "}
           {m.why}
         </p>
@@ -54,14 +58,14 @@ export function VerdictDigest({ id, dossier }: { id: string; dossier: DossierVM 
               <span className={`mv-${dirFor(deltaPts)}`}>
                 {arrowFor(deltaPts)} {Math.abs(deltaPts)}%
               </span>
-              vs the {m.prior} prior
+              {t(RS.chipVsPrior, { prior: m.prior })}
             </StatChip>
           )}
           {/* No credibleInterval chip here: per user decision 2026-07-02 the
               engine's interval is an uncalibrated heuristic and must not be
               presented on user-facing surfaces. */}
-          <StatChip>{m.sources} sources</StatChip>
-          <StatChip>confidence {m.confidence}</StatChip>
+          <StatChip>{sourcesLabel(m.sources, locale)}</StatChip>
+          <StatChip>{t(RS.chipConfidence, { c: confidenceLabel(m.confidence, locale) })}</StatChip>
         </div>
 
         <Link
@@ -107,7 +111,7 @@ export function VerdictDigest({ id, dossier }: { id: string; dossier: DossierVM 
           </span>
           <span style={{ minWidth: 0 }}>
             <span style={{ display: "block", fontFamily: "var(--fd)", fontWeight: 600, fontSize: 15, lineHeight: 1.35 }}>
-              Dossier — {m.question}
+              {t(RS.cardTitle, { q: m.question })}
             </span>
             <span
               style={{
@@ -119,7 +123,7 @@ export function VerdictDigest({ id, dossier }: { id: string; dossier: DossierVM 
                 color: "var(--faint)"
               }}
             >
-              {m.verdict} · P(YES) {m.prob} · evidence book · resolution criteria
+              {t(RS.cardSub, { verdict: verdictLabel(m.verdict, locale), p: m.prob })}
             </span>
             <span
               className="rvd-clamp"
@@ -140,7 +144,7 @@ export function VerdictDigest({ id, dossier }: { id: string; dossier: DossierVM 
               marginTop: 3
             }}
           >
-            READ →
+            {t(RS.cardRead)}
           </span>
         </Link>
       </RavenMessage>

--- a/apps/raven/lib/i18n/home.ts
+++ b/apps/raven/lib/i18n/home.ts
@@ -1,0 +1,57 @@
+// Home (Ask) screen dictionary. Entries are passed straight to t() from
+// app/page.tsx; engine-produced words (verdict / confidence / source counts)
+// are localized by the label helpers in ./index, not duplicated here.
+// Data-borne content (question texts, quips, dossier copy) is never
+// translated — labels only.
+
+import type { Entry } from "./index";
+
+export const HOME = {
+  researchPreview: { en: "RESEARCH PREVIEW", zh: "研究预览" },
+  mascotAlt: {
+    en: "Raven, a hooded crow holding a glowing orb",
+    zh: "Raven——一只捧着发光宝珠的乌鸦"
+  },
+  heroTitleAccent: { en: "Forecasting Engine", zh: "预测引擎" },
+  heroLede: {
+    en: "Ask a hard yes-or-no question about the future. Raven frames it precisely, researches it in adversarial rounds, and returns a probability — with every source that moved it laid out in reading order.",
+    zh: "提出一个关于未来的是非题。Raven 会精确定题，做对抗式多轮研究，最后给出一个概率——每条影响结论的来源都按阅读顺序列出。"
+  },
+  askPlaceholder: { en: "Will … happen by …?", zh: "……会在……之前发生吗？" },
+  askAriaLabel: { en: "Forecast question", zh: "预测问题" },
+  submitIdle: { en: "Forecast it", zh: "开始预测" },
+  submitBusy: { en: "Framing…", zh: "定题中…" },
+  requestFailed: { en: "request failed ({status})", zh: "请求失败（{status}）" },
+  hintPrefix: {
+    en: "Works best with a deadline and a checkable outcome — try",
+    zh: "带明确截止日期、结果可核查的问题效果最好——试试"
+  },
+  exampleChip: {
+    en: "Will the GTA 6 launch slip past November 19, 2026?",
+    zh: "GTA 6 发售会推迟到 2026 年 11 月 19 日之后吗？"
+  },
+  latestDossier: { en: "Latest dossier", zh: "最新档案" },
+  liveRun: { en: "LIVE — {question}", zh: "进行中 — {question}" },
+  confidenceMeta: { en: "{level} confidence", zh: "{level}置信度" },
+  resolvesOn: { en: "resolves {date}", zh: "{date} 结算" },
+  readDossier: { en: "Read the dossier", zh: "阅读档案" },
+  watchRun: { en: "Watch the run", zh: "查看运行过程" },
+  step1Kicker: { en: "01 · FRAME", zh: "01 · 定题" },
+  step1Title: { en: "The question is pinned down", zh: "把问题钉死" },
+  step1Body: {
+    en: "Normalized into something checkable — exact date, exact resolution criteria — and given an honest base-rate prior.",
+    zh: "改写成可核查的形式——精确到日期与判定标准——并给出诚实的基准率先验。"
+  },
+  step2Kicker: { en: "02 · RESEARCH", zh: "02 · 研究" },
+  step2Title: { en: "Adversarial rounds", zh: "对抗式多轮研究" },
+  step2Body: {
+    en: "Gather evidence, weigh its credibility and value, then hunt for whatever would prove the current lean wrong. You can push back mid-run.",
+    zh: "收集证据，衡量可信度与价值，再主动寻找能推翻当前倾向的反证。运行中你可以随时质疑。"
+  },
+  step3Kicker: { en: "03 · VERDICT", zh: "03 · 判决" },
+  step3Title: { en: "A number you can audit", zh: "一个可审计的数字" },
+  step3Body: {
+    en: "One probability with its confidence band — and every source that moved it, in reading order, line by line.",
+    zh: "一个概率，附置信度——以及每条改变它的来源，按阅读顺序逐条列出。"
+  }
+} satisfies Record<string, Entry>;

--- a/apps/raven/lib/i18n/index.tsx
+++ b/apps/raven/lib/i18n/index.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+// Minimal locale layer for the Raven app: a context provider (persisted to
+// localStorage, same pattern as the theme toggle), a `useT` hook that renders
+// an Entry in the active locale with {var} interpolation, and tier/verdict
+// label maps for engine-produced English words.
+//
+// Entries are plain objects passed directly to t() — no central key registry,
+// so domain dictionaries (core/home/verdict) can't collide and TS checks
+// existence at the call site.
+
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
+
+export type Locale = "en" | "zh";
+
+export interface Entry {
+  en: string;
+  zh: string;
+}
+
+const STORE_KEY = "raven-locale";
+
+const LocaleCtx = createContext<{ locale: Locale; setLocale: (l: Locale) => void }>({
+  locale: "en",
+  setLocale: () => undefined
+});
+
+export function LocaleProvider({ children }: { children: React.ReactNode }) {
+  const [locale, setLocaleState] = useState<Locale>("en");
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(STORE_KEY);
+      if (saved === "zh") setLocaleState("zh");
+    } catch {
+      /* private mode etc. — stay en */
+    }
+  }, []);
+  const setLocale = useCallback((l: Locale) => {
+    setLocaleState(l);
+    try {
+      localStorage.setItem(STORE_KEY, l);
+    } catch {
+      /* non-persistent is fine */
+    }
+  }, []);
+  return <LocaleCtx.Provider value={{ locale, setLocale }}>{children}</LocaleCtx.Provider>;
+}
+
+export function useLocale(): { locale: Locale; setLocale: (l: Locale) => void } {
+  return useContext(LocaleCtx);
+}
+
+export type TFn = (entry: Entry, vars?: Record<string, string | number>) => string;
+
+export function render(entry: Entry, locale: Locale, vars?: Record<string, string | number>): string {
+  let s = entry[locale];
+  if (vars) {
+    for (const [k, v] of Object.entries(vars)) s = s.replaceAll(`{${k}}`, String(v));
+  }
+  return s;
+}
+
+export function useT(): TFn {
+  const { locale } = useLocale();
+  return useCallback((entry: Entry, vars?: Record<string, string | number>) => render(entry, locale, vars), [locale]);
+}
+
+// --- engine-word localization (adapter emits English; display maps it) ---
+
+const VERDICT_ZH: Record<string, string> = {
+  "Very unlikely": "基本不会",
+  Unlikely: "不太可能",
+  "Leaning no": "偏否",
+  "Too close to call": "五五开",
+  "Leaning yes": "偏是",
+  Likely: "很可能",
+  "Very likely": "几乎确定"
+};
+
+export function verdictLabel(verdict: string, locale: Locale): string {
+  return locale === "zh" ? (VERDICT_ZH[verdict] ?? verdict) : verdict;
+}
+
+const CONF_ZH: Record<string, string> = { high: "高", medium: "中", low: "低" };
+
+export function confidenceLabel(conf: string, locale: Locale): string {
+  return locale === "zh" ? (CONF_ZH[conf] ?? conf) : conf;
+}
+
+// Tier words as decorated by the VM ("High" | "Med" | "Low").
+const TIER_ZH: Record<string, string> = { High: "高", Med: "中", Low: "低" };
+
+export function tierWord(tier: string, locale: Locale): string {
+  return locale === "zh" ? (TIER_ZH[tier] ?? tier) : tier;
+}
+
+export function sourcesLabel(n: number | string, locale: Locale): string {
+  if (locale === "zh") return `${n} 个来源`;
+  return `${n} source${Number(n) === 1 ? "" : "s"}`;
+}

--- a/apps/raven/lib/i18n/research-parts.ts
+++ b/apps/raven/lib/i18n/research-parts.ts
@@ -1,0 +1,85 @@
+// Dictionary for the research-screen subcomponents: analyst desk, annotation
+// toolbar/overlays, evidence cards, non-feed state cards and the status strip.
+// Labels only — data-borne strings (takeaways, analysis text, note bodies,
+// queued-row labels) are rendered exactly as passed.
+
+import type { Entry } from "./index";
+
+export const RP = {
+  // --- analyst desk ---
+  deskTitle: { en: "Analyst desk", zh: "分析师工作台" },
+  // Helper copy is split around the inline <b> segment: pre + bold + post.
+  deskHelpRunPre: {
+    en: "Queue a hypothesis or a lead. Raven treats each one as a claim to test in ",
+    zh: "排入一个假设或线索。Raven 会把每一条当作待检验的论断，在"
+  },
+  deskHelpRunBold: { en: "iteration {n}", zh: "第 {n} 轮" },
+  deskHelpRunPost: { en: ".", zh: "验证。" },
+  deskHelpDonePre: {
+    en: "Queue a hypothesis or a lead. The run is complete, so notes are ",
+    zh: "排入一个假设或线索。本次运行已完成，笔记将"
+  },
+  deskHelpDoneBold: { en: "saved with the dossier", zh: "随档案保存" },
+  deskHelpDonePost: { en: ".", zh: "。" },
+  deskPlaceholder: {
+    en: "e.g. Check retailer supply-chain listings — physical stock timelines would confirm the date better than press.",
+    zh: "例如：查零售商供应链上架记录——实体备货时间线比新闻稿更能确认日期。"
+  },
+  deskComposerAria: { en: "Queue a hypothesis or a lead", zh: "排入假设或线索" },
+  deskStanceAria: { en: "How this note pushes the forecast", zh: "这条笔记对预测的推动方向" },
+  stanceYes: { en: "PUSHES YES", zh: "推向 YES" },
+  stanceNo: { en: "PUSHES NO", zh: "推向 NO" },
+  stanceQuestion: { en: "QUESTION", zh: "疑问" },
+  deskSubmitQueue: { en: "Queue for iteration {n}", zh: "排入第 {n} 轮" },
+  deskSubmitSave: { en: "Save note for the dossier", zh: "保存笔记到档案" },
+  deskQueuedHeading: { en: "Queued · {nn}", zh: "已排入 · {nn}" },
+  deskQueuedEmpty: {
+    en: "Nothing queued yet. Your circles, strikes and notes land here — and in Raven's next research round.",
+    zh: "暂无排入内容。你的圈住、存疑和笔记会汇集到这里，并进入 Raven 的下一轮研究。"
+  },
+  deskRemoveTitle: { en: "Remove", zh: "移除" },
+  deskRemoveAria: { en: "Remove this note", zh: "移除这条笔记" },
+
+  // --- annotation overlays + hover toolbar ---
+  annoKept: { en: "KEPT", zh: "已圈住" },
+  annoDoubted: { en: "DOUBTED", zh: "已存疑" },
+  annoKeep: { en: "KEEP", zh: "圈住" },
+  annoDoubt: { en: "DOUBT", zh: "存疑" },
+  annoNote: { en: "+ NOTE", zh: "+ 笔记" },
+  annoKeepAria: { en: "Keep this {subject}", zh: "圈住这条{subject}" },
+  annoDoubtAria: { en: "Doubt this {subject}", zh: "对这条{subject}存疑" },
+  annoNoteAria: { en: "Attach a note", zh: "附加笔记" },
+  // Subject words for the aria-labels above ({subject} slot).
+  subjectEvidence: { en: "evidence", zh: "证据" },
+  subjectReasoning: { en: "reasoning", zh: "推理" },
+
+  // --- evidence card ---
+  evAria: { en: "Evidence {idx}: {title}", zh: "证据 {idx}：{title}" },
+  evRevises: { en: "↻ Revises a prior source", zh: "↻ 修正先前来源" },
+  evCredTitle: { en: "How trustworthy the source is", zh: "来源的可信程度" },
+  evCredPill: { en: "{tier} credibility", zh: "可信度{tier}" },
+  evValueTitle: { en: "How much this source adds to the forecast", zh: "该来源对预测的增益程度" },
+  evValuePill: { en: "{tier} value", zh: "价值{tier}" },
+  evYourNote: { en: "Your note", zh: "你的笔记" },
+  evNotePlaceholder: { en: "Attach a note to this evidence…", zh: "给这条证据附加笔记…" },
+  evNoteAria: { en: "Attach a note to this evidence", zh: "给这条证据附加笔记" },
+  evAdd: { en: "ADD", zh: "添加" },
+
+  // --- state cards (framing skeleton / loading / notice) ---
+  // Framing line is split around the inline <b> segment: prefix + bold + rest.
+  framingNow: { en: "Now: ", zh: "当前：" },
+  framingBold: { en: "framing", zh: "界定问题" },
+  framingRest: {
+    en: " — normalizing the question, pinning resolution criteria, setting a base-rate prior",
+    zh: "——规范化问题、锁定结算标准、设定基准率先验"
+  },
+  loadingAria: { en: "Loading the run", zh: "正在加载本次运行" },
+  loadingText: { en: "Loading the run…", zh: "正在加载本次运行…" },
+  backToAsk: { en: "← Back to Ask", zh: "← 返回提问" },
+
+  // --- status strip ---
+  stripNow: { en: "Now: ", zh: "当前：" },
+  stripFromPrior: { en: "from the {prior}% prior", zh: "较先验 {prior}%" },
+  stripAxisNow: { en: "now {n}%", zh: "现值 {n}%" },
+  stripAxisPrior: { en: "prior {n}%", zh: "先验 {n}%" }
+} satisfies Record<string, Entry>;

--- a/apps/raven/lib/i18n/ui.ts
+++ b/apps/raven/lib/i18n/ui.ts
@@ -1,0 +1,162 @@
+// Dictionary for the shared chrome (rv-shell) and the research screen's
+// orchestration layer (page, view-model builders, iteration block, progress
+// dock, verdict digest). Subcomponent dictionaries live in home.ts /
+// verdict.ts / research-parts.ts.
+
+import type { Entry } from "./index";
+
+export const CHROME = {
+  navAsk: { en: "01 · Ask", zh: "01 · 提问" },
+  navResearch: { en: "02 · Research", zh: "02 · 研究" },
+  navVerdict: { en: "03 · Verdict", zh: "03 · 判决" },
+  footerInstrument: {
+    en: "Raven is a research instrument — probabilities with sources, not advice.",
+    zh: "Raven 是研究工具——给出带来源的概率，不构成建议。"
+  },
+  footerMarketBlind: {
+    en: "No prediction-market or betting data is used as evidence.",
+    zh: "不使用任何预测市场或博彩数据作为证据。"
+  },
+  themeLight: { en: "LIGHT", zh: "浅色" },
+  themeDark: { en: "DARK", zh: "深色" },
+  themeToLight: { en: "Switch to light theme", zh: "切换到浅色主题" },
+  themeToDark: { en: "Switch to dark theme", zh: "切换到深色主题" },
+  langSwitch: { en: "中文", zh: "EN" },
+  langSwitchTitle: { en: "切换到中文界面", zh: "Switch to English" }
+} satisfies Record<string, Entry>;
+
+export const RS = {
+  // --- plan message ---
+  planIntroA: {
+    en: "On it. I'll pin this down to a checkable yes-or-no question with a base-rate prior, then research it in up to {n} rounds — each round deliberately hunts for evidence that cuts against the current lean. ",
+    zh: "收到。我会先把它界定成一个可判定的是/否问题并设定基础概率先验，然后最多研究 {n} 轮——每一轮都刻意寻找与当前倾向相反的证据。"
+  },
+  planIntroBold: {
+    en: "Circle what holds up, strike what you doubt",
+    zh: "圈住站得住的、存疑靠不住的"
+  },
+  planIntroB: {
+    en: ", or queue a hypothesis; I fold analyst pushback into the next round.",
+    zh: "，或排入你的假设；分析师的质疑会折入下一轮。"
+  },
+
+  // --- plan steps ---
+  frameLabel: { en: "Frame the question", zh: "界定问题" },
+  frameSubPending: { en: "resolution criteria + base-rate prior", zh: "判定标准 + 基础概率先验" },
+  frameSubDone: { en: "checkable yes/no · prior {prior}", zh: "可判定的是/否 · 先验 {prior}" },
+  roundLabel: { en: "Research round {k}", zh: "研究第 {k} 轮" },
+  roundSubFirst: { en: "gather the first evidence", zh: "收集第一批证据" },
+  roundSubLater: { en: "hunt for evidence that cuts the other way", zh: "寻找反向证据" },
+  roundSubLive: { en: "gathering evidence · {span}", zh: "正在收集证据 · {span}" },
+  roundSubDone: { en: "{sources} · {span}", zh: "{sources} · {span}" },
+  verdictLabel: { en: "Weigh signals, deliver the verdict", zh: "权衡信号，给出判决" },
+  verdictSubDone: { en: "dossier ready", zh: "档案已生成" },
+  verdictSubPending: { en: "P(YES) + confidence + open risks", zh: "P(YES) + 置信度 + 未决风险" },
+
+  // --- block status words (view-model) ---
+  statusRunningSpan: { en: "running · {from} → {to} so far", zh: "进行中 · {from} → {to}（至今）" },
+  statusCompleteSpan: { en: "complete · {from} → {to}", zh: "已完成 · {from} → {to}" },
+  moveSoFar: { en: "{arrow} {net} so far", zh: "{arrow} {net}（至今）" },
+  placeholderNote: {
+    en: "Question framed — starting from a {p} base-rate prior. Round 1 is gathering its first evidence.",
+    zh: "问题已界定——从 {p} 的基础概率先验出发。第 1 轮正在收集第一批证据。"
+  },
+
+  // --- reading line tails (readingFromJob) ---
+  readingTailWeighing: { en: " — weighing what it changes…", zh: "——正在评估它改变了什么…" },
+  readingTailEvidence: { en: "weighing evidence…", zh: "正在评估证据…" },
+  readingTailSearching: { en: "searching for new evidence…", zh: "正在搜索新证据…" },
+
+  // --- header status ---
+  headerLive: {
+    en: "LIVE · ITERATION {cur} OF {max} · {elapsed} · {n} SOURCES",
+    zh: "进行中 · 第 {cur}/{max} 轮 · {elapsed} · {n} 个来源"
+  },
+  headerComplete: { en: "COMPLETE · {dur} · {n} SOURCES", zh: "已完成 · {dur} · {n} 个来源" },
+  headerAborted: { en: "RUN ABORTED", zh: "运行中止" },
+  headerUnforecastable: { en: "UNFORECASTABLE", zh: "无法预测" },
+
+  // --- status strip ---
+  framingQuestion: { en: "Framing the question…", zh: "正在界定问题…" },
+  nowRoundBold: { en: "research round {n}", zh: "研究第 {n} 轮" },
+  nowRoundRest: { en: " — gathering evidence and updating the estimate.", zh: "——收集证据并更新估计。" },
+  quantProvisional: { en: "P(YES) · provisional", zh: "P(YES) · 暂定" },
+  quantFinal: { en: "P(YES) · final", zh: "P(YES) · 最终" },
+
+  // --- notices ---
+  notFoundTitle: { en: "Forecast not found", zh: "未找到该预测" },
+  notFoundBody: {
+    en: "There's no run with this id — it may have been cleared when the server restarted. Ask a new question from the Ask screen.",
+    zh: "没有找到这个 id 对应的运行——可能在服务器重启时被清除了。请回到提问页重新提问。"
+  },
+  loadFailTitle: { en: "Couldn't load this run", zh: "无法加载这次运行" },
+  loadFailBody: { en: "{err} — retrying automatically.", zh: "{err}——正在自动重试。" },
+  vagueTitle: { en: "This question is too vague to forecast", zh: "问题太模糊，无法预测" },
+  vagueBodyQuoted: {
+    en: "Raven couldn't pin “{q}” down to a checkable yes-or-no outcome with a deadline.",
+    zh: "Raven 无法把「{q}」界定成带截止日期、可判定的是/否结果。"
+  },
+  vagueBodyPlain: {
+    en: "Raven couldn't pin the question down to a checkable yes-or-no outcome with a deadline.",
+    zh: "Raven 无法把这个问题界定成带截止日期、可判定的是/否结果。"
+  },
+  vagueBodyTail: {
+    en: "Rephrase it with a concrete event and date — “Will … happen by …?” — and ask again.",
+    zh: "请改成具体事件加日期——「……会在……之前发生吗？」——再问一次。"
+  },
+  abortedTitle: { en: "The run aborted", zh: "运行中止了" },
+  abortedBodyTerminal: {
+    en: "The engine stopped before finishing this run. The last log lines may explain why.",
+    zh: "引擎在完成这次运行前停止了。最后几行日志可能说明原因。"
+  },
+  abortedBodyInline: {
+    en: "The engine stopped before this run finished. Everything it gathered so far is shown below.",
+    zh: "引擎在这次运行完成前停止了。已收集到的内容都显示在下方。"
+  },
+
+  // --- analyst summary + queued rows (view-model) ---
+  markSummary: { en: "{k} kept · {d} doubted · {n} notes", zh: "圈住 {k} · 存疑 {d} · 笔记 {n}" },
+  stancePushYes: { en: "Pushes YES", zh: "推 YES" },
+  stancePushNo: { en: "Pushes NO", zh: "推 NO" },
+  stanceQuestion: { en: "Open question", zh: "开放问题" },
+  targetGeneral: { en: "General", zh: "一般" },
+  targetOnEvidence: { en: "on evidence {idx}", zh: "针对证据 {idx}" },
+  tagFolded: { en: "FOLDED INTO IT {n}", zh: "已折入第 {n} 轮" },
+  tagSaved: { en: "SAVED", zh: "已保存" },
+  tagQueued: { en: "QUEUED · IT {n}", zh: "排队 · 第 {n} 轮" },
+
+  // --- iteration block ---
+  iterationWord: { en: "Iteration", zh: "迭代" },
+  reasoningLabel: { en: "Raven's reasoning", zh: "Raven 的推理" },
+  pushbackChip: { en: "↳ analyst pushback folded in ({n})", zh: "↳ 分析师质疑已折入（{n}）" },
+  pushbackTitle: {
+    en: "Your queued notes were injected into this round's research prompt",
+    zh: "你排入的笔记已注入本轮研究的提示词"
+  },
+  readWord: { en: "Read", zh: "已读" },
+  readingWord: { en: "Reading", zh: "正在阅读" },
+  trailAria: { en: "Sources visited this round", zh: "本轮已访问的来源" },
+  foldAria: { en: "Fold iteration {n}", zh: "收起第 {n} 轮" },
+  foldedAria: { en: "Iteration {n} (folded)", zh: "第 {n} 轮（已收起）" },
+
+  // --- progress dock ---
+  dockComplete: { en: "Forecast complete — P(YES) {p}", zh: "预测完成——P(YES) {p}" },
+  dockAborted: { en: "Run aborted — partial evidence kept", zh: "运行中止——已保留部分证据" },
+  dockWorking: { en: "Working…", zh: "进行中…" },
+  dockCta: { en: "Read the dossier →", zh: "阅读档案 →" },
+  dockShowPlan: { en: "Show the run plan", zh: "展开运行计划" },
+  dockHidePlan: { en: "Hide the run plan", zh: "收起运行计划" },
+
+  // --- verdict digest ---
+  digestLead: { en: "Forecast complete — P(YES) {p}, {verdict}.", zh: "预测完成——P(YES) {p}，{verdict}。" },
+  chipVsPrior: { en: "vs the {prior} prior", zh: "相对先验 {prior}" },
+  chipConfidence: { en: "confidence {c}", zh: "置信度{c}" },
+  cardTitle: { en: "Dossier — {q}", zh: "档案——{q}" },
+  cardSub: {
+    en: "{verdict} · P(YES) {p} · evidence book · resolution criteria",
+    zh: "{verdict} · P(YES) {p} · 证据书 · 判定标准"
+  },
+  cardRead: { en: "READ →", zh: "查看 →" },
+  messageAria: { en: "Raven's message", zh: "Raven 的消息" },
+  planAria: { en: "Run plan", zh: "运行计划" }
+} satisfies Record<string, Entry>;

--- a/apps/raven/lib/i18n/verdict.ts
+++ b/apps/raven/lib/i18n/verdict.ts
@@ -1,0 +1,108 @@
+// Verdict (report) screen dictionary — chrome labels only. Engine-produced
+// content (why, quips, summaries, evidence claims) renders untranslated in
+// the run's own language. Pure module: safe to import from decorate.ts.
+
+import type { Entry } from "./index";
+import type { DossierStatus, Side, SrcType } from "../vm/types";
+
+export const V = {
+  // Not-found / loading / run-state banners
+  notFound: { en: "Forecast not found", zh: "未找到该预测" },
+  backToAsk: { en: "← Back to 01 · Ask", zh: "← 返回 01 · 提问" },
+  loadingDossier: { en: "Loading dossier…", zh: "档案加载中…" },
+  retrying: { en: "{err} — retrying", zh: "{err} — 重试中" },
+  stillRunning: { en: "This forecast is still running —", zh: "该预测仍在运行 —" },
+  watchLive: { en: "watch it live", zh: "查看实时进展" },
+  runAborted: {
+    en: "This run aborted — the dossier below is partial.",
+    zh: "本次运行已中止 — 以下档案不完整。"
+  },
+
+  // Hero
+  confidence: { en: "Confidence", zh: "置信度" },
+  confTooltip: {
+    en: "Overall confidence in this inference: {conf}",
+    zh: "本次推断的整体置信度：{conf}"
+  },
+  // Split around the styled prior value ("started as a <38%> prior")
+  priorNotePre: { en: "started as a ", zh: "先验起点为 " },
+  priorNotePost: { en: " prior", zh: "" },
+  theWhy: { en: "The why", zh: "核心理由" },
+  coreSignals: { en: "Three core signals", zh: "三大核心信号" },
+  strongestCounter: { en: "Strongest counter-signal", zh: "最强反向信号" },
+
+  // Summary
+  ravensSummary: { en: "Raven's summary", zh: "Raven 总结" },
+  openRisk: { en: "Open risk", zh: "未决风险" },
+
+  // Evidence book
+  evidenceInOrder: { en: "The evidence, in order — {src}", zh: "全部证据（按序）— {src}" },
+  legendSupporting: { en: "supporting", zh: "支持" },
+  legendCounter: { en: "counter", zh: "反向" },
+  legendNeutral: { en: "neutral", zh: "中性" },
+  iteration: { en: "Iteration", zh: "轮次" },
+  revisesPrior: { en: "↻ Revises a prior source", zh: "↻ 修正先前来源" },
+  verified: { en: "Verified", zh: "已核实" },
+  unverified: { en: "Unverified", zh: "未核实" },
+  preview: { en: "Preview", zh: "预览" },
+  openSource: { en: "Open {dom}", zh: "打开 {dom}" },
+
+  // Evidence pills
+  credPill: { en: "{tier} credibility", zh: "可信度·{tier}" },
+  credTooltip: { en: "How trustworthy the source is", zh: "来源可信程度" },
+  valuePill: { en: "{tier} value", zh: "价值·{tier}" },
+  valueTooltip: {
+    en: "How much this source adds to the forecast",
+    zh: "该来源对预测的增量价值"
+  },
+
+  // Resolution & framing (folded section)
+  resolutionFraming: { en: "Resolution & framing", zh: "判定与框架" },
+  resolutionHint: {
+    en: "Normalized question · criteria · prior · assumptions",
+    zh: "标准化问题 · 判定标准 · 先验 · 假设"
+  },
+  normalizedQuestion: { en: "Normalized question", zh: "标准化问题" },
+  resolutionCriteria: { en: "Resolution criteria", zh: "判定标准" },
+  prior: { en: "Prior", zh: "先验" },
+  assumptions: { en: "Assumptions", zh: "假设" },
+  settlementSource: { en: "Settlement source", zh: "结算来源" }
+} satisfies Record<string, Entry>;
+
+// --- engine-word maps (server/demo emit English keys; display translates) ---
+
+// Header status chip ("COMPLETE · 33m 35s · 13 SOURCES"); en is uppercased at
+// the call site, which is a no-op for zh.
+export const STATUS_LABELS: Record<DossierStatus, Entry> = {
+  complete: { en: "complete", zh: "已完成" },
+  running: { en: "running", zh: "运行中" },
+  failed: { en: "failed", zh: "已中止" },
+  unforecastable: { en: "unforecastable", zh: "无法预测" }
+};
+
+// Core-signal ranks produced by lib/server/dossier.ts and the demo dossier.
+// Unknown ranks fall back to the raw English string in both locales.
+const RANK_LABELS: Record<string, Entry> = {
+  "Biggest move": { en: "Biggest move", zh: "最大变动" },
+  "Key reversal": { en: "Key reversal", zh: "关键反转" },
+  "On the record": { en: "On the record", zh: "官方口径" },
+  "Strong signal": { en: "Strong signal", zh: "强信号" }
+};
+
+export const rankEntry = (rank: string): Entry => RANK_LABELS[rank] ?? { en: rank, zh: rank };
+
+// Source-type label shown in the evidence popover (keyed by srcType so the
+// VM's English srcLabel string never needs parsing).
+export const SRC_TYPE_LABELS: Record<SrcType, Entry> = {
+  official: { en: "Official source", zh: "官方来源" },
+  press: { en: "Press", zh: "媒体报道" },
+  insider: { en: "Insider report", zh: "内部消息" }
+};
+
+// Templates for decorate.ts's sideLabelFor — {dir} is "YES" | "NO" (kept
+// verbatim in zh; P(YES) terms are never translated).
+export const SIDE_LABEL_TEMPLATES: Record<Side, Entry> = {
+  neutral: { en: "No directional weight", zh: "无方向性影响" },
+  support: { en: "Supports the forecast (pushes {dir})", zh: "支持当前预测（推向 {dir}）" },
+  counter: { en: "Cuts against the forecast (pushes {dir})", zh: "削弱当前预测（推向 {dir}）" }
+};

--- a/apps/raven/lib/server/run-manager.ts
+++ b/apps/raven/lib/server/run-manager.ts
@@ -31,13 +31,16 @@ export function getJob(eventId: string): Job | null {
 // Build the child env: process env, backfilled from the repo-root .env.deepseek
 // (gitignored, local testing only) so `pnpm --filter @autopoly/raven dev` works
 // without exporting keys by hand. Secrets never touch the client or the repo.
-function buildEnv(provider: string): NodeJS.ProcessEnv {
+function buildEnv(provider: string, language?: string): NodeJS.ProcessEnv {
   const fromFile = readEnvFile(path.join(repoRoot(), ".env.deepseek"));
   const env: NodeJS.ProcessEnv = { ...process.env };
   for (const [k, v] of Object.entries(fromFile)) {
     if (!env[k]) env[k] = v;
   }
   env.FORECAST_PROVIDER = provider;
+  // Per-run output language for the engine's user-facing prose (opt-in "zh";
+  // absent = English, so trading-pipeline callers are untouched).
+  if (language === "zh") env.FORECAST_LANGUAGE = "zh";
   // App runs favor richer dossiers: a balanced round 1 (net ~0pp) must not
   // count as convergence before the round-2 disconfirmation pass has run.
   if (!env.FORECAST_MIN_ROUNDS) env.FORECAST_MIN_ROUNDS = "2";
@@ -66,6 +69,7 @@ export interface StartOptions {
   maxRounds?: number;
   fresh?: boolean;
   provider?: string;
+  language?: "en" | "zh";
 }
 
 // An "open" state whose file changed recently means an engine process is (very
@@ -117,7 +121,7 @@ export function startForecast(question: string, opts: StartOptions = {}): Job {
 
   const child = spawn(path.join(root, "node_modules/.bin/tsx"), args, {
     cwd: root,
-    env: buildEnv(provider)
+    env: buildEnv(provider, opts.language)
   });
   const onData = (buf: Buffer) => {
     for (const line of buf.toString().split("\n")) {

--- a/apps/raven/next-env.d.ts
+++ b/apps/raven/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -11,6 +11,10 @@
 >
 > 英文版：[`docs/en/agent-handoff.md`](en/agent-handoff.md)
 >
+> 最后更新：2026-07-03 by Claude（**Raven 全站中英切换 + 引擎中文输出**，分支 `claude/kind-goodall-e0d263`）。
+> ① **UI i18n**：无依赖自研 locale 层（`apps/raven/lib/i18n/`：LocaleProvider（localStorage 持久化，Provider 挂在 `app/layout.tsx`）+ `useT(entry, vars)` + 判词/置信度/档位映射）；字典按域拆文件防冲突（ui/home/verdict/research-parts，约 170 键）。三屏 + chrome 全量翻译（导航/页脚/计划清单/进度坞/摘要/分析师工作台/证据 pill/判决页全部标签），头部新增「中文/EN」切换。GTA6 demo 内容保持英文（英文档案）。
+> ② **引擎输出语言（opt-in，交易管线不受影响）**：`scripts/forecast/language.ts` — `FORECAST_LANGUAGE=zh` 时向 framing/audit/round/summary 四个 prompt 注入「自由文本字段写简体中文、JSON 键/枚举/URL 保持 ASCII」指令；**默认（不设 env）prompt 逐字节不变**（已验证 + vitest 62/62 绿）。链路：首页 POST 带 `language: locale` → API zod → run-manager 子进程 env。zh 用户新起的 run，推理/证据 takeaway/summary 全中文；已有英文档案不动。
+> 验收：typecheck + build 绿；zh/en × 桌面/375px × 三屏截图自评全过，0 page error。英文版 handoff 待同步翻译。
 > 最后更新：2026-07-02 by Claude（**Raven 研究页 Manus 风格渐进呈现改版**，分支 `claude/kind-goodall-e0d263`，**改动未提交** working tree）。
 > 用户给了两个 Manus share 样例，要求学其「逐步揭示 + 证据强调」但保留 Raven 配色。Screen 02 · Research 改成对话式：① Raven 开场消息（头像 + provider 徽章 + 时间）自述计划，下面挂**实时任务清单**（Frame → Round 1..N → Verdict，虚线连接，✓/脉冲/待办三态，done 步骤带「N sources · 38%→30%」小结）；② **证据卡逐条入场动画**（`use-reveal.ts` 交错队列，只对 run 中新到的条目播动画，终态/加载即全显）；③ **底部固定进度坞**（当前步骤 + N/M + 可展开清单；完成变绿 ✓ + 「Read the dossier」CTA；修复了移动端此前完全看不到进度的问题——顺手把 `.rv-hdr-meta` 移动端隐藏加了 `!important`，原来被行内样式压过没生效）；④ **完成摘要消息**：结论先行（P(YES) + 判词 + whySentence）+ 统计 chips + Manus 式档案附件卡链到 Screen 03；⑤ 证据卡正文改为 **takeaway 加粗引领**（该字段之前研究页根本没渲染）。CoachBar/CompleteCta 已删（文案并入计划消息和进度坞）。新文件：`components/research/plan.tsx` / `progress-dock.tsx` / `use-reveal.ts` / `verdict-digest.tsx`；`research-vm.ts` 加 `buildPlanSteps/planStepNo`。
 > 验收：`pnpm --filter @autopoly/raven build` 绿 + typecheck 绿；demo（运行态）+ 完成态 fixture（临时 state.json，已删）× 桌面/375px 移动 × dark/light 截图自评全过，0 console/page error。**注意本 worktree 3200 被并行会话占用，本地预览用 `.claude/launch.json` 的 `raven-alt`（3211）**。英文版 handoff 此条待同步翻译。

--- a/scripts/forecast/engine.ts
+++ b/scripts/forecast/engine.ts
@@ -9,6 +9,7 @@
 // computed, not guessed -> persist -> check stop conditions.
 
 import { providerHasWebSearch, runAgent } from "./agent";
+import { languageDirective } from "./language";
 import {
   applyLlrs,
   clamp,
@@ -163,7 +164,8 @@ OUTPUT FORMAT: Respond with ONLY a single JSON object — no prose before or aft
   "found_new_information": true,
   "notes": "caveats, resolution assumptions, what to check next round"
 }
-If you genuinely found no new relevant information this round, return an empty new_evidence array, an empty reflection array, and set found_new_information to false.`;
+If you genuinely found no new relevant information this round, return an empty new_evidence array, an empty reflection array, and set found_new_information to false.
+${languageDirective()}`;
 }
 
 export function newForecastState(input: {

--- a/scripts/forecast/framing.ts
+++ b/scripts/forecast/framing.ts
@@ -10,6 +10,7 @@
 
 import { providerHasWebSearch, runAgent } from "./agent";
 import { extractJsonObject } from "./claude-agent";
+import { languageDirective } from "./language";
 import type { EventFraming } from "./types";
 
 // Provider-aware research line: a search-less provider must not be told to
@@ -39,7 +40,7 @@ Produce:
 - clarification_needed: if forecastable is false, what the user must specify; else "".
 - prior_probability: your PRIOR P(YES) in [0,1] from GENERAL KNOWLEDGE / a reference class ONLY — the base rate BEFORE weighing specific current evidence (e.g. "a named product shipping by a pre-announced date ~0.55", "a specific bilateral ceasefire holding 6 months ~0.3"). Not 0.5 unless the reference class truly is a coin flip.
 - prior_rationale: the reference class and why that base rate.
-
+${languageDirective()}
 OUTPUT only a single JSON object, no prose, no code fence:
 {"normalized_question":"...","resolution_criteria":"...","resolution_date":"2026-12-31","settlement_source":"...","assumptions":"...","forecastable":true,"clarification_needed":"","prior_probability":0.45,"prior_rationale":"..."}`;
 }
@@ -58,7 +59,7 @@ PROPOSED FRAME:
 - prior_rationale: ${frame.priorRationale}
 
 Re-derive the frame independently. Return a CORRECTED frame (keep it if already correct), PLUS an honest audit. Be strict: if the resolution bar is ambiguous or unfaithful to the user's intent, fix it and say so in framing_caveats.
-
+${languageDirective()}
 OUTPUT only a single JSON object, no prose, no code fence:
 {"normalized_question":"...","resolution_criteria":"...","resolution_date":"2026-12-31","settlement_source":"...","assumptions":"...","forecastable":true,"clarification_needed":"","prior_probability":0.45,"prior_rationale":"...","framing_caveats":"edge cases / ambiguities the user should know, or '' if none","framing_confidence":"high|medium|low"}`;
 }

--- a/scripts/forecast/language.ts
+++ b/scripts/forecast/language.ts
@@ -1,0 +1,20 @@
+// Output-language control for the forecaster's user-facing prose.
+//
+// Opt-in via FORECAST_LANGUAGE=zh (set per-run by the Raven app; defaults to
+// English so the trading pipeline and every existing caller are unaffected).
+// The directive only touches free-text fields — JSON keys, enum values, URLs,
+// dates and numbers stay ASCII so validators and the Bayesian harness see the
+// exact same machine contract in every language.
+
+export type ForecastLanguage = "en" | "zh";
+
+export function forecastLanguage(): ForecastLanguage {
+  return process.env.FORECAST_LANGUAGE === "zh" ? "zh" : "en";
+}
+
+export function languageDirective(lang: ForecastLanguage = forecastLanguage()): string {
+  if (lang !== "zh") return "";
+  return `
+LANGUAGE: Write every free-text field of your output in Simplified Chinese (简体中文) — claims, rationales, summaries, criteria, assumptions, caveats, verdict prose, notes, quips. Keep JSON keys, enum values ("supports_yes", "weak", "official", "high", …), URLs, dates and numbers exactly as specified above, in English/ASCII.
+`;
+}

--- a/scripts/forecast/summary.ts
+++ b/scripts/forecast/summary.ts
@@ -8,6 +8,7 @@
 
 import { runAgent } from "./agent";
 import { extractJsonObject } from "./claude-agent";
+import { languageDirective } from "./language";
 import type { AgentRunResult, RunAgentOptions } from "./claude-agent";
 import type { ForecastState, ForecastSummary } from "./types";
 
@@ -55,7 +56,8 @@ OUTPUT only a single JSON object — no prose, no code fence:
   "why_sentence": "ONE complete, self-explaining sentence — the single reason the number landed where it did, naming the decisive evidence; no fragment",
   "quip": "one short dry human aside reacting to the verdict — personality, not advice",
   "confidence_reason": "one line on why confidence is high/medium/low"
-}`;
+}
+${languageDirective()}`;
 }
 
 function strArray(v: unknown): string[] {


### PR DESCRIPTION
## Summary

Full zh/en language support for the Raven Forecasting Engine, at both layers the user asked for: the UI chrome AND the engine's generated content (reasoning, evidence takeaways, summaries).

### UI (all three screens + chrome)

- Dependency-free locale layer: `apps/raven/lib/i18n/` — `LocaleProvider` (localStorage-persisted, mounted in `app/layout.tsx`), `useT(entry, vars)` with `{var}` interpolation, and display maps for engine words (verdict buckets, confidence, credibility/value tiers).
- Per-domain dictionaries (`ui` / `home` / `verdict` / `research-parts`, ~170 entries) so parallel work can't collide on keys.
- Translated: nav/footer, home (hero, ask bar, explainer cards, latest-dossier card), research screen (plan message + checklist, fold receipts, read-trail, progress dock, verdict digest, analyst desk, evidence pills, notices), verdict page (core signals + ranks, counter-signal, summary chrome, evidence book, resolution & framing).
- 「中文 / EN」 toggle in the header next to the theme toggle.
- GTA6 demo content intentionally stays English — it is a frozen English archive; only chrome is localized.

### Engine output language (opt-in — trading pipeline untouched)

- `scripts/forecast/language.ts`: with `FORECAST_LANGUAGE=zh`, the framing/audit/round/summary prompts append a directive: free-text output fields in Simplified Chinese; JSON keys, enum values, URLs, dates stay ASCII (machine contract unchanged).
- **Default behavior is byte-identical prompts** — verified `buildPrompt` contains no directive without the env var; engine tests 62/62 green.
- Wiring: home page POSTs `language: locale` → API zod schema → run-manager sets the child CLI env per run. New runs started in zh produce Chinese reasoning/claims/summaries; existing English dossiers render as-is.

### Test plan

- [x] `pnpm --filter @autopoly/raven typecheck` + `build` green
- [x] `vitest scripts/forecast` 62/62 green (prompt contract unchanged by default)
- [x] Language directive present iff `FORECAST_LANGUAGE=zh` (checked both ways)
- [x] zh + en × desktop/375px × home/research/verdict screenshots, 0 page errors
- [ ] Post-deploy: start a zh run on the VPS and confirm Chinese reasoning/evidence end-to-end