### PR TITLE
fix(paper-agent): survive Gamma slug renames via conditionId fallback; persist invalid agent output

### DIFF
--- a/packages/forecast-engine/src/engine.ts
+++ b/packages/forecast-engine/src/engine.ts
@@ -26,7 +26,7 @@ import {
 import { isMarketPriceSource, marketBlind, marketBlindDirective } from "./market-blind";
 import { validateRoundOutput } from "./claude-agent";
 import type { AgentRunResult, RunAgentOptions } from "./claude-agent";
-import { loadAnalyst, saveAnalyst, saveState, writeReport } from "./store";
+import { loadAnalyst, saveAnalyst, saveState, writeDiagnostic, writeReport } from "./store";
 import { summarizeForecast } from "./summary";
 import { canonicalizeUrl } from "./url";
 import type {
@@ -245,6 +245,13 @@ async function runOneRound(
     out = validate(result);
   }
   if (!out) {
+    // Persist the invalid output for diagnosis — two production rounds aborted
+    // with "no JSON object" (2026-07-06/07) and left no trace to debug from.
+    try {
+      writeDiagnostic(state.eventId, `invalid-round-${roundNo}.txt`, result.rawFinalText ?? "");
+    } catch {
+      // diagnostic only — never mask the real error
+    }
     throw new Error(
       `round ${roundNo} aborted: agent output invalid after retry: ${result.jsonError ?? "schema mismatch"}\n` +
         `stderr: ${result.stderrTail}`

--- a/packages/forecast-engine/src/store.ts
+++ b/packages/forecast-engine/src/store.ts
@@ -128,6 +128,16 @@ export function saveAnalyst(eventId: string, a: AnalystState): void {
   writeFileAtomic(analystPath(eventId), JSON.stringify(a, null, 2));
 }
 
+// Diagnostic artifacts (e.g. an agent's invalid round output) — persisted next
+// to the dossier so production failures are diagnosable after the fact.
+export function writeDiagnostic(eventId: string, name: string, content: string): string {
+  const dir = eventDir(eventId);
+  mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, name);
+  writeFileSync(file, content, "utf8");
+  return file;
+}
+
 const pct = (p: number): string => `${(p * 100).toFixed(1)}%`;
 const signed = (pp: number): string => `${pp >= 0 ? "+" : ""}${pp.toFixed(1)}pp`;
 

--- a/services/paper-agent/src/evaluator.ts
+++ b/services/paper-agent/src/evaluator.ts
@@ -129,7 +129,12 @@ export async function evaluateMarket(market: MarketInfo, opts: EvaluateOptions):
     FORECAST_MARKET_BLIND: "1",
     // The owner reads these dossiers; default to Chinese prose (override with
     // PAPER_FORECAST_LANGUAGE=en). Machine fields stay ASCII either way.
-    FORECAST_LANGUAGE: process.env.PAPER_FORECAST_LANGUAGE ?? "zh"
+    FORECAST_LANGUAGE: process.env.PAPER_FORECAST_LANGUAGE ?? "zh",
+    // 10 min per agent call (engine default is 6): the review prompts mandate
+    // more searches per round (disconfirmation + primary source + native
+    // language) and a live round timed out at 360s on 2026-07-07. Two calls
+    // per eval still fit the 25-min child timeout.
+    FORECAST_AGENT_TIMEOUT_MS: process.env.FORECAST_AGENT_TIMEOUT_MS ?? "600000"
   };
   // For the OpenAI-compatible path, web research is ON by default (function-
   // calling loop; keyless DuckDuckGo unless TAVILY_API_KEY). Opt out with

--- a/services/paper-agent/src/polymarket.test.ts
+++ b/services/paper-agent/src/polymarket.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchMarket } from "./polymarket";
+
+// Gamma renamed a live market's slug in place (2026-07-07: putin-out-before-2027
+// → putin-out-before-2027-346, same conditionId). A held position must fall
+// back to its immutable conditionId or it can never be re-evaluated or settled.
+
+const RENAMED = {
+  slug: "putin-out-before-2027-346",
+  conditionId: "0x6bd5",
+  question: "Putin out as President of Russia by December 31, 2026?",
+  closed: false,
+  outcomes: '["Yes","No"]',
+  clobTokenIds: '["11","22"]',
+  outcomePrices: '["0.1","0.9"]',
+  events: [{ slug: "putin-out-before-2027" }]
+};
+
+function stubFetch(handler: (url: string) => unknown): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string) => ({
+      ok: true,
+      json: async () => handler(String(url))
+    }))
+  );
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("fetchMarket conditionId fallback", () => {
+  it("falls back to condition_ids when both slug lookups miss", async () => {
+    stubFetch((url) => (url.includes("condition_ids=") ? [RENAMED] : []));
+    const m = await fetchMarket("putin-out-before-2027", "0x6bd5");
+    expect(m.slug).toBe("putin-out-before-2027-346");
+    expect(m.conditionId).toBe("0x6bd5");
+    expect(m.resolution).toBe("open");
+  });
+
+  it("does not hit the fallback when the slug still resolves", async () => {
+    stubFetch((url) => {
+      if (url.includes("condition_ids=")) throw new Error("fallback must not be queried");
+      return url.includes("closed=true") ? [] : [RENAMED];
+    });
+    const m = await fetchMarket("putin-out-before-2027-346", "0x6bd5");
+    expect(m.slug).toBe("putin-out-before-2027-346");
+  });
+
+  it("reports that the fallback was tried when everything misses", async () => {
+    stubFetch(() => []);
+    await expect(fetchMarket("gone-market", "0xdead")).rejects.toThrow(/conditionId fallback tried/);
+  });
+
+  it("keeps the plain two-step error when no conditionId is available", async () => {
+    stubFetch(() => []);
+    await expect(fetchMarket("gone-market")).rejects.toThrow(/open or closed\)/);
+  });
+});

--- a/services/paper-agent/src/polymarket.ts
+++ b/services/paper-agent/src/polymarket.ts
@@ -99,14 +99,21 @@ function resolutionOf(closed: boolean, prices: number[] | null): { state: Resolu
 }
 
 // Two-step lookup: the plain slug query only returns OPEN markets; once a
-// market closes it only appears with &closed=true. A miss on both = the
-// market is gone/renamed (caller escalates to the operator).
-export async function fetchMarket(slug: string): Promise<MarketInfo> {
+// market closes it only appears with &closed=true. Polymarket also RENAMES
+// market slugs in place (live incident 2026-07-07: putin-out-before-2027 →
+// putin-out-before-2027-346, same conditionId), so a held position must be
+// able to fall back to its immutable conditionId — otherwise it can neither
+// be re-evaluated nor SETTLED for as long as the slug stays broken. A miss on
+// all lookups = the market is gone (caller escalates to the operator).
+export async function fetchMarket(slug: string, conditionId?: string): Promise<MarketInfo> {
   const enc = encodeURIComponent(slug);
   let rows = await fetchJson<GammaMarket[]>(`${GAMMA}/markets?slug=${enc}`);
   if (!rows.length) rows = await fetchJson<GammaMarket[]>(`${GAMMA}/markets?slug=${enc}&closed=true`);
+  if (!rows.length && conditionId) {
+    rows = await fetchJson<GammaMarket[]>(`${GAMMA}/markets?condition_ids=${encodeURIComponent(conditionId)}`);
+  }
   const m = rows[0];
-  if (!m) throw new Error(`no Polymarket market found for slug "${slug}" (open or closed)`);
+  if (!m) throw new Error(`no Polymarket market found for slug "${slug}" (open or closed${conditionId ? ", conditionId fallback tried" : ""})`);
   const outcomes = parseJsonArray(m.outcomes);
   const tokenIds = parseJsonArray(m.clobTokenIds);
   const priceStrings = parseJsonArray(m.outcomePrices);

--- a/services/paper-agent/src/run-cycle.ts
+++ b/services/paper-agent/src/run-cycle.ts
@@ -160,9 +160,21 @@ async function runEvaluationCycleLocked(cfg: PaperConfig): Promise<void> {
   for (const stale of [...portfolio.positions]) {
     const posId = stale.id;
     try {
-      const current = findPosition(portfolio, posId);
+      let current = findPosition(portfolio, posId);
       if (!current) continue;
-      const market = await fetchMarket(current.slug);
+      const market = await fetchMarket(current.slug, current.conditionId);
+      // Self-heal a Gamma slug rename (conditionId fallback found the market
+      // under a new slug): store the new slug so future lookups hit directly.
+      if (market.slug !== current.slug) {
+        log.warn(`slug renamed on Gamma: ${current.slug} → ${market.slug} (position ${posId})`);
+        appendLedger({ type: "slug_renamed", positionId: posId, slug: current.slug, newSlug: market.slug });
+        current = { ...current, slug: market.slug };
+        portfolio = {
+          ...portfolio,
+          positions: portfolio.positions.map((x) => (x.id === posId ? current! : x))
+        };
+        savePortfolio(portfolio);
+      }
 
       if (market.closed) {
         const settled = settleFromMarket(portfolio, current, market);
@@ -441,7 +453,7 @@ async function runFillTickLocked(cfg: PaperConfig): Promise<void> {
     try {
       const pos = findPosition(portfolio, posId);
       if (!pos) continue;
-      const market = await fetchMarket(pos.slug);
+      const market = await fetchMarket(pos.slug, pos.conditionId);
 
       if (market.closed) {
         const settled = settleFromMarket(portfolio, pos, market);


### PR DESCRIPTION
## 背景（18:00 UTC 首轮新代码运行的评估结论）

新机制验证全部通过：`saturatedAt:"floor"` 标记正常流转、dossier 状态出现 `saturated`（不再伪装 converged）、`marketBlind.enabled=true` 且 blockedCount=0（prompt 禁令生效，无需拦截）、watchlist_eval 开始记录 `marketProbYes`（Brier 基线）。

但暴露两个生产问题：

1. **Gamma 把在持市场的 slug 原地改名**（`putin-out-before-2027` → `putin-out-before-2027-346`，conditionId 不变），02:08 UTC 起该持仓评估报错 "no Polymarket market found"。slug 是查询主键——不修的话该仓位**永远无法结算**。
   - 修复：`fetchMarket(slug, conditionId?)` 双查 miss 后走 `/markets?condition_ids=` 兜底（持仓必带 conditionId）；评估周期检测到改名即自愈更新存储的 slug（ledger 记 `slug_renamed`）；fill tick 同样兜底。
2. **两轮 agent 输出无 JSON 失败（重试后仍失败）无任何诊断痕迹**（7-06 18:12 / 7-07 02:04，旧代码 30+ 评估零此错，新 prompt 下 ~10 次出现 2 次，需要原始输出才能定位是否 prompt 变长/中文指令所致）。
   - 修复：验证失败时把原始 final text 落盘到 dossier 目录 `invalid-round-N.txt`。失败本身是安全的（该仓位本轮 hold，下轮自动恢复——7-07 02:14 同市场已成功续跑）。

## 验证

- 4 个新 fetchMarket fallback 单测（含"slug 正常时不得触发兜底"）；受影响两包 138 测试全绿；forecast-engine / paper-agent / raven typecheck 绿
- 线上实证：本机直查 Gamma 确认旧 slug 开/闭均 404、新 slug 同 conditionId 存在