### PR TITLE
refactor: Stage 2 loose ends — PnL formula single-source, managed ENV_FILE fix, recommendation wire-type locks

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,10 +1,12 @@
-// Barrel: the four contract domains are defined in sibling files and
-// re-exported here so `@autopoly/contracts` keeps its flat public surface.
+// Barrel: the contract domains are defined in sibling files and re-exported
+// here so `@autopoly/contracts` keeps its flat public surface.
 // - trade-decision: live-order schemas + queue/job/admin/system enums
 // - public-api: read-only shapes for the public web API
 // - paper-trading: paper-fill simulation logic
+// - recommendation-file: wire shape of the per-run recommendation.json
 // - rough-loop: dev-tool task schemas (consumed only by services/rough-loop)
 export * from "./trade-decision.js";
 export * from "./public-api.js";
 export * from "./paper-trading.js";
+export * from "./recommendation-file.js";
 export * from "./rough-loop.js";

--- a/packages/contracts/src/recommendation-file.ts
+++ b/packages/contracts/src/recommendation-file.ts
@@ -1,0 +1,76 @@
+// Wire shape of runtime-artifacts/pulse-live/<run>/recommendation.json — the
+// "order basis" file written once per forecast run and consumed by the report
+// renderers and the managed-trading bridge.
+//
+// IMPORTANT (see docs/internal/recommendation-json-operations-map.md):
+// - The file is a camelCase WRAPPER; decisions[] inside it are snake_case
+//   (decisionSchema) while executablePlans[] are camelCase. Both namings are
+//   real and must stay modeled separately.
+// - Stage 1 of the unification is COMPILE-TIME ONLY: the writer locks its
+//   literal with `satisfies RecommendationFile` and readers derive their local
+//   types from these schemas. Nothing calls .parse()/.safeParse() yet — the
+//   two disk readers deliberately soft-read (strict runtime validation would
+//   turn graceful degradation into aborted live runs; see the ops map).
+import { z } from "zod";
+import type { OverviewResponse } from "./public-api.js";
+import { actionSchema, decisionSchema, orderTypeSchema, sideSchema } from "./trade-decision.js";
+
+// Mirrors services/orchestrator/src/lib/execution-planning.ts PlannedExecution
+// (mutual-assignability asserted there in lib/wire-assertions.ts).
+export const plannedExecutionSchema = z.object({
+  action: actionSchema,
+  marketSlug: z.string(),
+  eventSlug: z.string(),
+  tokenId: z.string(),
+  outcomeLabel: z.string().nullish(),
+  side: sideSchema,
+  notionalUsd: z.number(),
+  bankrollRatio: z.number(),
+  executionAmount: z.number(),
+  unit: z.enum(["usd", "shares"]),
+  thesisMd: z.string(),
+  bestAsk: z.number().nullable(),
+  bestBid: z.number().nullable(),
+  minOrderSize: z.number().nullable(),
+  exchangeMinNotionalUsd: z.number().nullable(),
+  orderType: orderTypeSchema,
+  gtcLimitPrice: z.number().nullable(),
+  categorySlug: z.string().nullable(),
+  negRisk: z.boolean()
+});
+export type PlannedExecutionWire = z.infer<typeof plannedExecutionSchema>;
+
+// Mirrors execution-planning.ts SkippedDecision. Named "SkippedExecution*" to
+// avoid worsening the existing name collision with managed-trading's own,
+// structurally different SkippedDecision.
+export const skippedExecutionSchema = z.object({
+  action: actionSchema.nullable(),
+  marketSlug: z.string(),
+  tokenId: z.string().nullable(),
+  reason: z.string()
+});
+export type SkippedExecutionWire = z.infer<typeof skippedExecutionSchema>;
+
+// overview is typed (not validated): it is the OverviewResponse snapshot the
+// writer embeds; a zod schema for it belongs to the (future) runtime-
+// validation step, not the type-unification step.
+const overviewResponseType = z.custom<OverviewResponse>(
+  (value) => typeof value === "object" && value !== null
+);
+
+export const recommendationFileSchema = z.object({
+  runId: z.string(),
+  executionMode: z.string(),
+  envFilePath: z.string().nullable(),
+  collateralBalanceUsd: z.number(),
+  overview: overviewResponseType,
+  pulseMarkdownPath: z.string().nullable(),
+  pulseJsonPath: z.string().nullable(),
+  runtimeLogPath: z.string().nullable(),
+  promptSummary: z.string(),
+  reasoningMd: z.string(),
+  decisions: z.array(decisionSchema),
+  executablePlans: z.array(plannedExecutionSchema),
+  skipped: z.array(skippedExecutionSchema)
+});
+export type RecommendationFile = z.infer<typeof recommendationFileSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,9 +260,6 @@ importers:
       '@polymarket/clob-client-v2':
         specifier: 1.0.6
         version: 1.0.6(bufferutil@4.1.0)(typescript@5.9.3)(zod@3.25.76)
-      dotenv:
-        specifier: 17.2.3
-        version: 17.2.3
       drizzle-orm:
         specifier: 0.45.1
         version: 0.45.1(postgres@3.4.8)

--- a/scripts/pulse-live-helpers.ts
+++ b/scripts/pulse-live-helpers.ts
@@ -12,6 +12,7 @@ export {
   type PulseFilterArgs
 } from "../services/orchestrator/src/pulse/pulse-filters.ts";
 import type { PulseFilterArgs } from "../services/orchestrator/src/pulse/pulse-filters.ts";
+import { calculatePositionPnlPct as unroundedPositionPnlPct } from "../services/executor/src/lib/risk.ts";
 
 export function buildPulseLiveRunIdentityRows(input: {
   executionMode: string;
@@ -61,11 +62,14 @@ export function calculatePositionValueUsd(size: number, currentPrice: number) {
   return roundCurrency(size * currentPrice);
 }
 
+// Display variant of the executor's stop-loss PnL math: the FORMULA lives in
+// exactly one place (services/executor/src/lib/risk.ts, which stop-loss
+// comparisons consume unrounded); this wrapper only rounds for artifacts.
 export function calculatePositionPnlPct(avgCost: number, currentPrice: number) {
   if (!(avgCost > 0)) {
     return 0;
   }
-  return roundMetric((currentPrice - avgCost) / avgCost);
+  return roundMetric(unroundedPositionPnlPct(avgCost, currentPrice));
 }
 
 export function loadPulseFilterFile(filePath: string | null): PulseFilterArgs {

--- a/scripts/pulse-live.ts
+++ b/scripts/pulse-live.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { randomUUID } from "node:crypto";
-import type { OverviewResponse, PublicPosition, TradeDecision } from "@autopoly/contracts";
+import type { OverviewResponse, PublicPosition, RecommendationFile, TradeDecision } from "@autopoly/contracts";
 import {
   createTerminalPrinter,
   formatRatioPercent,
@@ -1158,6 +1158,9 @@ export async function runPulseLive(args: Args = parseArgs()) {
     });
     plansForSummary = plans;
     skippedForSummary = skipped;
+    // `satisfies` locks the on-disk shape to the shared wire schema at compile
+    // time (readers derive their types from the same schema); the emitted
+    // object is unchanged.
     await writeJsonArtifact(recommendationPath, {
       runId,
       executionMode: "pulse-live",
@@ -1172,7 +1175,7 @@ export async function runPulseLive(args: Args = parseArgs()) {
       decisions: coreResult.decisionSet.decisions,
       executablePlans: plans,
       skipped
-    });
+    } satisfies RecommendationFile);
 
     if (useHumanOutput) {
       printRecommendationSummary({

--- a/services/managed-trading/package.json
+++ b/services/managed-trading/package.json
@@ -32,7 +32,6 @@
     "@autopoly/db": "workspace:*",
     "@polymarket/builder-relayer-client": "^0.0.9",
     "@polymarket/clob-client-v2": "1.0.6",
-    "dotenv": "17.2.3",
     "drizzle-orm": "0.45.1",
     "ethers": "5.7.2",
     "viem": "2.31.0"

--- a/services/managed-trading/src/config.ts
+++ b/services/managed-trading/src/config.ts
@@ -5,8 +5,16 @@
 // on a real-money path. Mirrors the validation pattern used in
 // `services/executor/src/config.ts` (kept separate to avoid cross-service
 // coupling — if the schema diverges later, only one side needs to move).
+//
+// Env loading goes through the shared @autopoly/contracts/env loader (same as
+// executor/orchestrator) so ENV_FILE=.env.<wallet> switches THIS service too.
+// The previous bare `import "dotenv/config"` ignored ENV_FILE — on a shared
+// machine that meant executor/orchestrator switched wallets while
+// managed-trading silently kept reading .env (multi-state-source risk).
 
-import "dotenv/config";
+import { loadEnvFile } from "@autopoly/contracts/env";
+
+loadEnvFile();
 
 export type ManagedTradingMode = "paper" | "live";
 

--- a/services/managed-trading/src/proposed-decision-mapper.ts
+++ b/services/managed-trading/src/proposed-decision-mapper.ts
@@ -18,6 +18,7 @@
 // managed-trading package stays decoupled). Concrete file loading lives
 // in `scripts/managed-pulse.ts`.
 
+import type { PlannedExecutionWire, RecommendationFile, TradeDecision } from "@autopoly/contracts";
 import type {
   ProposedDecision,
   ProposedDecisionAction,
@@ -258,3 +259,26 @@ function clamp01(value: number): number {
   if (value > 1) return 1;
   return value;
 }
+
+// ---------------------------------------------------------------------------
+// Compile-time wire locks
+// ---------------------------------------------------------------------------
+//
+// The Pulse* input types above are DELIBERATELY looser than the wire (this
+// mapper narrows untrusted JSON), so we don't replace them with the contracts
+// types. Instead we assert one direction: every valid wire object must be
+// accepted by our loose input types. If the recommendation.json wire schema
+// in @autopoly/contracts renames or retypes a field this mapper reads, this
+// becomes a typecheck failure instead of the silent drift the header used to
+// warn about ("not enforced by a runtime schema").
+type WireAssignableTo<Wire, LooseInput> = [Wire] extends [LooseInput] ? true : never;
+
+const plannedExecutionWireAccepted: WireAssignableTo<PlannedExecutionWire, PulsePlannedExecution> = true;
+const tradeDecisionWireAccepted: WireAssignableTo<TradeDecision, PulseTradeDecision> = true;
+const recommendationFileWireAccepted: WireAssignableTo<RecommendationFile, PulseRecommendationFile> = true;
+
+export const pulseWireLocks = {
+  plannedExecutionWireAccepted,
+  tradeDecisionWireAccepted,
+  recommendationFileWireAccepted
+};

--- a/services/orchestrator/src/lib/wire-assertions.ts
+++ b/services/orchestrator/src/lib/wire-assertions.ts
@@ -1,0 +1,17 @@
+// Compile-time locks between the orchestrator's execution-planning types and
+// the recommendation.json wire schemas in @autopoly/contracts.
+//
+// The orchestrator interfaces stay the source the planner code reads; the
+// contracts schemas are what the recommendation.json writer/readers type
+// against. These mutual-assignability assertions make any drift between the
+// two a typecheck failure instead of a silently mis-shaped artifact (the
+// neg-risk fee field that was "sent but not received" cost three live fixes).
+import type { PlannedExecutionWire, SkippedExecutionWire } from "@autopoly/contracts";
+import type { PlannedExecution, SkippedDecision } from "./execution-planning.js";
+
+type MutuallyAssignable<A, B> = [A] extends [B] ? ([B] extends [A] ? true : never) : never;
+
+const plannedExecutionMatchesWire: MutuallyAssignable<PlannedExecution, PlannedExecutionWire> = true;
+const skippedDecisionMatchesWire: MutuallyAssignable<SkippedDecision, SkippedExecutionWire> = true;
+
+export const wireAssertions = { plannedExecutionMatchesWire, skippedDecisionMatchesWire };


### PR DESCRIPTION
## Stage 2 收尾:两个真钱相关漏项 + recommendation 编译期类型统一

用户批准的四步计划中的 ②③（① #73 已合、④ forecast-engine 抽包另开 PR）。全部**零运行时行为变化**（除 managed-trading 的 ENV_FILE 修复——那是有意的行为修正）。

### ② 两个漏项

1. **`calculatePositionPnlPct` 公式单源化**：executor `risk.ts`（未取整，喂止损判断）与 pulse-live-helpers（取整，喂归档）各有一份公式。现在 helpers 委托 risk.ts 的公式、只保留展示层取整——止损阈值数学只有一个落点。行为逐位一致（含 NaN/≤0 守卫语义）。
2. **managed-trading 忽略 ENV_FILE 的隐患修复**：原来裸 `import "dotenv/config"` 只读 `.env`——同机用 ENV_FILE 切钱包时 executor/orchestrator 切了、managed-trading **静默留在默认钱包 env**（CLAUDE.md §6 多状态源风险）。现在走共享 `@autopoly/contracts/env` loadEnvFile（ENV_FILE 优先 + override + fail-closed），与其他实盘服务对齐。顺删无用 dotenv 依赖。

### ③ recommendation.json 编译期类型统一（操作地图文档的第一步）

**全程无 .parse()**——按调研结论，运行时严格校验会把优雅降级变成实盘中断，留给未来单点 safeParse 步骤。本步只做类型锁：

- contracts 新增 `recommendation-file.ts`：camelCase 外壳 schema + `plannedExecutionSchema`/`skippedExecutionSchema`（内嵌复用 snake_case 的 `decisionSchema`——两套命名如实建模）
- **写盘方 pulse-live 加 `satisfies RecommendationFile`**：落盘形状被编译期锁死（首次尝试即通过 = 字面量与 schema 精确吻合，输出字节不变）
- orchestrator `wire-assertions.ts`：PlannedExecution/SkippedDecision 与 wire schema 互赋值断言
- managed-trading mapper：单向锁（wire 类型必须可赋值给 mapper 故意放宽的输入类型）——文件头自己警告的"not enforced by a runtime schema"静默漂移，现在变成编译错误，而防御性收窄语义原封不动

## Test plan
- [x] `pnpm -r typecheck` 全绿（三处编译期锁全部首次通过）
- [x] `pnpm typecheck:scripts` 基线 13 不变（satisfies 零新错 = 写盘字面量与 schema 吻合）
- [x] `pnpm test` 838/838
- [x] 未下任何实盘单
