### PR TITLE
feat(routing): mount Forecasting Engine at /engine and Raven Delta at /delta

### DIFF
--- a/apps/raven-delta/components/delta-console.tsx
+++ b/apps/raven-delta/components/delta-console.tsx
@@ -4,6 +4,7 @@
 
 import { useState, type FormEvent } from "react";
 import type { DeltaRun } from "../lib/analyzer/schema";
+import { withBasePath } from "../lib/base-path";
 import { useLocale, useT } from "../lib/i18n";
 import { ReportView } from "./report-view";
 import { WsPanel } from "./ws-panel";
@@ -48,7 +49,8 @@ export function DeltaConsole({ engine, universeSize, universeVersion }: ConsoleP
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch("/api/analyze", {
+      // Hand-written fetch URLs are not basePath-prefixed by Next; do it here.
+      const response = await fetch(withBasePath("/api/analyze"), {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({

--- a/apps/raven-delta/lib/base-path.ts
+++ b/apps/raven-delta/lib/base-path.ts
@@ -1,0 +1,13 @@
+// Single source of truth for the app's basePath. The app is reverse-proxied
+// by the main site at forecasting-agent.com/delta/*, so Next serves everything
+// (pages, /api/*, /_next/*) under this prefix — in dev and prod alike.
+//
+// Imported by next.config.ts (build-time config) and by client code that
+// hand-writes fetch URLs (Next only auto-prefixes router/asset URLs, not
+// window.fetch calls).
+
+export const BASE_PATH = "/delta";
+
+export function withBasePath(path: string): string {
+  return `${BASE_PATH}${path}`;
+}

--- a/apps/raven-delta/lib/news-sources/types.ts
+++ b/apps/raven-delta/lib/news-sources/types.ts
@@ -18,7 +18,7 @@ export interface NewsSourceAdapter {
 }
 
 export interface IngestClientOptions {
-  ingestUrl: string; // e.g. http://127.0.0.1:3300/api/ingest
+  ingestUrl: string; // e.g. http://127.0.0.1:3300/delta/api/ingest (basePath included)
   accessToken?: string;
 }
 

--- a/apps/raven-delta/next.config.ts
+++ b/apps/raven-delta/next.config.ts
@@ -1,9 +1,12 @@
 import path from "node:path";
 import type { NextConfig } from "next";
+import { BASE_PATH } from "./lib/base-path";
 
 const workspaceRoot = path.join(import.meta.dirname, "../..");
 
 const nextConfig: NextConfig = {
+  // Served behind the main site's reverse proxy at forecasting-agent.com/delta/*.
+  basePath: BASE_PATH,
   // Monorepo: trace files from the workspace root so workspace deps resolve.
   outputFileTracingRoot: workspaceRoot,
   turbopack: {

--- a/apps/raven-delta/proxy.ts
+++ b/apps/raven-delta/proxy.ts
@@ -10,6 +10,10 @@
 import { NextRequest, NextResponse } from "next/server";
 
 const COOKIE = "delta-access";
+// Note on basePath ("/delta" in next.config.ts): inside proxy/middleware Next
+// strips the basePath before matching, so `nextUrl.pathname` and the matcher
+// below see "/api/health", not "/delta/api/health". These patterns stay
+// basePath-free on purpose. The prefix is available as `nextUrl.basePath`.
 const PUBLIC_PATHS = [/^\/_next\//, /^\/favicon\.ico$/, /^\/api\/health$/];
 
 // Constant-time-ish comparison; avoids early-exit timing on the token match.
@@ -22,10 +26,13 @@ function tokenMatches(provided: string, expected: string): boolean {
   return diff === 0;
 }
 
-function accessPage(): string {
+// `action` must carry the basePath: this HTML is returned raw by the proxy,
+// so the browser resolves the form target against the domain root, not the
+// Next app root.
+function accessPage(action: string): string {
   return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Raven Delta — access</title></head>
 <body style="margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;background:#15120c;color:#ede5d6;font-family:Georgia,serif">
-<form method="GET" action="/" style="text-align:center;padding:24px">
+<form method="GET" action="${action}" style="text-align:center;padding:24px">
 <div style="font-size:22px;font-weight:600">Raven <span style="color:#ee7130">Delta</span></div>
 <p style="color:#a99d87;font-size:13px;margin:10px 0 18px">This instance is private. Enter your access token.</p>
 <input name="token" autofocus placeholder="access token" style="background:#221b10;border:1px solid #3b3324;border-radius:9px;color:#ede5d6;font-size:14px;padding:10px 14px;outline:none;width:240px">
@@ -45,7 +52,8 @@ export default function proxy(req: NextRequest) {
   const expected = process.env.DELTA_ACCESS_TOKEN?.trim();
   if (!expected) return NextResponse.next(); // gate disabled (local dev)
 
-  const { pathname } = req.nextUrl;
+  const { pathname } = req.nextUrl; // basePath already stripped here
+  const basePath = req.nextUrl.basePath || "";
   if (PUBLIC_PATHS.some((r) => r.test(pathname))) return NextResponse.next();
 
   const fromQuery = req.nextUrl.searchParams.get("token");
@@ -62,7 +70,10 @@ export default function proxy(req: NextRequest) {
         sameSite: "lax",
         secure: req.nextUrl.protocol === "https:",
         maxAge: 60 * 60 * 24 * 90,
-        path: "/"
+        // Scope to the basePath: the app shares forecasting-agent.com with
+        // other apps behind the reverse proxy, and the token cookie must not
+        // be sent to them.
+        path: basePath || "/"
       });
       return res;
     }
@@ -72,7 +83,7 @@ export default function proxy(req: NextRequest) {
   if (pathname.startsWith("/api/")) {
     return NextResponse.json({ error: "unauthorized — provide the access token" }, { status: 401 });
   }
-  return new NextResponse(accessPage(), {
+  return new NextResponse(accessPage(`${basePath}/`), {
     status: 401,
     headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-store" }
   });
@@ -80,5 +91,8 @@ export default function proxy(req: NextRequest) {
 
 export const config = {
   // Everything except Next's static assets (also filtered above for safety).
-  matcher: ["/((?!_next/static|_next/image).*)"]
+  // "/" is listed explicitly: the grouped pattern requires a non-empty match
+  // under Next 16, so the bare root path would otherwise bypass the gate
+  // (verified against next start: / rendered ungated, /x was gated).
+  matcher: ["/", "/((?!_next/static|_next/image).*)"]
 };

--- a/apps/raven/app/page.tsx
+++ b/apps/raven/app/page.tsx
@@ -9,6 +9,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { RvShell } from "../components/chrome/rv-shell";
+import { withBasePath } from "../lib/base-path";
 import { GTA6_DEMO, GTA6_DEMO_ID } from "../lib/demo/gta6";
 import { confidenceLabel, sourcesLabel, useLocale, useT, verdictLabel } from "../lib/i18n";
 import { HOME } from "../lib/i18n/home";
@@ -104,7 +105,7 @@ export default function HomePage() {
     let alive = true;
     const load = async () => {
       try {
-        const res = await fetch("/api/forecasts", { cache: "no-store" });
+        const res = await fetch(withBasePath("/api/forecasts"), { cache: "no-store" });
         if (!res.ok) return;
         const body = (await res.json()) as { runs?: RunListItem[] };
         if (!alive || !Array.isArray(body.runs)) return;
@@ -138,7 +139,7 @@ export default function HomePage() {
     setSubmitError(null);
     try {
       const inviteCode = invite.trim();
-      const res = await fetch("/api/forecasts", {
+      const res = await fetch(withBasePath("/api/forecasts"), {
         method: "POST",
         headers: { "content-type": "application/json" },
         // `language` makes the engine write its reasoning/evidence in the
@@ -207,7 +208,7 @@ export default function HomePage() {
 
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
-          src="/raven-mascot.png"
+          src={withBasePath("/raven-mascot.png")}
           alt={t(HOME.mascotAlt)}
           style={{
             position: "relative",

--- a/apps/raven/components/chrome/rv-shell.tsx
+++ b/apps/raven/components/chrome/rv-shell.tsx
@@ -7,6 +7,7 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
+import { withBasePath } from "../../lib/base-path";
 import { useLocale, useT } from "../../lib/i18n";
 import { CHROME } from "../../lib/i18n/ui";
 import { GTA6_DEMO_ID } from "../../lib/demo/gta6";
@@ -75,7 +76,7 @@ export function RvShell({ active, forecastId, headerRight, showFooter = true, ch
         >
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
-            src="/raven-mascot.png"
+            src={withBasePath("/raven-mascot.png")}
             alt="Raven mascot"
             style={{
               width: 32,

--- a/apps/raven/components/research/plan.tsx
+++ b/apps/raven/components/research/plan.tsx
@@ -5,6 +5,7 @@
 // and PlanList renders the live checklist — steps check off as the run
 // advances, joined by a dashed connector.
 
+import { withBasePath } from "../../lib/base-path";
 import { useT } from "../../lib/i18n";
 import { RS } from "../../lib/i18n/ui";
 import type { PlanStepVM } from "./research-vm";
@@ -24,7 +25,7 @@ export function RavenMessage({
       <div style={{ display: "flex", alignItems: "center", gap: 9 }}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
-          src="/raven-mascot.png"
+          src={withBasePath("/raven-mascot.png")}
           alt=""
           aria-hidden="true"
           style={{

--- a/apps/raven/lib/base-path.ts
+++ b/apps/raven/lib/base-path.ts
@@ -1,0 +1,11 @@
+// Single source of truth for the URL prefix this app is mounted under
+// (forecasting-agent.com/engine/* via the main site's reverse proxy).
+//
+// next.config.ts consumes BASE_PATH for Next's `basePath`. Next auto-prefixes
+// router navigations, <Link> and next/image — but NOT hand-written URLs
+// (fetch/EventSource/WebSocket/plain <img src>), which must use withBasePath.
+export const BASE_PATH = "/engine";
+
+export function withBasePath(path: string): string {
+  return `${BASE_PATH}${path}`;
+}

--- a/apps/raven/lib/client/use-forecast.ts
+++ b/apps/raven/lib/client/use-forecast.ts
@@ -6,6 +6,7 @@
 // polling stops once the run is terminal and the dossier is complete.
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { withBasePath } from "../base-path";
 import type { AnalystState } from "../server/analyst";
 import type { DossierVM } from "../vm/types";
 
@@ -34,7 +35,7 @@ export function useForecast(id: string) {
 
   const fetchOnce = useCallback(async (): Promise<ForecastPayload | null> => {
     try {
-      const res = await fetch(`/api/forecasts/${encodeURIComponent(id)}`, { cache: "no-store" });
+      const res = await fetch(withBasePath(`/api/forecasts/${encodeURIComponent(id)}`), { cache: "no-store" });
       if (!res.ok) {
         const body = (await res.json().catch(() => null)) as { error?: string } | null;
         throw new Error(body?.error ?? `request failed (${res.status})`);
@@ -72,7 +73,7 @@ export function useForecast(id: string) {
 }
 
 export async function apiSetMark(id: string, targetId: string, mark: "keep" | "doubt" | null): Promise<void> {
-  const res = await fetch(`/api/forecasts/${encodeURIComponent(id)}/marks`, {
+  const res = await fetch(withBasePath(`/api/forecasts/${encodeURIComponent(id)}/marks`), {
     method: "PUT",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ targetId, mark })
@@ -84,7 +85,7 @@ export async function apiAddNote(
   id: string,
   input: { text: string; stance: "yes" | "no" | "question"; targetId: string | null }
 ): Promise<void> {
-  const res = await fetch(`/api/forecasts/${encodeURIComponent(id)}/notes`, {
+  const res = await fetch(withBasePath(`/api/forecasts/${encodeURIComponent(id)}/notes`), {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(input)
@@ -93,7 +94,7 @@ export async function apiAddNote(
 }
 
 export async function apiRemoveNote(id: string, noteId: string): Promise<void> {
-  const res = await fetch(`/api/forecasts/${encodeURIComponent(id)}/notes/${encodeURIComponent(noteId)}`, {
+  const res = await fetch(withBasePath(`/api/forecasts/${encodeURIComponent(id)}/notes/${encodeURIComponent(noteId)}`), {
     method: "DELETE"
   });
   if (!res.ok && res.status !== 404) throw new Error(`removing note failed (${res.status})`);

--- a/apps/raven/next.config.ts
+++ b/apps/raven/next.config.ts
@@ -1,9 +1,12 @@
 import path from "node:path";
 import type { NextConfig } from "next";
+import { BASE_PATH } from "./lib/base-path";
 
 const workspaceRoot = path.join(import.meta.dirname, "../..");
 
 const nextConfig: NextConfig = {
+  // Served under forecasting-agent.com/engine/* via the main site's proxy.
+  basePath: BASE_PATH,
   // Monorepo: trace files from the workspace root so workspace deps resolve.
   outputFileTracingRoot: workspaceRoot,
   turbopack: {

--- a/apps/raven/proxy.ts
+++ b/apps/raven/proxy.ts
@@ -6,8 +6,11 @@
 // redirects to the clean URL. APIs also accept an `x-raven-token` header.
 
 import { NextRequest, NextResponse } from "next/server";
+import { BASE_PATH } from "./lib/base-path";
 
 const COOKIE = "raven-access";
+// Note: `req.nextUrl.pathname` (and the matcher below) are basePath-stripped,
+// so these patterns stay basePath-free even though the app mounts at /engine.
 const PUBLIC_PATHS = [/^\/_next\//, /^\/favicon\.ico$/, /^\/raven-mascot\.png$/];
 
 // Constant-time-ish comparison; avoids early-exit timing on the token match.
@@ -23,7 +26,7 @@ function tokenMatches(provided: string, expected: string): boolean {
 function accessPage(): string {
   return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Raven — access</title></head>
 <body style="margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;background:#15120c;color:#ede5d6;font-family:Georgia,serif">
-<form method="GET" action="/" style="text-align:center;padding:24px">
+<form method="GET" action="${BASE_PATH || "/"}" style="text-align:center;padding:24px">
 <div style="font-size:22px;font-weight:600">Raven <span style="color:#ee7130">Forecasting Engine</span></div>
 <p style="color:#a99d87;font-size:13px;margin:10px 0 18px">This instance is private. Enter your access token.</p>
 <input name="token" autofocus placeholder="access token" style="background:#221b10;border:1px solid #3b3324;border-radius:9px;color:#ede5d6;font-size:14px;padding:10px 14px;outline:none;width:240px">
@@ -52,7 +55,9 @@ export default function proxy(req: NextRequest) {
         sameSite: "lax",
         secure: req.nextUrl.protocol === "https:",
         maxAge: 60 * 60 * 24 * 90,
-        path: "/"
+        // Scope to the mount prefix so the cookie is not sent to the rest of
+        // the shared domain once the main site reverse-proxies /engine/*.
+        path: BASE_PATH || "/"
       });
       return res;
     }
@@ -70,5 +75,7 @@ export default function proxy(req: NextRequest) {
 
 export const config = {
   // Everything except Next's static assets (also filtered above for safety).
-  matcher: ["/((?!_next/static|_next/image).*)"]
+  // Next prepends basePath to each matcher, so "/((?!…).*)" only covers
+  // /engine/<something>; the bare "/" entry is needed to gate /engine itself.
+  matcher: ["/", "/((?!_next/static|_next/image).*)"]
 };

--- a/vercel.json
+++ b/vercel.json
@@ -12,6 +12,22 @@
       "dest": "/apps/web"
     },
     {
+      "src": "^/engine$",
+      "dest": "http://34.85.97.32/engine"
+    },
+    {
+      "src": "^/engine/(.*)$",
+      "dest": "http://34.85.97.32/engine/$1"
+    },
+    {
+      "src": "^/delta$",
+      "dest": "http://34.85.97.32:3300/delta"
+    },
+    {
+      "src": "^/delta/(.*)$",
+      "dest": "http://34.85.97.32:3300/delta/$1"
+    },
+    {
       "src": "^/world-cup/(zh-CN|zh-TW)/?$",
       "dest": "/$1/world-cup",
       "continue": true


### PR DESCRIPTION
## What

Mount the two VM-hosted apps under forecasting-agent.com paths:

- `forecasting-agent.com/engine` → apps/raven (Forecasting Engine, VM :80→3200)
- `forecasting-agent.com/delta` → apps/raven-delta (Raven Delta, VM :3300)

## Changes

- **apps/raven**: `basePath: '/engine'` via new `lib/base-path.ts` single source; prefixed handwritten `fetch`/`<img>` URLs; proxy.ts token-gate hardening (matcher root hole — bare `/engine` bypassed the gate, form action, cookie path scoped)
- **apps/raven-delta**: `basePath: '/delta'`, same pattern; **fixes pre-existing token-gate root bypass** (its proxy.ts lagged behind raven's equivalent fix); cookie scoped to `/delta`
- **vercel.json**: 4 proxy routes before the catch-all

## Verification

- `pnpm --filter @autopoly/raven build` + typecheck ✅
- `pnpm --filter @autopoly/raven-delta build` + typecheck ✅
- `pnpm --filter @autopoly/web build` ✅
- Token-gate curl matrix on both apps (401/307/200/asset-passthrough/health) ✅

## Deploy plan (after merge)

1. VM: backup tree → rebuild ONLY `raven` + `raven-delta` containers (`--no-deps`)
2. `gh workflow run wc-results.yml --ref main` (the sanctioned channel)
3. Live acceptance: /engine + /delta with token, desktop+mobile screenshots

Note: direct URLs move (`34.85.97.32` → `34.85.97.32/engine`, `:3300` → `:3300/delta`).