### PR TITLE
refactor(scripts): unify preflight gates across live-trading entries (Stage 2)

### DIFF
--- a/scripts/agent-persistent-runner.ts
+++ b/scripts/agent-persistent-runner.ts
@@ -12,7 +12,7 @@ import {
 } from "@autopoly/terminal-ui";
 import { Wallet } from "ethers";
 import { loadConfig as loadExecutorConfig } from "../services/executor/src/config.ts";
-import { fetchRemotePositions } from "../services/executor/src/lib/polymarket.ts";
+import { fetchRemotePositions, resolvePolymarketSigningIdentity, type PolymarketSigningIdentity } from "../services/executor/src/lib/polymarket.ts";
 import { loadConfig as loadOrchestratorConfig } from "../services/orchestrator/src/config.ts";
 import {
   buildExecutionDispatchPlan,
@@ -33,6 +33,13 @@ import {
   writeJsonArtifact
 } from "./live-run-common.ts";
 import { runPulseLive } from "./pulse-live.ts";
+import {
+  buildCredentialsCheck,
+  buildEnvFileCheck,
+  buildExecutionModeCheck,
+  buildSignerFunderCheck,
+  getPreflightBlockingReason
+} from "./preflight-checks.ts";
 
 interface Args {
   json: boolean;
@@ -119,10 +126,6 @@ export function parseArgs(argv = process.argv.slice(2)): Args {
   };
 }
 
-function getBlockingReason(checks: RunnerPreflightCheck[]) {
-  return checks.find((check) => check.blocking && !check.ok)?.summary ?? null;
-}
-
 function deriveSignerAddress(privateKey: string) {
   if (!privateKey) {
     return "";
@@ -158,9 +161,24 @@ async function runRunnerPreflight(input: {
   executorConfig: ReturnType<typeof loadExecutorConfig>;
   orchestratorConfig: ReturnType<typeof loadOrchestratorConfig>;
 }): Promise<RunnerPreflightReport> {
-  const signerAddress = deriveSignerAddress(input.executorConfig.privateKey);
-  const signerMatchesFunder = signerAddress && input.executorConfig.funderAddress
-    ? signerAddress.toLowerCase() === input.executorConfig.funderAddress.toLowerCase()
+  // Resolve the signing identity the same way pulse-live does, so the
+  // credentials/signer gates handle the onchainos wallet (this path used to
+  // only understand PRIVATE_KEY + FUNDER_ADDRESS — the drift the shared
+  // preflight builders close).
+  const usesOnchainOsWallet = input.executorConfig.walletProvider === "onchainos";
+  let walletIdentity: PolymarketSigningIdentity | null = null;
+  let walletIdentityError: string | null = null;
+  try {
+    if (usesOnchainOsWallet || input.executorConfig.privateKey || input.executorConfig.funderAddress) {
+      walletIdentity = await resolvePolymarketSigningIdentity(input.executorConfig);
+    }
+  } catch (error) {
+    walletIdentityError = getErrorMessage(error);
+  }
+  const signerAddress = walletIdentity?.signerAddress ?? deriveSignerAddress(input.executorConfig.privateKey);
+  const funderAddress = walletIdentity?.funderAddress ?? input.executorConfig.funderAddress;
+  const signerMatchesFunder = signerAddress && funderAddress
+    ? signerAddress.toLowerCase() === funderAddress.toLowerCase()
     : null;
   const collateralProbe = await probeCollateralBalanceUsd(input.executorConfig);
   const remotePositions = await fetchRemotePositions(input.executorConfig).catch(() => []);
@@ -168,42 +186,23 @@ async function runRunnerPreflight(input: {
   const liveDispatch = !input.args.mockExecutor;
 
   const checks: RunnerPreflightCheck[] = [
-    {
-      key: "execution-mode",
-      blocking: true,
-      ok: process.env.AUTOPOLY_EXECUTION_MODE === "live",
-      summary: process.env.AUTOPOLY_EXECUTION_MODE === "live"
-        ? "Execution mode is live."
-        : `AUTOPOLY_EXECUTION_MODE must be live. Received ${process.env.AUTOPOLY_EXECUTION_MODE ?? "-"}.`
-    },
-    {
-      key: "env-file",
-      blocking: true,
-      ok: Boolean(input.orchestratorConfig.envFilePath ?? input.executorConfig.envFilePath),
-      summary: (input.orchestratorConfig.envFilePath ?? input.executorConfig.envFilePath)
-        ? `Using env file ${(input.orchestratorConfig.envFilePath ?? input.executorConfig.envFilePath)}.`
-        : "ENV_FILE is required for persistent live runs."
-    },
-    {
-      key: "credentials",
-      blocking: liveDispatch,
-      ok: Boolean(input.executorConfig.privateKey && input.executorConfig.funderAddress),
-      summary: input.executorConfig.privateKey && input.executorConfig.funderAddress
-        ? "PRIVATE_KEY and FUNDER_ADDRESS are present."
-        : liveDispatch
-          ? "Missing PRIVATE_KEY or FUNDER_ADDRESS; live dispatch is blocked."
-          : "Missing PRIVATE_KEY or FUNDER_ADDRESS; mock executor mode will not broadcast."
-    },
-    {
-      key: "signer-funder",
-      blocking: false,
-      ok: true,
-      summary: signerMatchesFunder === true
-        ? "Signer address matches FUNDER_ADDRESS."
-        : signerMatchesFunder === false
-          ? `Signer ${signerAddress} does not match FUNDER_ADDRESS ${input.executorConfig.funderAddress}. Proxy/funder setups may be intentional.`
-          : "Signer/FUNDER_ADDRESS alignment could not be verified."
-    },
+    buildExecutionModeCheck(process.env.AUTOPOLY_EXECUTION_MODE),
+    buildEnvFileCheck(input.orchestratorConfig.envFilePath ?? input.executorConfig.envFilePath, "persistent live runs"),
+    buildCredentialsCheck({
+      usesOnchainOsWallet,
+      walletIdentity,
+      walletIdentityError,
+      hasPrivateKey: Boolean(input.executorConfig.privateKey),
+      hasFunderAddress: Boolean(input.executorConfig.funderAddress),
+      blocking: liveDispatch
+    }),
+    buildSignerFunderCheck({
+      usesOnchainOsWallet,
+      walletIdentity,
+      signerAddress,
+      funderAddress: funderAddress ?? "",
+      signerMatchesFunder: signerMatchesFunder === true
+    }),
     {
       key: "wallet-inventory",
       blocking: liveDispatch,
@@ -237,14 +236,14 @@ async function runRunnerPreflight(input: {
 
   return {
     ok: checks.every((check) => check.ok || !check.blocking),
-    blockingReason: getBlockingReason(checks),
+    blockingReason: getPreflightBlockingReason(checks),
     executionMode: process.env.AUTOPOLY_EXECUTION_MODE ?? "live",
     decisionStrategy: input.orchestratorConfig.decisionStrategy,
     envFilePath: input.orchestratorConfig.envFilePath ?? input.executorConfig.envFilePath,
     redisUrl: input.orchestratorConfig.redisUrl,
     archiveRoot: input.args.archiveRoot,
     wallet: {
-      funderAddress: input.executorConfig.funderAddress,
+      funderAddress,
       signerAddress,
       signerMatchesFunder
     },

--- a/scripts/preflight-checks.test.ts
+++ b/scripts/preflight-checks.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCredentialsCheck,
+  buildEnvFileCheck,
+  buildExecutionModeCheck,
+  buildSignerFunderCheck,
+  getPreflightBlockingReason,
+  type PreflightWalletIdentity
+} from "./preflight-checks.ts";
+
+// Characterization tests: lock the canonical (pulse-live) behavior that both
+// forecast:live and agent:persistent now share, so future edits to the gates
+// can't silently drift the two entries apart again.
+
+const onchainos: PreflightWalletIdentity = {
+  signerAddress: "0x1111111111111111111111111111111111111111",
+  funderAddress: "0x2222222222222222222222222222222222222222",
+  signatureType: 2,
+  walletMode: "proxy"
+};
+
+describe("buildExecutionModeCheck", () => {
+  it("passes only when the mode is live, and is always blocking", () => {
+    const ok = buildExecutionModeCheck("live");
+    expect(ok).toMatchObject({ key: "execution-mode", blocking: true, ok: true, summary: "Execution mode is live." });
+    const bad = buildExecutionModeCheck("paper");
+    expect(bad).toMatchObject({ blocking: true, ok: false });
+    expect(bad.summary).toBe("AUTOPOLY_EXECUTION_MODE must be live. Received paper.");
+    expect(buildExecutionModeCheck(undefined).summary).toBe("AUTOPOLY_EXECUTION_MODE must be live. Received -.");
+  });
+});
+
+describe("buildEnvFileCheck", () => {
+  it("uses the caller's run context in the failure message", () => {
+    expect(buildEnvFileCheck("/x/.env.pizza", "forecast:live runs")).toMatchObject({
+      blocking: true,
+      ok: true,
+      summary: "Using env file /x/.env.pizza."
+    });
+    expect(buildEnvFileCheck(null, "persistent live runs")).toMatchObject({
+      ok: false,
+      summary: "ENV_FILE is required for persistent live runs."
+    });
+  });
+});
+
+describe("buildCredentialsCheck", () => {
+  it("onchainos: ok iff a wallet identity resolved", () => {
+    const ok = buildCredentialsCheck({
+      usesOnchainOsWallet: true,
+      walletIdentity: onchainos,
+      walletIdentityError: null,
+      hasPrivateKey: false,
+      hasFunderAddress: false,
+      blocking: true
+    });
+    expect(ok.ok).toBe(true);
+    expect(ok.summary).toContain("WALLET_PROVIDER=onchainos");
+    expect(ok.summary).toContain("signatureType=2");
+
+    const failed = buildCredentialsCheck({
+      usesOnchainOsWallet: true,
+      walletIdentity: null,
+      walletIdentityError: "session expired",
+      hasPrivateKey: false,
+      hasFunderAddress: false,
+      blocking: true
+    });
+    expect(failed.ok).toBe(false);
+    expect(failed.summary).toBe("WALLET_PROVIDER=onchainos, but wallet identity could not be resolved: session expired.");
+  });
+
+  it("private-key path: ok iff both key and funder present; blocking is passthrough", () => {
+    expect(
+      buildCredentialsCheck({
+        usesOnchainOsWallet: false,
+        walletIdentity: null,
+        walletIdentityError: null,
+        hasPrivateKey: true,
+        hasFunderAddress: true,
+        blocking: false
+      })
+    ).toMatchObject({ ok: true, blocking: false, summary: "PRIVATE_KEY and FUNDER_ADDRESS are present." });
+
+    expect(
+      buildCredentialsCheck({
+        usesOnchainOsWallet: false,
+        walletIdentity: null,
+        walletIdentityError: null,
+        hasPrivateKey: true,
+        hasFunderAddress: false,
+        blocking: true
+      })
+    ).toMatchObject({ ok: false, blocking: true, summary: "Missing PRIVATE_KEY or FUNDER_ADDRESS." });
+  });
+});
+
+describe("buildSignerFunderCheck", () => {
+  it("is never blocking and reports match/mismatch/missing by name", () => {
+    const match = buildSignerFunderCheck({
+      usesOnchainOsWallet: false,
+      walletIdentity: null,
+      signerAddress: "0xabc",
+      funderAddress: "0xABC",
+      signerMatchesFunder: true
+    });
+    expect(match).toMatchObject({ blocking: false, ok: true, summary: "Signer address matches FUNDER_ADDRESS." });
+
+    const mismatch = buildSignerFunderCheck({
+      usesOnchainOsWallet: false,
+      walletIdentity: null,
+      signerAddress: "0xaaa",
+      funderAddress: "0xbbb",
+      signerMatchesFunder: false
+    });
+    expect(mismatch.summary).toContain("does not match FUNDER_ADDRESS");
+    expect(mismatch.summary).toContain("proxy/funder setup may be intentional");
+
+    expect(
+      buildSignerFunderCheck({
+        usesOnchainOsWallet: false,
+        walletIdentity: null,
+        signerAddress: "",
+        funderAddress: "0xbbb",
+        signerMatchesFunder: false
+      }).summary
+    ).toBe("Unable to derive signer address from PRIVATE_KEY.");
+
+    expect(
+      buildSignerFunderCheck({
+        usesOnchainOsWallet: true,
+        walletIdentity: onchainos,
+        signerAddress: onchainos.signerAddress,
+        funderAddress: onchainos.funderAddress,
+        signerMatchesFunder: false
+      }).summary
+    ).toContain("trades through proxy funder");
+  });
+});
+
+describe("getPreflightBlockingReason", () => {
+  it("returns the first blocking failed check's summary, else null", () => {
+    expect(getPreflightBlockingReason([{ key: "a", blocking: true, ok: true, summary: "ok" }])).toBeNull();
+    expect(
+      getPreflightBlockingReason([
+        { key: "a", blocking: false, ok: false, summary: "non-blocking fail" },
+        { key: "b", blocking: true, ok: false, summary: "blocked here" },
+        { key: "c", blocking: true, ok: false, summary: "second block" }
+      ])
+    ).toBe("blocked here");
+  });
+});

--- a/scripts/preflight-checks.ts
+++ b/scripts/preflight-checks.ts
@@ -1,0 +1,105 @@
+/**
+ * Shared preflight checks for the live-trading entry scripts.
+ *
+ * Before this, forecast:live (pulse-live.ts) and agent:persistent
+ * (agent-persistent-runner.ts) each maintained their own copy of the
+ * execution-mode / env-file / credentials / signer-funder gates. They had
+ * DRIFTED — most importantly, only pulse-live handled the onchainos wallet in
+ * its credentials/signer checks, so the same onchainos wallet passed the gate
+ * from forecast:live but was rejected from agent:persistent.
+ *
+ * pulse-live is the canonical, battle-tested entry (the daily real-money path);
+ * these builders reproduce its exact behavior. agent:persistent adopts them,
+ * which incidentally closes the onchainos gap. (live-test's preflight keeps its
+ * own differently-shaped, unit-tested pure function.)
+ */
+import { maskAddressForDisplay } from "./live-run-common.js";
+
+export interface PreflightCheck {
+  readonly key: string;
+  readonly blocking: boolean;
+  readonly ok: boolean;
+  readonly summary: string;
+}
+
+// A resolved onchainos/proxy wallet identity, as returned by
+// resolvePolymarketSigningIdentity. Typed structurally so this module stays
+// free of the executor package import.
+export interface PreflightWalletIdentity {
+  readonly signerAddress: string;
+  readonly funderAddress: string;
+  readonly signatureType: number;
+  readonly walletMode: string;
+}
+
+export function getPreflightBlockingReason(checks: readonly PreflightCheck[]): string | null {
+  return checks.find((check) => check.blocking && !check.ok)?.summary ?? null;
+}
+
+export function buildExecutionModeCheck(executionMode: string | undefined): PreflightCheck {
+  const ok = executionMode === "live";
+  return {
+    key: "execution-mode",
+    blocking: true,
+    ok,
+    summary: ok ? "Execution mode is live." : `AUTOPOLY_EXECUTION_MODE must be live. Received ${executionMode ?? "-"}.`
+  };
+}
+
+export function buildEnvFileCheck(envFilePath: string | null | undefined, runContext: string): PreflightCheck {
+  return {
+    key: "env-file",
+    blocking: true,
+    ok: Boolean(envFilePath),
+    summary: envFilePath ? `Using env file ${envFilePath}.` : `ENV_FILE is required for ${runContext}.`
+  };
+}
+
+export function buildCredentialsCheck(input: {
+  usesOnchainOsWallet: boolean;
+  walletIdentity: PreflightWalletIdentity | null;
+  walletIdentityError: string | null;
+  hasPrivateKey: boolean;
+  hasFunderAddress: boolean;
+  blocking: boolean;
+}): PreflightCheck {
+  const { usesOnchainOsWallet, walletIdentity, walletIdentityError, hasPrivateKey, hasFunderAddress, blocking } = input;
+  return {
+    key: "credentials",
+    blocking,
+    ok: usesOnchainOsWallet ? walletIdentity != null : Boolean(hasPrivateKey && hasFunderAddress),
+    summary: usesOnchainOsWallet
+      ? walletIdentity
+        ? `WALLET_PROVIDER=onchainos. Active signer ${maskAddressForDisplay(walletIdentity.signerAddress)}; Polymarket funder ${maskAddressForDisplay(walletIdentity.funderAddress)}; signatureType=${walletIdentity.signatureType}.`
+        : `WALLET_PROVIDER=onchainos, but wallet identity could not be resolved: ${walletIdentityError ?? "unknown error"}.`
+      : hasPrivateKey && hasFunderAddress
+        ? "PRIVATE_KEY and FUNDER_ADDRESS are present."
+        : "Missing PRIVATE_KEY or FUNDER_ADDRESS."
+  };
+}
+
+export function buildSignerFunderCheck(input: {
+  usesOnchainOsWallet: boolean;
+  walletIdentity: PreflightWalletIdentity | null;
+  signerAddress: string;
+  funderAddress: string;
+  signerMatchesFunder: boolean;
+}): PreflightCheck {
+  const { usesOnchainOsWallet, walletIdentity, signerAddress, funderAddress, signerMatchesFunder } = input;
+  return {
+    key: "signer-funder",
+    blocking: false,
+    ok: true,
+    summary: usesOnchainOsWallet
+      ? walletIdentity
+        ? `OnchainOS signer ${maskAddressForDisplay(walletIdentity.signerAddress)} trades through ${walletIdentity.walletMode} funder ${maskAddressForDisplay(walletIdentity.funderAddress)}.`
+        : "OnchainOS signer/funder alignment is unavailable until the wallet session resolves."
+      : !signerAddress
+        ? "Unable to derive signer address from PRIVATE_KEY."
+        : !funderAddress
+          ? "FUNDER_ADDRESS is missing."
+          : signerMatchesFunder
+            ? "Signer address matches FUNDER_ADDRESS."
+            : `Signer ${signerAddress} does not match FUNDER_ADDRESS ${funderAddress}. Proceeding in non-blocking mode (proxy/funder setup may be intentional).`
+  };
+}

--- a/scripts/pulse-live.ts
+++ b/scripts/pulse-live.ts
@@ -78,6 +78,13 @@ import {
   writeJsonArtifact
 } from "./live-run-common.ts";
 import {
+  buildCredentialsCheck,
+  buildEnvFileCheck,
+  buildExecutionModeCheck,
+  buildSignerFunderCheck,
+  getPreflightBlockingReason
+} from "./preflight-checks.ts";
+import {
   probeCollateralBalanceUsd
 } from "./live-preflight-probes.ts";
 import { appendEquitySnapshot } from "./equity-snapshot.ts";
@@ -236,10 +243,6 @@ function getErrorRawSummary(error: unknown): string | null {
     return null;
   }
   return getErrorMessage(cause);
-}
-
-function getPreflightBlockingReason(checks: PreflightReport["checks"]): string | null {
-  return checks.find((check) => check.blocking && !check.ok)?.summary ?? null;
 }
 
 function getMarketBindingBlocks(items: SkippedDecision[]) {
@@ -534,50 +537,23 @@ async function runPreflight(input: {
     collateralProbe.balanceUsd ?? input.orchestratorConfig.initialBankrollUsd
   );
   const checks = [
-    {
-      key: "execution-mode",
-      blocking: true,
-      ok: process.env.AUTOPOLY_EXECUTION_MODE === "live",
-      summary: process.env.AUTOPOLY_EXECUTION_MODE === "live"
-        ? "Execution mode is live."
-        : `AUTOPOLY_EXECUTION_MODE must be live. Received ${process.env.AUTOPOLY_EXECUTION_MODE ?? "-"}.`
-    },
-    {
-      key: "env-file",
-      blocking: true,
-      ok: Boolean(input.orchestratorConfig.envFilePath ?? input.executorConfig.envFilePath),
-      summary: (input.orchestratorConfig.envFilePath ?? input.executorConfig.envFilePath)
-        ? `Using env file ${(input.orchestratorConfig.envFilePath ?? input.executorConfig.envFilePath)}.`
-        : "ENV_FILE is required for forecast:live runs."
-    },
-    {
-      key: "credentials",
-      blocking: true,
-      ok: usesOnchainOsWallet ? walletIdentity != null : Boolean(input.executorConfig.privateKey && input.executorConfig.funderAddress),
-      summary: usesOnchainOsWallet
-        ? walletIdentity
-          ? `WALLET_PROVIDER=onchainos. Active signer ${maskAddressForDisplay(walletIdentity.signerAddress)}; Polymarket funder ${maskAddressForDisplay(walletIdentity.funderAddress)}; signatureType=${walletIdentity.signatureType}.`
-          : `WALLET_PROVIDER=onchainos, but wallet identity could not be resolved: ${walletIdentityError ?? "unknown error"}.`
-        : input.executorConfig.privateKey && input.executorConfig.funderAddress
-          ? "PRIVATE_KEY and FUNDER_ADDRESS are present."
-          : "Missing PRIVATE_KEY or FUNDER_ADDRESS."
-    },
-    {
-      key: "signer-funder",
-      blocking: false,
-      ok: true,
-      summary: usesOnchainOsWallet
-        ? walletIdentity
-          ? `OnchainOS signer ${maskAddressForDisplay(walletIdentity.signerAddress)} trades through ${walletIdentity.walletMode} funder ${maskAddressForDisplay(walletIdentity.funderAddress)}.`
-          : "OnchainOS signer/funder alignment is unavailable until the wallet session resolves."
-        : !signerAddress
-        ? "Unable to derive signer address from PRIVATE_KEY."
-        : !funderAddress
-          ? "FUNDER_ADDRESS is missing."
-          : signerMatchesFunder
-            ? "Signer address matches FUNDER_ADDRESS."
-            : `Signer ${signerAddress} does not match FUNDER_ADDRESS ${funderAddress}. Proceeding in non-blocking mode (proxy/funder setup may be intentional).`
-    },
+    buildExecutionModeCheck(process.env.AUTOPOLY_EXECUTION_MODE),
+    buildEnvFileCheck(input.orchestratorConfig.envFilePath ?? input.executorConfig.envFilePath, "forecast:live runs"),
+    buildCredentialsCheck({
+      usesOnchainOsWallet,
+      walletIdentity,
+      walletIdentityError,
+      hasPrivateKey: Boolean(input.executorConfig.privateKey),
+      hasFunderAddress: Boolean(input.executorConfig.funderAddress),
+      blocking: true
+    }),
+    buildSignerFunderCheck({
+      usesOnchainOsWallet,
+      walletIdentity,
+      signerAddress,
+      funderAddress: funderAddress ?? "",
+      signerMatchesFunder: Boolean(signerMatchesFunder)
+    }),
     {
       key: "collateral",
       blocking: !input.recommendOnly,


### PR DESCRIPTION
## ⚠️ 触及实盘下单入口——请单独 review 后再合

延续复杂度重构 Stage 2。**用量数据背书了风险判断**，但因为改的是实盘 preflight 安全闸，单独开 PR 给你过目。

## 发现：三条入口的 preflight 已经分叉，且有一个潜在漏洞

execution-mode / env-file / credentials / signer-funder 四道闸在 forecast:live 和 agent:persistent 里各写一份、已漂移。**最关键**:只有 forecast:live 处理 onchainos 钱包——**同一个 onchainos 钱包，从 forecast:live 进能过凭据闸，从 agent:persistent 进会被判凭据缺失**。

## 做法（以 pulse-live 为准，冷门路径对齐）

抽出四道公共闸 + getPreflightBlockingReason 到有单测的 `scripts/preflight-checks.ts`:
- **pulse-live（主力/热）**:逐字节不变（builder 就是它原来的内联 check 逐字搬出）。
- **agent:persistent（冷）**:对齐 canonical，顺带**修掉 onchainos 漏洞**（现在和 pulse-live 一样解析签名身份）。
- **live-test**:保留它自己另一套形状、已有测试的纯函数 preflight，不动。

## 用量数据支撑风险判断（你要求分析的）

| 入口 | 真实运行归档 | 近3月提交 | 判断 |
|---|---|---|---|
| forecast:live (pulse-live) | **8 次**（都在 7-03，活跃）| 6 | 主力真钱入口，逐字节保留 |
| agent:persistent | **0 次**（从没真跑过）| 1 | 冷门，对齐 canonical 近零风险 |
| live-test | 0 次 | 2 | 冷门，形状不同+有测试，保留 |

## Test plan
- [x] pulse-live 逐字节不变（scripts tsc 门禁 13 不变、无新错误、行号仅位移）
- [x] 6 个特征化测试锁住共享 builder 的 canonical 行为
- [x] `pnpm test` 838/838（含 runner 测试）
- [x] **未下任何实盘单**（纯代码重构 + dry typecheck/test）

**建议**：合并前你可以 dry-run 一次 `ENV_FILE=.env.pizza pnpm forecast:recommend`（只读、不下单）确认 preflight 表格输出与之前一致。