### PR TITLE
refactor(executor): single Gamma transport helper (Stage 2)

### DIFF
--- a/services/executor/src/lib/gamma.ts
+++ b/services/executor/src/lib/gamma.ts
@@ -1,0 +1,17 @@
+// Single transport for every executor call to the Polymarket Gamma API.
+//
+// The Gamma clients across the executor (polymarket-sdk.ts, redeem.ts,
+// orderbook-limits.ts) each hardcoded the host and hit DIFFERENT endpoints
+// (/events/slug, /markets, /public-profile) with DIFFERENT response parsing and
+// DIFFERENT error handling — some throw, some degrade gracefully. Those choices
+// legitimately differ per call site, so this helper owns ONLY the transport:
+// the base URL and a consistent client user-agent. Callers keep their own
+// parsing + error handling.
+export const GAMMA_BASE = "https://gamma-api.polymarket.com";
+
+export function gammaFetch(path: string, init?: RequestInit): Promise<Response> {
+  return fetch(`${GAMMA_BASE}${path}`, {
+    ...init,
+    headers: { "user-agent": "@autopoly/executor", ...init?.headers }
+  });
+}

--- a/services/executor/src/lib/orderbook-limits.ts
+++ b/services/executor/src/lib/orderbook-limits.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { gammaFetch } from "./gamma.js";
 import type { BookSnapshot } from "./polymarket-sdk.js";
 
 export interface PersistedPolymarketOrderLimit {
@@ -153,13 +154,8 @@ async function writeStore(filePath: string, store: PersistedPolymarketOrderLimit
 }
 
 async function fetchActiveMarketPage(limit: number, offset: number) {
-  const response = await fetch(
-    `https://gamma-api.polymarket.com/markets?limit=${limit}&offset=${offset}&active=true&closed=false&order=liquidity&ascending=false`,
-    {
-      headers: {
-        "user-agent": "@autopoly/executor"
-      }
-    }
+  const response = await gammaFetch(
+    `/markets?limit=${limit}&offset=${offset}&active=true&closed=false&order=liquidity&ascending=false`
   );
   if (!response.ok) {
     throw new Error(`Gamma API failed: ${response.status}`);

--- a/services/executor/src/lib/polymarket-sdk.ts
+++ b/services/executor/src/lib/polymarket-sdk.ts
@@ -3,6 +3,7 @@ import { ClobClient, OrderType, Side, type Chain } from "@polymarket/clob-client
 import { buildPaperOrderResult } from "@autopoly/contracts";
 import { Wallet } from "ethers";
 import type { ExecutorConfig } from "../config.js";
+import { gammaFetch } from "./gamma.js";
 import {
   OkxAgenticSigner,
   type ExecutorWalletProvider,
@@ -96,14 +97,7 @@ export async function fetchPolymarketProxyWallet(address: string): Promise<strin
   }
 
   try {
-    const response = await fetch(
-      `https://gamma-api.polymarket.com/public-profile?address=${encodeURIComponent(normalizedAddress)}`,
-      {
-        headers: {
-          "user-agent": "@autopoly/executor"
-        }
-      }
-    );
+    const response = await gammaFetch(`/public-profile?address=${encodeURIComponent(normalizedAddress)}`);
 
     if (response.status === 404) {
       return null;
@@ -515,7 +509,7 @@ export async function fetchRemotePositions(config: ExecutorConfig): Promise<Remo
 }
 
 export async function fetchEventBySlug(_config: ExecutorConfig, slug: string): Promise<GammaRecord> {
-  const response = await fetch(`https://gamma-api.polymarket.com/events/slug/${encodeURIComponent(slug)}`);
+  const response = await gammaFetch(`/events/slug/${encodeURIComponent(slug)}`);
   if (!response.ok) {
     throw new Error(`Failed to resolve event slug "${slug}": ${response.status}`);
   }
@@ -527,7 +521,7 @@ export async function fetchEventBySlug(_config: ExecutorConfig, slug: string): P
 }
 
 export async function fetchMarketBySlug(_config: ExecutorConfig, slug: string): Promise<GammaRecord[]> {
-  const response = await fetch(`https://gamma-api.polymarket.com/markets?slug=${encodeURIComponent(slug)}`);
+  const response = await gammaFetch(`/markets?slug=${encodeURIComponent(slug)}`);
   if (!response.ok) {
     throw new Error(`Failed to resolve market slug "${slug}": ${response.status}`);
   }
@@ -540,8 +534,8 @@ export async function fetchMarketBySlug(_config: ExecutorConfig, slug: string): 
 
 export async function fetchActiveMarkets(_config: ExecutorConfig, limit = 100): Promise<GammaRecord[]> {
   const clampedLimit = Math.max(1, Math.min(500, Math.trunc(limit)));
-  const response = await fetch(
-    `https://gamma-api.polymarket.com/markets?limit=${clampedLimit}&active=true&closed=false&order=liquidity&ascending=false`
+  const response = await gammaFetch(
+    `/markets?limit=${clampedLimit}&active=true&closed=false&order=liquidity&ascending=false`
   );
   if (!response.ok) {
     throw new Error(`Gamma API failed: ${response.status}`);

--- a/services/executor/src/lib/redeem.ts
+++ b/services/executor/src/lib/redeem.ts
@@ -1,5 +1,6 @@
 import { Contract, Wallet, providers } from "ethers";
 import type { ExecutorConfig } from "../config.js";
+import { gammaFetch } from "./gamma.js";
 import { fetchRemotePositions, type RemotePosition } from "./polymarket-sdk.js";
 
 // ConditionalTokens contract on Polygon
@@ -81,10 +82,7 @@ export async function fetchMarketResolutionStatus(
   conditionId: string | null;
   winnerTokenId: string | null;
 }> {
-  const response = await fetch(
-    `https://gamma-api.polymarket.com/markets?slug=${encodeURIComponent(marketSlug)}`,
-    { headers: { "user-agent": "@autopoly/executor" } }
-  );
+  const response = await gammaFetch(`/markets?slug=${encodeURIComponent(marketSlug)}`);
 
   if (!response.ok) {
     return { resolved: false, conditionId: null, winnerTokenId: null };


### PR DESCRIPTION
## ⚠️ 触及实盘 executor（赎回/下单量）——请单独 review + dry-run 后再合

延续 Stage 2。你让我"写 Gamma executor 收敛"——做完了，但先说清楚我发现的真相。

## "6→1" 前提不成立

executor 的三个 Gamma 客户端各打**不同 endpoint**、**不同解析**、**不同错误处理**：
- polymarket-sdk：`/events/slug` + `/markets` + `/public-profile`（错误抛异常）
- redeem：`/markets?slug`（错误**优雅返回** `{resolved:false}`——这是赎回中奖仓位的路径，绝不能改成抛异常）
- orderbook-limits：`/markets?limit&offset`（带 **offset 分页**，sdk 不支持）

所以**不能**"让 redeem/orderbook 直接用 sdk 的 fetcher"——那会改掉真钱路径的错误处理。它们唯一真正共享的是**传输层**（host 字符串）。

## 做法（只收敛传输层，行为保留）

新增 `services/executor/src/lib/gamma.ts` 的 `gammaFetch(path, init?)`（共享 base URL + 统一 user-agent）；6 个调用点全部走它，**各自保留自己的解析和错误处理**。redeem 的优雅降级、orderbook 的 offset 分页原封不动。

收益：Gamma host 从 6 处硬编码收敛到 1 处（换 host = 一处改动）、所有 executor 的 Gamma 访问可 grep 可审计。

## Test plan
- [x] 3 个文件里硬编码 host 归零
- [x] executor typecheck + build 绿
- [x] **executor 测试 53/53**（redeem 22/22 含 resolution-status 的 URL/解析断言、orderbook 4/4）——强证明请求等价
- [x] 全量 838/838
- [x] **未下任何实盘单**

**行为变化提示（唯一一处，评估为无害）**：polymarket-sdk 里 3 个只读 market-metadata GET 现在也带上 `@autopoly/executor` user-agent（之前没有）——对公开 Gamma GET 无影响（另 3 个调用一直带着它正常工作）。

**建议**：合并前 dry-run 一次 `ENV_FILE=.env.pizza pnpm forecast:recommend`（只读、不下单）确认市场数据抓取正常。
