### PR TITLE
refactor(orchestrator): Stage 2 dedup — provider-output + isChineseLocale helpers

### DIFF
--- a/services/orchestrator/src/config.ts
+++ b/services/orchestrator/src/config.ts
@@ -59,6 +59,10 @@ export type AgentDecisionStrategy = (typeof agentDecisionStrategies)[number];
 export const skillLocales = ["en", "zh"] as const;
 export type SkillLocale = (typeof skillLocales)[number];
 
+export function isChineseLocale(locale: SkillLocale): boolean {
+  return locale === "zh";
+}
+
 export const pulseSourceRepos = ["all-polymarket-skill", "polymarket-market-pulse"] as const;
 export type PulseSourceRepo = (typeof pulseSourceRepos)[number];
 export const pulseTimeoutModes = ["default", "unbounded"] as const;

--- a/services/orchestrator/src/lib/provider-output.ts
+++ b/services/orchestrator/src/lib/provider-output.ts
@@ -1,0 +1,38 @@
+// Shared helpers for handling external provider-CLI output and run timing.
+// Extracted verbatim from provider-runtime.ts and full-pulse.ts, which held
+// byte-identical copies (Stage 2 dedup, 2026-07-03).
+import { existsSync, statSync } from "node:fs";
+
+/** Strip a single wrapping ``` code fence from a provider's stdout, if present. */
+export function stripCodeFences(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("```")) {
+    return trimmed;
+  }
+
+  const lines = trimmed.split("\n");
+  if (lines.length < 3) {
+    return trimmed;
+  }
+
+  return lines.slice(1, -1).join("\n").trim();
+}
+
+export function readOutputSizeBytes(outputPath: string | undefined): number {
+  if (!outputPath || !existsSync(outputPath)) {
+    return 0;
+  }
+  try {
+    return statSync(outputPath).size;
+  } catch {
+    return 0;
+  }
+}
+
+export function formatRemainingTimeoutMs(startedAt: number, timeoutMs: number | null): string {
+  if (timeoutMs == null) {
+    return "disabled";
+  }
+  const remainingMs = Math.max(0, timeoutMs - (Date.now() - startedAt));
+  return `${Math.ceil(remainingMs / 1000)}s`;
+}

--- a/services/orchestrator/src/pulse/full-pulse.ts
+++ b/services/orchestrator/src/pulse/full-pulse.ts
@@ -1,11 +1,13 @@
 import { spawn } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { isChineseLocale } from "../config.js";
 import type { AgentRuntimeProvider, OrchestratorConfig, SkillLocale } from "../config.js";
 import { writeStoredArtifact } from "../lib/artifacts.js";
 import { OPENCLAW_DEFAULT_COMMAND_TEMPLATE } from "../lib/provider-command-templates.js";
+import { formatRemainingTimeoutMs, readOutputSizeBytes, stripCodeFences } from "../lib/provider-output.js";
 import { calculateQuarterKelly } from "../lib/risk.js";
 import { combineTextMetrics, formatTextMetrics, measureText, readTextMetrics } from "../lib/text-metrics.js";
 import type { ProgressReporter } from "../lib/terminal-progress.js";
@@ -84,10 +86,6 @@ type FullPulsePurpose = "market-scan" | "position-review";
 type JsonRecord = Record<string, unknown>;
 const COMMAND_HEARTBEAT_INTERVAL_MS = 5000;
 const DEFAULT_PULSE_DIRECT_RENDER_TIMEOUT_SECONDS = 1200;
-
-function isChineseLocale(locale: SkillLocale): boolean {
-  return locale === "zh";
-}
 
 function asRecord(value: unknown): JsonRecord | null {
   return value && typeof value === "object" && !Array.isArray(value) ? value as JsonRecord : null;
@@ -548,25 +546,6 @@ function buildDeterministicPulseMarkdown(context: FullPulseContext): string {
   ].join("\n");
 }
 
-function readOutputSizeBytes(outputPath: string | undefined): number {
-  if (!outputPath || !existsSync(outputPath)) {
-    return 0;
-  }
-  try {
-    return statSync(outputPath).size;
-  } catch {
-    return 0;
-  }
-}
-
-function formatRemainingTimeoutMs(startedAt: number, timeoutMs: number | null): string {
-  if (timeoutMs == null) {
-    return "disabled";
-  }
-  const remainingMs = Math.max(0, timeoutMs - (Date.now() - startedAt));
-  return `${Math.ceil(remainingMs / 1000)}s`;
-}
-
 function buildCommandHeartbeatDetail(input: {
   stage: string;
   progressDetail?: string;
@@ -588,19 +567,6 @@ function buildCommandHeartbeatDetail(input: {
     .join(" | ");
 }
 
-function stripCodeFences(text: string): string {
-  const trimmed = text.trim();
-  if (!trimmed.startsWith("```")) {
-    return trimmed;
-  }
-
-  const lines = trimmed.split("\n");
-  if (lines.length < 3) {
-    return trimmed;
-  }
-
-  return lines.slice(1, -1).join("\n").trim();
-}
 
 async function runCommand(input: {
   command: string;

--- a/services/orchestrator/src/pulse/market-pulse.ts
+++ b/services/orchestrator/src/pulse/market-pulse.ts
@@ -4,6 +4,7 @@ import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { RunMode } from "@autopoly/contracts";
+import { isChineseLocale } from "../config.js";
 import type { AgentRuntimeProvider, OrchestratorConfig, SkillLocale } from "../config.js";
 import { buildArtifactRelativePath } from "../lib/artifacts.js";
 import type { ProgressReporter } from "../lib/terminal-progress.js";
@@ -159,10 +160,6 @@ export interface PulseSnapshot {
   candidates: PulseCandidate[];
   riskFlags: string[];
   tradeable: boolean;
-}
-
-function isChineseLocale(locale: SkillLocale): boolean {
-  return locale === "zh";
 }
 
 function toPulseTag(tag: NonNullable<RawPulseMarket["tags"]>[number]): PulseTag | null {

--- a/services/orchestrator/src/runtime/provider-runtime.ts
+++ b/services/orchestrator/src/runtime/provider-runtime.ts
@@ -1,23 +1,21 @@
-import { existsSync, statSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { tradeDecisionSetSchema, type Artifact, type TradeDecisionSet } from "@autopoly/contracts";
+import { isChineseLocale } from "../config.js";
 import type { AgentRuntimeProvider, OrchestratorConfig, SkillLocale } from "../config.js";
 import { buildArtifactRelativePath, writeStoredArtifact } from "../lib/artifacts.js";
 import { OPENCLAW_DEFAULT_COMMAND_TEMPLATE } from "../lib/provider-command-templates.js";
+import { formatRemainingTimeoutMs, readOutputSizeBytes, stripCodeFences } from "../lib/provider-output.js";
 import { combineTextMetrics, formatTextMetrics, measureText, readTextMetrics } from "../lib/text-metrics.js";
 import type { PulseSnapshot } from "../pulse/market-pulse.js";
 import type { AgentRuntime, RuntimeExecutionContext, RuntimeExecutionResult } from "./agent-runtime.js";
 import { resolveProviderSkillSettings, type ResolvedProviderSkillSettings } from "./skill-settings.js";
 
 const RUNTIME_HEARTBEAT_INTERVAL_MS = 5000;
-
-function isChineseLocale(locale: ResolvedProviderSkillSettings["locale"]): boolean {
-  return locale === "zh";
-}
 
 function formatPulseTradeable(value: boolean, locale: ResolvedProviderSkillSettings["locale"]): string {
   if (isChineseLocale(locale)) {
@@ -35,39 +33,6 @@ function formatPulseRiskFlags(flags: string[], locale: ResolvedProviderSkillSett
 
 function truncate(text: string, maxChars: number): string {
   return text.length <= maxChars ? text : `${text.slice(0, maxChars - 24)}\n\n... truncated ...\n`;
-}
-
-function stripCodeFences(text: string): string {
-  const trimmed = text.trim();
-  if (!trimmed.startsWith("```")) {
-    return trimmed;
-  }
-
-  const lines = trimmed.split("\n");
-  if (lines.length < 3) {
-    return trimmed;
-  }
-
-  return lines.slice(1, -1).join("\n").trim();
-}
-
-function readOutputSizeBytes(outputPath: string | undefined): number {
-  if (!outputPath || !existsSync(outputPath)) {
-    return 0;
-  }
-  try {
-    return statSync(outputPath).size;
-  } catch {
-    return 0;
-  }
-}
-
-function formatRemainingTimeoutMs(startedAt: number, timeoutMs: number | null): string {
-  if (timeoutMs == null) {
-    return "disabled";
-  }
-  const remainingMs = Math.max(0, timeoutMs - (Date.now() - startedAt));
-  return `${Math.ceil(remainingMs / 1000)}s`;
 }
 
 function buildRuntimeHeartbeatDetail(input: {


### PR DESCRIPTION
## Stage 2（消重复）——第一批安全去重

延续复杂度重构计划（[plan](docs/internal/plan/2026-07-03-repo-complexity-refactor-3stage.md) §3）。本 PR 只做**行为保留**的去重，不碰实盘下单逻辑。

### 做了什么

forecast 管线里 4 个 helper 有逐字节重复的副本，收敛成单一来源：

| helper | 原来 | 现在 |
|---|---|---|
| `stripCodeFences` / `readOutputSizeBytes` / `formatRemainingTimeoutMs` | provider-runtime.ts + full-pulse.ts 各一份（逐字节相同） | 新增 `lib/provider-output.ts` 单一来源 |
| `isChineseLocale` | provider-runtime / full-pulse / market-pulse 三份 | 移到 `config.ts`（`SkillLocale` 旁） |

### 为什么安全

- 三个纯函数**函数体逐字节搬移**（已 diff 确认 IDENTICAL），无逻辑改动。
- `isChineseLocale` 三份只差参数类型注解，且已核实 `ResolvedProviderSkillSettings["locale"]` === `SkillLocale`（skill-settings.ts:27），合并后类型完全一致。
- 收益：改一处超时/转义/locale 判定的行为，不再需要同步改 2-3 个文件（历史上这类改一处漏一处是真实 bug 来源）。

## Test plan

- [x] `pnpm --filter @autopoly/orchestrator typecheck` 绿
- [x] `pnpm --filter @autopoly/orchestrator build` 绿
- [x] `pnpm test` 832/832（含 hermetic 化后的 provider-runtime 测试全绿）
- [x] 不触实盘下单路径（纯 helper 搬移）