### PR TITLE
feat(raven-delta): LongPort (长桥) MCP — read-only live market data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -224,3 +224,15 @@ DELTA_WS_TOKEN=
 DELTA_WS_SUBSCRIBE_TOKEN=
 DELTA_WS_BROADCAST_URL=
 DELTA_DELIVERY_TIMEOUT_MS=
+# LongPort (长桥) MCP — READ-ONLY market data for the claude-cli engine only.
+# Gives the analyst live US/HK quotes, candlesticks & fundamentals to ground its
+# numbers. The integration exposes ONLY read market-data tools (allowlist in
+# lib/analyzer/longport-mcp.ts); order/account/watchlist-write tools are never
+# reachable. Off unless DELTA_LONGPORT_ENABLED=1 AND DELTA_PROVIDER=claude.
+DELTA_LONGPORT_ENABLED=
+# Hosted endpoint (default https://mcp.longportapp.com) or a self-hosted URL.
+DELTA_LONGPORT_MCP_URL=
+# A LongPort OAuth access token for headless auth (injected as a Bearer header).
+# SECRET. Leave empty to instead rely on a claude session that already ran
+# `claude mcp add --transport http longport https://mcp.longportapp.com` + OAuth.
+DELTA_LONGPORT_TOKEN=

--- a/apps/raven-delta/lib/analyzer/analyze.ts
+++ b/apps/raven-delta/lib/analyzer/analyze.ts
@@ -5,6 +5,7 @@
 import { headlineOf, type DeltaAnalysis, type DeltaRun, type EngineId, type NewsInput, type RunStage } from "./schema";
 import { buildAnalysisPrompt } from "./prompt";
 import { resolveEngine, runLlmAnalysis } from "./provider";
+import { resolveLongport } from "./longport-mcp";
 import { runRulesAnalysis } from "./rules-engine";
 import { getUniverse } from "./universe";
 import { saveRun } from "./store";
@@ -34,12 +35,16 @@ export async function runDeltaAnalysis(news: NewsInput, now = new Date()): Promi
   let engineFallbackReason: string | null = engine === "rules" ? resolution.reason : null;
   let analysis: DeltaAnalysis;
 
+  // LongPort live market data is only reachable by the claude-cli engine.
+  const longport = resolveLongport();
+  const promptEngine = engine; // the engine the prompt was built for (may fall back below)
+
   const engineStart = Date.now();
   if (engine === "rules") {
     analysis = runRulesAnalysis(news, nowIso);
   } else {
     try {
-      analysis = await runLlmAnalysis(engine, buildAnalysisPrompt(news));
+      analysis = await runLlmAnalysis(engine, buildAnalysisPrompt(news, engine));
     } catch (error) {
       engineFallbackReason = `${engine} failed: ${error instanceof Error ? error.message : String(error)}`;
       engine = "rules";
@@ -47,6 +52,22 @@ export async function runDeltaAnalysis(news: NewsInput, now = new Date()): Promi
     }
   }
   stages.push({ id: "engine", title: `engine:${engine}`, durationMs: Date.now() - engineStart });
+  // Record whether the analyst had live market data (surfaced to the reader so a
+  // price-grounded run is distinguishable from a news-text-only one — never a
+  // silent capability difference, repo rule §6). Computed on the FINAL engine:
+  // a claude run that fell back to rules never touched a live price.
+  const marketDataLive = engine === "claude-cli" && longport.enabled;
+  const marketDataOffReason =
+    promptEngine === "claude-cli" && longport.enabled
+      ? `fell back to ${engine}`
+      : engine === "claude-cli"
+        ? longport.reason
+        : "engine has no MCP tools";
+  stages.push({
+    id: "market-data",
+    title: marketDataLive ? "longport:live" : `longport:off (${marketDataOffReason})`,
+    durationMs: 0,
+  });
 
   const run: DeltaRun = {
     id: buildRunId(headline, nowIso),

--- a/apps/raven-delta/lib/analyzer/longport-mcp.test.ts
+++ b/apps/raven-delta/lib/analyzer/longport-mcp.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readFileSync, statSync, existsSync } from "node:fs";
+import {
+  LONGPORT_ALLOWED_TOOL_IDS,
+  LONGPORT_BLOCKED_TOOLS,
+  LONGPORT_BLOCKED_TOOL_IDS,
+  LONGPORT_READ_TOOLS,
+  LONGPORT_SERVER_NAME,
+  assertReadOnlyAllowlist,
+  buildLongportMcpConfig,
+  isSensitiveToolName,
+  longportMcpUrl,
+  prepareLongportCli,
+  resolveLongport,
+} from "./longport-mcp";
+
+afterEach(() => vi.unstubAllEnvs());
+
+// The load-bearing safety property: no read tool the analyst can reach is a
+// trade / account / write tool. A regression here could let an autonomous LLM
+// place real orders against a real brokerage account.
+describe("LongPort allowlist safety", () => {
+  it("never exposes any order/trade tool", () => {
+    for (const forbidden of ["submit_order", "cancel_order", "replace_order", "estimate_max_purchase_quantity"]) {
+      expect(LONGPORT_READ_TOOLS).not.toContain(forbidden);
+      expect(LONGPORT_ALLOWED_TOOL_IDS).not.toContain(`mcp__${LONGPORT_SERVER_NAME}__${forbidden}`);
+    }
+  });
+
+  it("never exposes account / portfolio reads or funds movement", () => {
+    for (const forbidden of ["account_balance", "stock_positions", "fund_positions", "cash_flow", "bank_cards", "deposits", "withdrawals"]) {
+      expect(LONGPORT_READ_TOOLS).not.toContain(forbidden);
+    }
+  });
+
+  it("never exposes the watchlist WRITE tools that hide in the quote category", () => {
+    for (const forbidden of ["create_watchlist_group", "delete_watchlist_group", "update_watchlist_group", "watchlist"]) {
+      expect(LONGPORT_READ_TOOLS).not.toContain(forbidden);
+    }
+  });
+
+  it("keeps the allowlist and blocklist strictly disjoint", () => {
+    const blocked = new Set(LONGPORT_BLOCKED_TOOLS);
+    for (const allowed of LONGPORT_READ_TOOLS) {
+      expect(blocked.has(allowed)).toBe(false);
+    }
+  });
+
+  it("qualifies every tool with the mcp__longport__ prefix", () => {
+    for (const id of LONGPORT_ALLOWED_TOOL_IDS) {
+      expect(id.startsWith(`mcp__${LONGPORT_SERVER_NAME}__`)).toBe(true);
+    }
+    for (const id of LONGPORT_BLOCKED_TOOL_IDS) {
+      expect(id.startsWith(`mcp__${LONGPORT_SERVER_NAME}__`)).toBe(true);
+    }
+  });
+
+  it("includes the core market-data reads a news-impact desk needs", () => {
+    for (const wanted of ["quote", "candlesticks", "history_candlesticks_by_date", "market_status", "valuation"]) {
+      expect(LONGPORT_READ_TOOLS).toContain(wanted);
+    }
+  });
+
+  it("passes the fail-closed sensitive-pattern assertion for the real allowlist", () => {
+    expect(() => assertReadOnlyAllowlist()).not.toThrow();
+  });
+
+  it("the sensitive-pattern assertion does NOT false-positive on genuine market-data reads", () => {
+    // short_positions = market short interest (read); capital_flow, fund_holder,
+    // trade_stats, short_trades are all legitimate reads that superficially
+    // resemble account/trade tools.
+    for (const safe of ["short_positions", "capital_flow", "fund_holder", "trade_stats", "short_trades", "operating"]) {
+      expect(LONGPORT_READ_TOOLS).toContain(safe);
+      expect(isSensitiveToolName(safe)).toBe(false);
+    }
+    expect(() => assertReadOnlyAllowlist()).not.toThrow();
+  });
+
+  it("the sensitive-pattern catches every write/trade/account tool (fail-closed backstop)", () => {
+    for (const dangerous of [
+      "submit_order",
+      "cancel_order",
+      "replace_order",
+      "account_balance",
+      "stock_positions",
+      "fund_positions",
+      "today_orders",
+      "history_executions",
+      "cash_flow",
+      "create_watchlist_group",
+      "delete_watchlist_group",
+      "deposits",
+      "withdrawals",
+      "dca_create",
+      "alert_add",
+      "sharelist_create",
+      "statement_export",
+      "authenticate",
+      "quant_run",
+      "estimate_max_purchase_quantity",
+    ]) {
+      expect(isSensitiveToolName(dangerous)).toBe(true);
+    }
+  });
+});
+
+describe("resolveLongport", () => {
+  it("is OFF by default", () => {
+    vi.stubEnv("DELTA_LONGPORT_ENABLED", "");
+    expect(resolveLongport().enabled).toBe(false);
+  });
+
+  it("is ON only with the explicit opt-in", () => {
+    vi.stubEnv("DELTA_LONGPORT_ENABLED", "1");
+    expect(resolveLongport().enabled).toBe(true);
+    vi.stubEnv("DELTA_LONGPORT_ENABLED", "true");
+    expect(resolveLongport().enabled).toBe(false); // only "1" enables
+  });
+});
+
+describe("buildLongportMcpConfig", () => {
+  it("points at the hosted endpoint by default with no auth header", () => {
+    vi.stubEnv("DELTA_LONGPORT_TOKEN", "");
+    vi.stubEnv("DELTA_LONGPORT_MCP_URL", "");
+    const { config, hasToken } = buildLongportMcpConfig();
+    const server = config.mcpServers[LONGPORT_SERVER_NAME]!;
+    expect(server.type).toBe("http");
+    expect(server.url).toBe("https://mcp.longportapp.com");
+    expect(server.headers).toBeUndefined();
+    expect(hasToken).toBe(false);
+  });
+
+  it("injects a bearer header when a token is provided", () => {
+    vi.stubEnv("DELTA_LONGPORT_TOKEN", "tok-123");
+    const { config, hasToken } = buildLongportMcpConfig();
+    expect(config.mcpServers[LONGPORT_SERVER_NAME]!.headers).toEqual({ Authorization: "Bearer tok-123" });
+    expect(hasToken).toBe(true);
+  });
+
+  it("honors a custom endpoint and strips trailing slashes", () => {
+    vi.stubEnv("DELTA_LONGPORT_MCP_URL", "http://127.0.0.1:8000/");
+    expect(longportMcpUrl()).toBe("http://127.0.0.1:8000");
+  });
+});
+
+describe("prepareLongportCli", () => {
+  it("writes a private (0600) mcp-config temp file and cleans it up", () => {
+    vi.stubEnv("DELTA_LONGPORT_TOKEN", "secret-token");
+    const cli = prepareLongportCli();
+    try {
+      expect(existsSync(cli.configPath)).toBe(true);
+      const mode = statSync(cli.configPath).mode & 0o777;
+      expect(mode).toBe(0o600);
+      const written = JSON.parse(readFileSync(cli.configPath, "utf8")) as {
+        mcpServers: Record<string, { headers?: Record<string, string> }>;
+      };
+      expect(written.mcpServers[LONGPORT_SERVER_NAME]!.headers!.Authorization).toBe("Bearer secret-token");
+      expect(cli.allowedTools).toEqual(LONGPORT_ALLOWED_TOOL_IDS);
+      expect(cli.disallowedTools).toEqual(LONGPORT_BLOCKED_TOOL_IDS);
+    } finally {
+      cli.cleanup();
+    }
+    expect(existsSync(cli.configPath)).toBe(false);
+  });
+});

--- a/apps/raven-delta/lib/analyzer/longport-mcp.ts
+++ b/apps/raven-delta/lib/analyzer/longport-mcp.ts
@@ -1,0 +1,294 @@
+// LongPort (长桥/Longbridge) MCP integration — READ-ONLY market data only.
+//
+// Wires the official LongPort MCP server (github.com/longportapp/longport-mcp,
+// hosted at https://mcp.longportapp.com) into the claude-cli engine so the
+// news-impact analyst can ground its numbers (direction, expectedMovePct) on
+// the ACTUAL live price and recent move of an impacted US stock, instead of
+// reasoning from the news text alone.
+//
+// SAFETY MODEL — non-negotiable, this is a real brokerage account:
+//   The LongPort MCP exposes 145 tools, 14 of which PLACE/CANCEL/REPLACE REAL
+//   ORDERS (submit_order, cancel_order, replace_order, ...) plus account,
+//   funds-transfer, DCA, alert and watchlist WRITE tools. Raven Delta is a
+//   demo_read_only news engine and the whole project is PAPER-ONLY. So we use
+//   an ALLOWLIST-ONLY control: claude's --allowedTools names ONLY the read
+//   market-data tools; every tool NOT on the list is unreachable. A missed
+//   read tool is merely unavailable (harmless); a leaked write tool would be
+//   catastrophic — so the list is curated, never a wildcard. The allowlist is
+//   the SOLE load-bearing control. The --disallowedTools denylist is a
+//   best-effort, hand-curated subset (defense-in-depth only) — do NOT relax
+//   allowlist curation trusting it to catch a write tool it may not list.
+//   As a fail-closed backstop, assertReadOnlyAllowlist() throws (rather than
+//   spawn) if any allowlisted name matches a sensitive order/account pattern.
+//
+// Tool names verified against longportapp/longport-mcp src/tools/*.rs
+// (145 tools across 13 categories, retrieved 2026-07-07).
+
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// The MCP server name we register under; claude exposes each tool as
+// `mcp__${SERVER_NAME}__<tool>`. Fixed so the allowlist prefixes are stable.
+export const LONGPORT_SERVER_NAME = "longport";
+
+// READ-ONLY market-data tools we expose to the analyst. Scope (user decision
+// 2026-07-07): "quotes + market data" — Quote (reads) + Market + Fundamental +
+// Calendar + the `now` utility. Deliberately EXCLUDES the three watchlist-write
+// tools that live in the quote category, plus account/portfolio reads, news
+// screeners, and the server-side quant_run script executor.
+export const LONGPORT_READ_TOOLS: readonly string[] = Object.freeze([
+  // --- Quote (real-time & historical market data; reads only) ---
+  "static_info",
+  "quote",
+  "option_quote",
+  "warrant_quote",
+  "depth",
+  "brokers",
+  "participants",
+  "trades",
+  "intraday",
+  "candlesticks",
+  "history_candlesticks_by_offset",
+  "history_candlesticks_by_date",
+  "trading_days",
+  "option_chain_expiry_date_list",
+  "option_chain_info_by_date",
+  "capital_flow",
+  "capital_distribution",
+  "trading_session",
+  "market_temperature",
+  "history_market_temperature",
+  "filings",
+  "warrant_issuers",
+  "warrant_list",
+  "calc_indexes",
+  "security_list",
+  "short_positions",
+  "option_volume",
+  "option_volume_daily",
+  // --- Market (status, ranks, holdings, anomalies; reads only) ---
+  "market_status",
+  "broker_holding",
+  "broker_holding_detail",
+  "broker_holding_daily",
+  "ah_premium",
+  "ah_premium_intraday",
+  "trade_stats",
+  "anomaly",
+  "constituent",
+  "industry_rank",
+  "short_trades",
+  "top_movers",
+  "rank_categories",
+  "rank_list",
+  // --- Fundamental (financials, ratings, dividends, valuations; reads only) ---
+  "financial_report",
+  "financial_report_latest",
+  "financial_report_snapshot",
+  "financial_statement",
+  "institution_rating",
+  "institution_rating_detail",
+  "institution_rating_history",
+  "institution_rating_industry_rank",
+  "dividend",
+  "dividend_detail",
+  "forecast_eps",
+  "consensus",
+  "valuation",
+  "valuation_history",
+  "valuation_rank",
+  "valuation_comparison",
+  "industry_valuation",
+  "industry_valuation_dist",
+  "company",
+  "executive",
+  "shareholder",
+  "shareholder_top",
+  "shareholder_detail",
+  "fund_holder",
+  "corp_action",
+  "invest_relation",
+  "operating",
+  "business_segments",
+  "business_segments_history",
+  "institutional_views",
+  "industry_peers",
+  // --- Calendar & utility ---
+  "finance_calendar",
+  "now",
+]);
+
+// Write / trade / account tools — NEVER allowed. Passed as --disallowedTools
+// (defense-in-depth) and used as the test oracle: the allowlist must be
+// disjoint from this set. Any future write tool the MCP adds is excluded by
+// the allowlist-only semantics regardless of whether it is listed here.
+export const LONGPORT_BLOCKED_TOOLS: readonly string[] = Object.freeze([
+  // Trade — real orders against a real account
+  "submit_order",
+  "cancel_order",
+  "replace_order",
+  "estimate_max_purchase_quantity",
+  "account_balance",
+  "stock_positions",
+  "fund_positions",
+  "margin_ratio",
+  "short_margin",
+  "today_orders",
+  "order_detail",
+  "today_executions",
+  "history_orders",
+  "history_executions",
+  "cash_flow",
+  // Watchlist writes (they live in the quote category — easy to miss)
+  "create_watchlist_group",
+  "delete_watchlist_group",
+  "update_watchlist_group",
+  "watchlist",
+  // Alerts (CRUD), DCA (recurring-investment writes), sharelists, statements
+  "alert_add",
+  "alert_delete",
+  "alert_disable",
+  "alert_enable",
+  "alert_list",
+  "dca_create",
+  "dca_update",
+  "dca_pause",
+  "dca_resume",
+  "dca_stop",
+  "dca_history",
+  "dca_list",
+  "dca_stats",
+  "dca_check",
+  "sharelist_add",
+  "sharelist_create",
+  "sharelist_delete",
+  "sharelist_detail",
+  "sharelist_list",
+  "sharelist_popular",
+  "sharelist_remove",
+  "sharelist_sort",
+  "statement_export",
+  "statement_list",
+  // ATM (bank cards, deposits, withdrawals) & portfolio account analytics
+  "bank_cards",
+  "deposits",
+  "withdrawals",
+  "exchange_rate",
+  "profit_analysis",
+  "profit_analysis_detail",
+  // Reverse-auth + server-side script executor + user screeners
+  "authenticate",
+  "quant_run",
+  "screener_search",
+  "screener_indicators",
+  "screener_recommend_strategies",
+  "screener_strategy",
+  "screener_user_strategies",
+]);
+
+// Fail-closed backstop: names that must NEVER appear in the read allowlist. The
+// patterns catch order/account/funds/write verbs precisely enough to avoid
+// false-positives on genuine market-data reads (e.g. `short_positions` = market
+// short interest, `capital_flow`, `fund_holder` are all fine and unmatched).
+const SENSITIVE_TOOL_PATTERN =
+  /^(submit|cancel|replace|dca|alert|sharelist|statement)_|_orders?$|order_detail|execution|account_balance|stock_positions|fund_positions|^margin_ratio$|^short_margin$|deposit|withdraw|bank_cards|exchange_rate|profit_analysis|authenticate|quant_run|^watchlist$|watchlist_group|estimate_max_purchase|^cash_flow$/;
+
+export function isSensitiveToolName(name: string): boolean {
+  return SENSITIVE_TOOL_PATTERN.test(name);
+}
+
+// Throws if a sensitive tool ever slips into LONGPORT_READ_TOOLS (e.g. a future
+// edit adds one without updating the blocklist). Called before every spawn so a
+// misconfiguration fails the run instead of granting the tool.
+export function assertReadOnlyAllowlist(): void {
+  const offenders = LONGPORT_READ_TOOLS.filter((t) => SENSITIVE_TOOL_PATTERN.test(t));
+  if (offenders.length > 0) {
+    throw new Error(
+      `LongPort allowlist safety violation: sensitive tool(s) in the read allowlist: ${offenders.join(", ")}`
+    );
+  }
+}
+
+function qualify(tool: string): string {
+  return `mcp__${LONGPORT_SERVER_NAME}__${tool}`;
+}
+
+// Fully-qualified allow / deny tool identifiers as claude's --allowedTools /
+// --disallowedTools see them.
+export const LONGPORT_ALLOWED_TOOL_IDS: readonly string[] = Object.freeze(
+  LONGPORT_READ_TOOLS.map(qualify)
+);
+export const LONGPORT_BLOCKED_TOOL_IDS: readonly string[] = Object.freeze(
+  LONGPORT_BLOCKED_TOOLS.map(qualify)
+);
+
+export interface LongportResolution {
+  enabled: boolean;
+  reason: string;
+}
+
+// Opt-in via DELTA_LONGPORT_ENABLED=1 (default OFF so the app is unchanged for
+// anyone who has not deployed credentials). Only the claude-cli engine can use
+// MCP tools; deepseek/rules ignore this.
+export function resolveLongport(): LongportResolution {
+  if (process.env.DELTA_LONGPORT_ENABLED?.trim() !== "1") {
+    return { enabled: false, reason: "DELTA_LONGPORT_ENABLED not set" };
+  }
+  return { enabled: true, reason: "DELTA_LONGPORT_ENABLED=1" };
+}
+
+export function longportMcpUrl(): string {
+  return (process.env.DELTA_LONGPORT_MCP_URL?.trim() || "https://mcp.longportapp.com").replace(/\/+$/, "");
+}
+
+// The MCP config object claude --mcp-config consumes. When a bearer token is
+// present (DELTA_LONGPORT_TOKEN — a LongPort OAuth access token) it is injected
+// as an Authorization header so a HEADLESS server run authenticates without the
+// interactive browser OAuth flow. Without a token, the config still points at
+// the hosted endpoint and relies on a claude session that has already completed
+// `claude mcp add` OAuth (documented).
+export function buildLongportMcpConfig(): {
+  config: { mcpServers: Record<string, { type: "http"; url: string; headers?: Record<string, string> }> };
+  hasToken: boolean;
+} {
+  const token = process.env.DELTA_LONGPORT_TOKEN?.trim();
+  const server: { type: "http"; url: string; headers?: Record<string, string> } = {
+    type: "http",
+    url: longportMcpUrl(),
+  };
+  if (token) server.headers = { Authorization: `Bearer ${token}` };
+  return { config: { mcpServers: { [LONGPORT_SERVER_NAME]: server } }, hasToken: Boolean(token) };
+}
+
+export interface LongportCliArtifacts {
+  configPath: string; // temp mcp-config file (0600); caller MUST call cleanup()
+  allowedTools: readonly string[];
+  disallowedTools: readonly string[];
+  cleanup: () => void;
+}
+
+// Materialize the mcp-config to a private temp file (0600 — it may carry the
+// bearer token) and return the args the provider needs. The caller MUST invoke
+// cleanup() in a finally block so the token never lingers on disk.
+export function prepareLongportCli(): LongportCliArtifacts {
+  assertReadOnlyAllowlist(); // fail-closed: never spawn with a tainted allowlist
+  const { config } = buildLongportMcpConfig();
+  // mkdtemp creates the directory with 0700 (POSIX), so the 0600 config inside
+  // is not readable by other users on the host.
+  const dir = mkdtempSync(path.join(tmpdir(), "delta-longport-"));
+  const configPath = path.join(dir, "mcp-config.json");
+  writeFileSync(configPath, JSON.stringify(config), { mode: 0o600 });
+  return {
+    configPath,
+    allowedTools: LONGPORT_ALLOWED_TOOL_IDS,
+    disallowedTools: LONGPORT_BLOCKED_TOOL_IDS,
+    cleanup: () => {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // best-effort; a leftover 0600 temp file is not worth failing a run
+      }
+    },
+  };
+}

--- a/apps/raven-delta/lib/analyzer/prompt.ts
+++ b/apps/raven-delta/lib/analyzer/prompt.ts
@@ -3,8 +3,27 @@
 // text avoids over-constraining the reasoning and instead states the desk
 // context, the increment-first doctrine, and the output surface.
 
-import type { NewsInput } from "./schema";
+import type { EngineId, NewsInput } from "./schema";
 import { universePromptTable, getUniverse } from "./universe";
+import { LONGPORT_SERVER_NAME, resolveLongport } from "./longport-mcp";
+
+// Guidance injected ONLY for the claude-cli engine when LongPort market data is
+// wired in — deepseek/rules have no MCP tools, so telling them to call quotes
+// would be a lie. The analyst grounds its numbers on the live price/recent move
+// but must NOT treat a quote as evidence about the NEWS itself (freshness is
+// still established by web search).
+function marketDataSection(engine: EngineId | undefined): string {
+  if (engine !== "claude-cli" || !resolveLongport().enabled) return "";
+  const p = `mcp__${LONGPORT_SERVER_NAME}__`;
+  return `
+LIVE MARKET DATA (LongPort, read-only) — you have MCP tools for real US/HK market data:
+- \`${p}quote\` (real-time price), \`${p}candlesticks\` / \`${p}history_candlesticks_by_date\` (recent move), \`${p}intraday\`, \`${p}depth\`, \`${p}trading_session\` / \`${p}market_status\` (is the market open?), \`${p}valuation\` / \`${p}financial_report_latest\` (fundamentals).
+- Use them to GROUND each impacted stock: check the actual last price and how far it has already moved TODAY before you state a direction and expectedMovePct — a 4% pop that already happened is priced in, and belongs in risks, not upside.
+- Record what you pulled as evidence: put the price / % move / quote timestamp in the stock's evidence[] with source "LongPort". Never invent a quote you did not fetch.
+- These tools are market data ONLY. You cannot and must not place, cancel, or size any order, or read account/portfolio data — that is out of scope for this desk.
+- If a tool call fails or the market is closed, say so in limitations and fall back to reasoning from the news; do not block the analysis on it.
+`;
+}
 
 const OUTPUT_SPEC = `Return EXACTLY ONE JSON object (no markdown fences, no prose outside it) with this shape:
 {
@@ -41,7 +60,7 @@ const OUTPUT_SPEC = `Return EXACTLY ONE JSON object (no markdown fences, no pros
   "limitations": [ string ]           // at least one honest limitation of this analysis
 }`;
 
-export function buildAnalysisPrompt(news: NewsInput): string {
+export function buildAnalysisPrompt(news: NewsInput, engine?: EngineId): string {
   const universe = getUniverse();
   const lang =
     news.locale === "zh"
@@ -49,6 +68,7 @@ export function buildAnalysisPrompt(news: NewsInput): string {
       : "Write every human-readable string field in English.";
 
   return `You are the news-impact analyst behind Raven Delta, Raven Labs' real-time news engine for US equities.
+${marketDataSection(engine)}
 
 Doctrine — trade the increment, not the level:
 - A static "will this stock go up" probability is not the product. The question is what THIS headline changes relative to the pre-news baseline: which cash flows, multiples, or risk premia get repriced, and for whom.

--- a/apps/raven-delta/lib/analyzer/provider.test.ts
+++ b/apps/raven-delta/lib/analyzer/provider.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { extractJsonObject, resolveEngine } from "./provider";
+import { buildClaudeArgs, extractJsonObject, resolveEngine } from "./provider";
+import { LONGPORT_ALLOWED_TOOL_IDS } from "./longport-mcp";
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -48,5 +49,53 @@ describe("resolveEngine", () => {
     vi.stubEnv("DEEPSEEK_API_KEY", "");
     vi.stubEnv("DELTA_CLAUDE_CLI", "1");
     expect(resolveEngine().engine).toBe("claude-cli");
+  });
+});
+
+describe("buildClaudeArgs LongPort wiring", () => {
+  it("adds no MCP config or longport tools when disabled", () => {
+    vi.stubEnv("DELTA_LONGPORT_ENABLED", "");
+    const { args, cleanup } = buildClaudeArgs(true);
+    try {
+      expect(args).not.toContain("--mcp-config");
+      expect(args).not.toContain("--disallowedTools");
+      const allowed = args[args.indexOf("--allowedTools") + 1];
+      expect(allowed).toBe("WebSearch");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("adds no MCP config for a non-market-data call even when enabled (gate/repair path)", () => {
+    vi.stubEnv("DELTA_LONGPORT_ENABLED", "1");
+    vi.stubEnv("DELTA_LONGPORT_TOKEN", "tok");
+    const { args, cleanup } = buildClaudeArgs(false);
+    try {
+      expect(args).not.toContain("--mcp-config");
+      const allowed = args[args.indexOf("--allowedTools") + 1];
+      expect(allowed).toBe("WebSearch");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("attaches the MCP config, read-only allowlist, and trade denylist for a market-data call when enabled", () => {
+    vi.stubEnv("DELTA_LONGPORT_ENABLED", "1");
+    vi.stubEnv("DELTA_LONGPORT_TOKEN", "tok");
+    const { args, cleanup } = buildClaudeArgs(true);
+    try {
+      expect(args).toContain("--mcp-config");
+      expect(args).toContain("--strict-mcp-config");
+      const allowed = args[args.indexOf("--allowedTools") + 1];
+      expect(allowed).toContain("WebSearch");
+      expect(allowed).toContain(LONGPORT_ALLOWED_TOOL_IDS[0]);
+      // Trade tools must be BOTH absent from the allowlist and present in the denylist.
+      expect(allowed).not.toContain("submit_order");
+      const disallowed = args[args.indexOf("--disallowedTools") + 1];
+      expect(disallowed).toContain("submit_order");
+      expect(disallowed).toContain("create_watchlist_group");
+    } finally {
+      cleanup();
+    }
   });
 });

--- a/apps/raven-delta/lib/analyzer/provider.ts
+++ b/apps/raven-delta/lib/analyzer/provider.ts
@@ -10,6 +10,7 @@ import { spawn } from "node:child_process";
 import { deltaAnalysisSchema, type DeltaAnalysis, type EngineId } from "./schema";
 import { buildRepairPrompt } from "./prompt";
 import { findStock } from "./universe";
+import { prepareLongportCli, resolveLongport } from "./longport-mcp";
 
 const DEFAULT_TIMEOUT_MS = 180_000;
 
@@ -96,44 +97,101 @@ async function runDeepSeekPrompt(prompt: string): Promise<string> {
   }
 }
 
-async function runClaudeCliPrompt(prompt: string): Promise<string> {
-  const timeoutMs = engineTimeoutMs();
-  const allowedTools = process.env.DELTA_ALLOWED_TOOLS ?? "WebSearch";
+// Build the claude CLI args. The LongPort MCP is attached ONLY when the caller
+// asks for market data (marketData=true — the analysis path) AND it is enabled;
+// the quality gate and the schema-repair round get plain args with no MCP, so
+// the bearer-token temp file and the live brokerage session never open for a
+// prompt that cannot use them. When attached: merge the READ-ONLY market-data
+// tools into --allowedTools and pass the write/trade tools as --disallowedTools
+// (defense-in-depth — the allowlist alone already makes them unreachable).
+// Returns a cleanup() that removes the temp mcp-config (which may carry the
+// bearer token).
+export function buildClaudeArgs(marketData = false): { args: string[]; cleanup: () => void } {
   const model = process.env.DELTA_CLAUDE_MODEL?.trim() || "";
-  const args = ["--print", "--output-format", "json", "--allowedTools", allowedTools];
-  if (model) args.push("--model", model);
+  const baseAllowed = (process.env.DELTA_ALLOWED_TOOLS ?? "WebSearch")
+    .split(",")
+    .map((t) => t.trim())
+    .filter(Boolean);
 
-  return await new Promise<string>((resolve, reject) => {
-    const child = spawn("claude", args, { env: process.env });
-    let stdout = "";
-    let stderr = "";
-    const timer = setTimeout(() => {
-      child.kill("SIGTERM");
-      reject(new Error(`claude CLI timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-    child.stdout.on("data", (d) => (stdout += d.toString()));
-    child.stderr.on("data", (d) => (stderr += d.toString()));
-    child.on("error", (error) => {
-      clearTimeout(timer);
-      reject(error);
+  const longport = resolveLongport();
+  if (!marketData || !longport.enabled) {
+    const args = ["--print", "--output-format", "json", "--allowedTools", baseAllowed.join(",")];
+    if (model) args.push("--model", model);
+    return { args, cleanup: () => {} };
+  }
+
+  const cli = prepareLongportCli();
+  const allowed = [...baseAllowed, ...cli.allowedTools].join(",");
+  const args = [
+    "--print",
+    "--output-format",
+    "json",
+    "--mcp-config",
+    cli.configPath,
+    // Use ONLY the longport server from our config — never inherit a globally
+    // registered MCP server (which could carry write/trade tools) into this run.
+    "--strict-mcp-config",
+    "--allowedTools",
+    allowed,
+    // Never reachable given the allowlist, but stated explicitly so the intent
+    // survives a future refactor that widens --allowedTools.
+    "--disallowedTools",
+    cli.disallowedTools.join(","),
+  ];
+  if (model) args.push("--model", model);
+  return { args, cleanup: cli.cleanup };
+}
+
+// Strip any bearer token from child-process stderr before it becomes a
+// persisted + browser-returned string (engineFallbackReason). The token should
+// never appear here — it only lives in the mcp-config file, not argv or the
+// prompt — but this closes the one channel where a future CLI could echo it.
+function redactSecrets(text: string): string {
+  const token = process.env.DELTA_LONGPORT_TOKEN?.trim();
+  let out = text.replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [redacted]");
+  if (token) out = out.split(token).join("[redacted]");
+  return out;
+}
+
+async function runClaudeCliPrompt(prompt: string, opts: { marketData?: boolean } = {}): Promise<string> {
+  const timeoutMs = engineTimeoutMs();
+  const { args, cleanup } = buildClaudeArgs(opts.marketData ?? false);
+
+  try {
+    return await new Promise<string>((resolve, reject) => {
+      const child = spawn("claude", args, { env: process.env });
+      let stdout = "";
+      let stderr = "";
+      const timer = setTimeout(() => {
+        child.kill("SIGTERM");
+        reject(new Error(`claude CLI timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      child.stdout.on("data", (d) => (stdout += d.toString()));
+      child.stderr.on("data", (d) => (stderr += d.toString()));
+      child.on("error", (error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+      child.on("close", (code) => {
+        clearTimeout(timer);
+        if (code !== 0) {
+          reject(new Error(`claude CLI exited ${code}: ${redactSecrets(stderr).slice(-300)}`));
+          return;
+        }
+        try {
+          const envelope = JSON.parse(stdout) as { result?: string };
+          resolve(envelope.result ?? "");
+        } catch {
+          // Older CLI versions may print the text directly.
+          resolve(stdout);
+        }
+      });
+      child.stdin.write(prompt);
+      child.stdin.end();
     });
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      if (code !== 0) {
-        reject(new Error(`claude CLI exited ${code}: ${stderr.slice(-300)}`));
-        return;
-      }
-      try {
-        const envelope = JSON.parse(stdout) as { result?: string };
-        resolve(envelope.result ?? "");
-      } catch {
-        // Older CLI versions may print the text directly.
-        resolve(stdout);
-      }
-    });
-    child.stdin.write(prompt);
-    child.stdin.end();
-  });
+  } finally {
+    cleanup();
+  }
 }
 
 function summarizeZodError(error: unknown): string {
@@ -180,26 +238,33 @@ function enforceUniverseFacts(analysis: DeltaAnalysis): DeltaAnalysis {
 }
 
 // Generic single-shot JSON call for small harness judgments (e.g. the ingest
-// quality gate). No repair round — callers fall back on failure.
+// quality gate). No repair round — callers fall back on failure. No market data:
+// these prompts never carry the tool-use guidance, so the LongPort MCP must not
+// be attached (would cost a token temp-file + brokerage session for nothing).
 export async function runLlmJson(engine: EngineId, prompt: string): Promise<unknown> {
   if (engine === "rules") throw new Error("runLlmJson cannot run the rules engine.");
-  const runPrompt = engine === "deepseek" ? runDeepSeekPrompt : runClaudeCliPrompt;
-  const raw = await runPrompt(prompt);
+  const raw = engine === "deepseek" ? await runDeepSeekPrompt(prompt) : await runClaudeCliPrompt(prompt);
   const candidate = extractJsonObject(raw);
   if (candidate === null) throw new Error("no JSON object in engine output");
   return candidate;
 }
 
 export async function runLlmAnalysis(engine: EngineId, prompt: string): Promise<DeltaAnalysis> {
-  const runPrompt = engine === "deepseek" ? runDeepSeekPrompt : runClaudeCliPrompt;
   if (engine === "rules") throw new Error("runLlmAnalysis cannot run the rules engine.");
+  // Only the first (analysis) call carries the marketDataSection guidance and
+  // may use LongPort tools; the repair round only fixes JSON shape, so it runs
+  // WITHOUT the MCP attached.
+  const runFirst = (p: string): Promise<string> =>
+    engine === "deepseek" ? runDeepSeekPrompt(p) : runClaudeCliPrompt(p, { marketData: true });
+  const runRepair = (p: string): Promise<string> =>
+    engine === "deepseek" ? runDeepSeekPrompt(p) : runClaudeCliPrompt(p);
 
-  const firstRaw = await runPrompt(prompt);
+  const firstRaw = await runFirst(prompt);
   const firstCandidate = normalizeCandidate(extractJsonObject(firstRaw));
   const firstParse = deltaAnalysisSchema.safeParse(firstCandidate);
   if (firstParse.success) return enforceUniverseFacts(firstParse.data);
 
-  const repairRaw = await runPrompt(buildRepairPrompt(firstRaw, summarizeZodError(firstParse.error)));
+  const repairRaw = await runRepair(buildRepairPrompt(firstRaw, summarizeZodError(firstParse.error)));
   const repairCandidate = normalizeCandidate(extractJsonObject(repairRaw));
   const repairParse = deltaAnalysisSchema.safeParse(repairCandidate);
   if (repairParse.success) return enforceUniverseFacts(repairParse.data);

--- a/apps/raven-delta/lib/analyzer/store.ts
+++ b/apps/raven-delta/lib/analyzer/store.ts
@@ -26,7 +26,9 @@ export function saveRun(run: DeltaRun): string {
   mkdirSync(dir, { recursive: true });
   const stamp = run.generatedAtUtc.replace(/[:.]/g, "-");
   const file = path.join(dir, `${stamp}-${run.id}.json`);
-  writeFileSync(file, JSON.stringify(run, null, 2));
+  // 0600: a run can carry engineFallbackReason (child-process stderr) — keep the
+  // durable archive owner-only, matching the temp mcp-config posture.
+  writeFileSync(file, JSON.stringify(run, null, 2), { mode: 0o600 });
   return file;
 }
 


### PR DESCRIPTION
## 做了什么

给 raven-delta 接入官方 **LongPort（长桥）MCP**（托管端点 `https://mcp.longportapp.com`，OAuth 2.1 / Streamable HTTP），让 claude-cli 引擎在给出方向/预期波动前能拉**真实实时盘口和近期涨跌**——补上之前评审指出的"分析对真实价格盲区"。

## 安全模型（这是真实券商账户，核心）

LongPort MCP 暴露 **145 个工具**，其中 **14 个直接下单/撤单/改单**（`submit_order`…），外加账户余额/持仓、资金进出、自选股写操作。raven-delta 是 `demo_read_only` + 全项目 PAPER-ONLY。所以用**只放行读工具**的白名单控制：

- `lib/analyzer/longport-mcp.ts` 精选 **75 个只读行情工具**（Quote 读、Market、Fundamental、Calendar、now）。claude `--allowedTools` 只列这些——`--print` 非交互模式下没有人工审批，未列的工具**不可达**。工具清单逐个核对过 `longportapp/longport-mcp` 源码。
- 纵深防御：`--disallowedTools` 列出交易工具、`--strict-mcp-config` 拒绝任何全局注册的 MCP、`prepareLongportCli()` **fail-closed**（任何白名单名撞上下单/账户模式就抛错、绝不 spawn）。**quote 类里藏着的 3 个自选股写工具**（`create/delete/update_watchlist_group`）已排除并断言。

## 开关与认证

- 默认 **OFF**，仅 `DELTA_LONGPORT_ENABLED=1` 且引擎是 claude-cli 时生效
- `DELTA_LONGPORT_TOKEN`（LongPort OAuth access token）经 **0600 临时 mcp-config** 注入 Bearer 头，headless 运行**无需交互式浏览器 OAuth**；用完 finally 删除
- 端点已实测存活：OAuth 元数据 200 + 未授权 `/mcp` 返回 `401 + www-authenticate: Bearer`

## 5 镜头对抗安全评审结论

**0 个确认的灾难路径**——LLM 无法触达任何下单/写/账户工具。修掉的是正确性/卫生项：

- MCP 只挂在**分析 prompt**，quality gate 和 JSON repair 轮不挂（不为用不上工具的 prompt 开 token 临时文件 + 券商会话）
- market-data stage 反映**最终引擎**：claude 降级到 rules 时报 `longport:off`，不再假报 `longport:live`
- 子进程 stderr 在进入 `engineFallbackReason`（会落盘 + 回浏览器）前**脱敏** Bearer/token；run 归档写 0600

## 验证

- 全仓 **946 测试通过**（新增 19：白名单↔交易工具不相交、fail-closed 模式抓全部写工具且不误伤 `short_positions`/`capital_flow`、MCP 门控、0600 临时文件、Bearer 头注入）
- workspace typecheck 绿、raven-delta build 绿
- 端点存活性实测（无需凭证）

## 你这边完成"联调"需要（我不接你的凭证）

1. 在 VM `.env` 填 `DELTA_LONGPORT_ENABLED=1` + `DELTA_LONGPORT_TOKEN=<你的 LongPort OAuth access token>`（或本地先 `claude mcp add --transport http longport https://mcp.longportapp.com` 走一遍 OAuth）
2. `DELTA_PROVIDER=claude`（生产已是）
3. 喂一条真新闻，看 run 的 `market-data` stage 是否 `longport:live`、受影响股票的 evidence 里是否带真实报价+时间戳

合并前若要我在 VM 上部署（feature 仍 OFF，等你填 token），说一声。