### PR TITLE
feat(paper): expose effective run parameters on /live-predict-raven

### DIFF
--- a/apps/web/components/live-predict-raven/report-tables.tsx
+++ b/apps/web/components/live-predict-raven/report-tables.tsx
@@ -3,7 +3,8 @@ import type {
   ClosedTrade,
   EquityPoint,
   ExitAlphaRow,
-  OpenPosition
+  OpenPosition,
+  PaperParams
 } from "../../lib/live-predict-raven/snapshot";
 import { fmtPrice, fmtProb, fmtSignedUsd, fmtUsd } from "./format";
 import styles from "./report.module.css";
@@ -152,6 +153,56 @@ export function BrierTable({ rows }: { rows: readonly BrierRow[] }) {
               <td className={styles.num}>{fmtProb(r.marketProb)}</td>
               <td>{r.happened ? "✓ 发生" : "✗ 未发生"}</td>
               <td>{r.resolvedUtc}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function ParamsTable({ config: c }: { config: PaperParams }) {
+  const rows: Array<[string, string, string]> = [
+    ["本金", `$${c.bankrollUsd.toLocaleString("en-US")}`, "PAPER_BANKROLL_USD"],
+    ["评估时间表", `每日 UTC ${c.evalTimesUtc.join(" / ")}（${c.evalTimesUtc.length} 轮）`, "PAPER_EVAL_TIMES_UTC"],
+    ["单仓名义", `$${c.entryNotionalUsd}`, "PAPER_ENTRY_NOTIONAL_USD"],
+    ["入场 edge 阈值", `≥ ${c.entryEdgePp}pp（扣费后）`, "PAPER_ENTRY_EDGE_PP"],
+    ["退出 edge 阈值", `< ${c.exitEdgePp}pp 即卖（饱和持有可豁免）`, "PAPER_EXIT_EDGE_PP"],
+    ["止损", `入场价 −${(c.stopLossPct * 100).toFixed(0)}%（压过模型；每 ${c.fillCheckMinutes} 分钟无模型扫描）`, "PAPER_STOP_LOSS_PCT"],
+    ["最大仓位数", `${c.maxPositions}`, "PAPER_MAX_POSITIONS"],
+    ["单事件仓位上限", `${c.maxPerEvent}`, "PAPER_MAX_PER_EVENT"],
+    ["每周期评估上限", `${c.maxEvalsPerCycle}（持仓复审优先，剩余给新候选）`, "PAPER_MAX_EVALS_PER_CYCLE"],
+    ["每次评估引擎轮次", `${c.evalMaxRounds}（新档案最少 2 轮）`, "PAPER_EVAL_MAX_ROUNDS"],
+    ["评估模型", `${c.evalProvider}（联网搜索、市场盲测）`, "PAPER_EVAL_PROVIDER"],
+    ["扫描类别", c.categories.join(" / ") || "—", "PAPER_CATEGORIES"],
+    [
+      "扫描门槛",
+      `流动性 ≥$${c.scanMinLiquidityUsd.toLocaleString("en-US")} · 24h 量 ≥$${c.scanMinVolume24hUsd.toLocaleString("en-US")} · 每类 ${c.scanPerCategory} 个`,
+      "PAPER_SCAN_*"
+    ],
+    [
+      "混合退出",
+      `${(c.hybridMarketRatio * 100).toFixed(0)}% 市价 + ${((1 - c.hybridMarketRatio) * 100).toFixed(0)}% 限价（TTL ${c.limitTtlHours}h 回落市价）`,
+      "PAPER_HYBRID_MARKET_RATIO"
+    ],
+    ["饱和持有", c.saturatedHoldEnabled ? "开启（钳位卖出拦截，持有到结算）" : "已关闭", "PAPER_SATURATED_HOLD"]
+  ];
+  return (
+    <div className={styles.tableWrap}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th scope="col">参数</th>
+            <th scope="col">当前值</th>
+            <th scope="col">env 键</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(([label, value, envKey]) => (
+            <tr key={envKey + label}>
+              <td>{label}</td>
+              <td>{value}</td>
+              <td className={styles.rowNote}>{envKey}</td>
             </tr>
           ))}
         </tbody>

--- a/apps/web/components/live-predict-raven/report.tsx
+++ b/apps/web/components/live-predict-raven/report.tsx
@@ -7,7 +7,8 @@ import {
   ClosedTradesTable,
   EquityTable,
   ExitAlphaTable,
-  OpenPositionsTable
+  OpenPositionsTable,
+  ParamsTable
 } from "./report-tables";
 import styles from "./report.module.css";
 
@@ -207,6 +208,18 @@ export function PaperReport({
           </li>
           <li>费用 $0：本批地缘市场 taker/maker 均为 0 bps，费用拖累尚未被真正测试。</li>
         </ul>
+      </section>
+
+      <section className={styles.section} aria-labelledby="sec-params">
+        <h2 id="sec-params" className={styles.sectionTitle}>
+          运行参数
+        </h2>
+        <p className={styles.sectionNote}>
+          {dataSource === "live"
+            ? "实时读取自 VM 环境配置（env 可调默认值，调整须经用户确认）。"
+            : "留档快照值（VM 暂不可达）；参数以 VM 环境配置为准。"}
+        </p>
+        <ParamsTable config={s.config} />
       </section>
 
       <section className={styles.section} aria-labelledby="sec-verdict">

--- a/apps/web/lib/live-predict-raven/live.test.ts
+++ b/apps/web/lib/live-predict-raven/live.test.ts
@@ -154,6 +154,17 @@ describe("parseLivePayload", () => {
     expect(s?.closedTrades).toHaveLength(1);
   });
 
+  it("carries the live config through and falls back per-field when absent", () => {
+    const withConfig = parseLivePayload({
+      ...validPayload,
+      config: { maxPositions: 10, maxEvalsPerCycle: 16, saturatedHoldEnabled: true }
+    });
+    expect(withConfig?.config.maxEvalsPerCycle).toBe(16);
+    expect(withConfig?.config.entryEdgePp).toBe(8); // absent field -> fallback default
+    const withoutConfig = parseLivePayload(validPayload);
+    expect(withoutConfig?.config.maxPositions).toBe(10); // whole block fallback
+  });
+
   it("tolerates a null hybrid metric", () => {
     const s = parseLivePayload({
       ...validPayload,

--- a/apps/web/lib/live-predict-raven/live.ts
+++ b/apps/web/lib/live-predict-raven/live.ts
@@ -5,7 +5,8 @@
 // baked snapshot, so the page never breaks when the VM is unreachable.
 
 import { tradeNote, shortUtc, zhExitReason, zhExitStyle, zhQuestion } from "./labels";
-import type { ClosedTrade, ExitReasonKind, OpenPosition, PaperSnapshot } from "./snapshot";
+import type { ClosedTrade, ExitReasonKind, OpenPosition, PaperParams, PaperSnapshot } from "./snapshot";
+import { PAPER_PARAMS_FALLBACK } from "./snapshot";
 
 const DEFAULT_UPSTREAM = "http://34.85.97.32:8787";
 const FETCH_TIMEOUT_MS = 5000;
@@ -56,6 +57,38 @@ function toExitReason(v: unknown): ExitReasonKind {
 
 function isIsoTimestamp(v: unknown): v is string {
   return typeof v === "string" && Number.isFinite(Date.parse(v));
+}
+
+// Config block: per-field lenient with the baked fallback (an older API build
+// without `config` must not sink the whole payload).
+function parseConfig(raw: unknown): PaperParams {
+  if (!isRec(raw)) return PAPER_PARAMS_FALLBACK;
+  const strings = (v: unknown): string[] | null =>
+    Array.isArray(v) && v.every((x) => typeof x === "string") ? (v as string[]) : null;
+  return {
+    bankrollUsd: num(raw.bankrollUsd) ?? PAPER_PARAMS_FALLBACK.bankrollUsd,
+    evalTimesUtc: strings(raw.evalTimesUtc) ?? PAPER_PARAMS_FALLBACK.evalTimesUtc,
+    entryNotionalUsd: num(raw.entryNotionalUsd) ?? PAPER_PARAMS_FALLBACK.entryNotionalUsd,
+    entryEdgePp: num(raw.entryEdgePp) ?? PAPER_PARAMS_FALLBACK.entryEdgePp,
+    exitEdgePp: num(raw.exitEdgePp) ?? PAPER_PARAMS_FALLBACK.exitEdgePp,
+    stopLossPct: num(raw.stopLossPct) ?? PAPER_PARAMS_FALLBACK.stopLossPct,
+    maxPositions: num(raw.maxPositions) ?? PAPER_PARAMS_FALLBACK.maxPositions,
+    maxPerEvent: num(raw.maxPerEvent) ?? PAPER_PARAMS_FALLBACK.maxPerEvent,
+    maxEvalsPerCycle: num(raw.maxEvalsPerCycle) ?? PAPER_PARAMS_FALLBACK.maxEvalsPerCycle,
+    evalMaxRounds: num(raw.evalMaxRounds) ?? PAPER_PARAMS_FALLBACK.evalMaxRounds,
+    evalProvider: typeof raw.evalProvider === "string" ? raw.evalProvider : PAPER_PARAMS_FALLBACK.evalProvider,
+    categories: strings(raw.categories) ?? PAPER_PARAMS_FALLBACK.categories,
+    scanMinLiquidityUsd: num(raw.scanMinLiquidityUsd) ?? PAPER_PARAMS_FALLBACK.scanMinLiquidityUsd,
+    scanMinVolume24hUsd: num(raw.scanMinVolume24hUsd) ?? PAPER_PARAMS_FALLBACK.scanMinVolume24hUsd,
+    scanPerCategory: num(raw.scanPerCategory) ?? PAPER_PARAMS_FALLBACK.scanPerCategory,
+    hybridMarketRatio: num(raw.hybridMarketRatio) ?? PAPER_PARAMS_FALLBACK.hybridMarketRatio,
+    limitTtlHours: num(raw.limitTtlHours) ?? PAPER_PARAMS_FALLBACK.limitTtlHours,
+    fillCheckMinutes: num(raw.fillCheckMinutes) ?? PAPER_PARAMS_FALLBACK.fillCheckMinutes,
+    saturatedHoldEnabled:
+      typeof raw.saturatedHoldEnabled === "boolean"
+        ? raw.saturatedHoldEnabled
+        : PAPER_PARAMS_FALLBACK.saturatedHoldEnabled
+  };
 }
 
 // Strict on the numbers the headline tiles divide by; lenient elsewhere.
@@ -141,6 +174,7 @@ export function parseLivePayload(json: unknown): PaperSnapshot | null {
 
   return {
     generatedAtUtc: str(json.generatedAtUtc),
+    config: parseConfig(json.config),
     reflectionReportUtc: str(json.reflectionReportUtc),
     lastEvalCycleUtc: str(json.lastEvalCycleUtc),
     startedUtc: str(json.startedUtc),

--- a/apps/web/lib/live-predict-raven/snapshot.ts
+++ b/apps/web/lib/live-predict-raven/snapshot.ts
@@ -66,8 +66,31 @@ export interface BrierRow {
   resolvedUtc: string;
 }
 
+export interface PaperParams {
+  bankrollUsd: number;
+  evalTimesUtc: string[];
+  entryNotionalUsd: number;
+  entryEdgePp: number;
+  exitEdgePp: number;
+  stopLossPct: number;
+  maxPositions: number;
+  maxPerEvent: number;
+  maxEvalsPerCycle: number;
+  evalMaxRounds: number;
+  evalProvider: string;
+  categories: string[];
+  scanMinLiquidityUsd: number;
+  scanMinVolume24hUsd: number;
+  scanPerCategory: number;
+  hybridMarketRatio: number;
+  limitTtlHours: number;
+  fillCheckMinutes: number;
+  saturatedHoldEnabled: boolean;
+}
+
 export interface PaperSnapshot {
   generatedAtUtc: string;
+  config: PaperParams;
   reflectionReportUtc: string;
   lastEvalCycleUtc: string;
   startedUtc: string;
@@ -105,8 +128,33 @@ export interface PaperSnapshot {
   };
 }
 
+// Effective VM config as of 2026-07-25 (env values + code defaults); the live
+// payload carries the current values read from the VM env each request.
+export const PAPER_PARAMS_FALLBACK: PaperParams = {
+  bankrollUsd: 10000,
+  evalTimesUtc: ["02:00", "10:00", "18:00"],
+  entryNotionalUsd: 500,
+  entryEdgePp: 8,
+  exitEdgePp: 0,
+  stopLossPct: 0.35,
+  maxPositions: 10,
+  maxPerEvent: 1,
+  maxEvalsPerCycle: 16,
+  evalMaxRounds: 1,
+  evalProvider: "claude",
+  categories: ["finance", "geopolitics", "tech"],
+  scanMinLiquidityUsd: 5000,
+  scanMinVolume24hUsd: 2000,
+  scanPerCategory: 12,
+  hybridMarketRatio: 0.5,
+  limitTtlHours: 8,
+  fillCheckMinutes: 10,
+  saturatedHoldEnabled: true
+};
+
 export const PAPER_SNAPSHOT: PaperSnapshot = {
   generatedAtUtc: "2026-07-24T11:15Z",
+  config: PAPER_PARAMS_FALLBACK,
   reflectionReportUtc: "2026-07-23T18:19Z",
   lastEvalCycleUtc: "2026-07-24T10:13Z",
   startedUtc: "2026-07-03T07:17Z",

--- a/services/forecast-api/src/paper-snapshot.test.ts
+++ b/services/forecast-api/src/paper-snapshot.test.ts
@@ -328,6 +328,43 @@ describe("buildPaperSnapshot", () => {
   });
 });
 
+describe("readPaperConfigView", () => {
+  const CONFIG_KEYS = [
+    "PAPER_MAX_POSITIONS",
+    "PAPER_MAX_EVALS_PER_CYCLE",
+    "PAPER_SATURATED_HOLD",
+    "PAPER_CATEGORIES",
+    "PAPER_EVAL_TIMES_UTC"
+  ];
+
+  afterEach(() => {
+    for (const k of CONFIG_KEYS) delete process.env[k];
+  });
+
+  it("mirrors paper-agent defaults when env is unset", () => {
+    const s = buildPaperSnapshot(root);
+    expect(s.config.maxPositions).toBe(10);
+    expect(s.config.entryEdgePp).toBe(8);
+    expect(s.config.stopLossPct).toBe(0.35);
+    expect(s.config.saturatedHoldEnabled).toBe(true);
+    expect(s.config.evalTimesUtc).toEqual(["00:10", "08:10", "16:10"]);
+  });
+
+  it("honors env overrides and the saturated-hold kill-switch spellings", () => {
+    process.env.PAPER_MAX_POSITIONS = "22";
+    process.env.PAPER_MAX_EVALS_PER_CYCLE = "16";
+    process.env.PAPER_SATURATED_HOLD = "off";
+    process.env.PAPER_CATEGORIES = "Finance, Tech";
+    process.env.PAPER_EVAL_TIMES_UTC = "02:00,10:00,18:00";
+    const s = buildPaperSnapshot(root);
+    expect(s.config.maxPositions).toBe(22);
+    expect(s.config.maxEvalsPerCycle).toBe(16);
+    expect(s.config.saturatedHoldEnabled).toBe(false);
+    expect(s.config.categories).toEqual(["finance", "tech"]);
+    expect(s.config.evalTimesUtc).toEqual(["02:00", "10:00", "18:00"]);
+  });
+});
+
 describe("getPaperSnapshot cache", () => {
   it("serves cached payloads within the TTL and rebuilds after it", () => {
     process.env.PAPER_ARTIFACTS_ROOT = root;

--- a/services/forecast-api/src/paper-snapshot.ts
+++ b/services/forecast-api/src/paper-snapshot.ts
@@ -37,6 +37,7 @@ export interface ApiClosedTrade {
 
 export interface PaperSnapshotPayload {
   generatedAtUtc: string;
+  config: PaperConfigView;
   startedUtc: string | null;
   lastEvalCycleUtc: string | null;
   reflectionReportUtc: string | null;
@@ -101,6 +102,72 @@ export interface PaperSnapshotPayload {
 
 const round2 = (n: number): number => Math.round(n * 100) / 100;
 const round4 = (n: number): number => Math.round(n * 10000) / 10000;
+
+export interface PaperConfigView {
+  bankrollUsd: number;
+  evalTimesUtc: string[];
+  entryNotionalUsd: number;
+  entryEdgePp: number;
+  exitEdgePp: number;
+  stopLossPct: number;
+  maxPositions: number;
+  maxPerEvent: number;
+  maxEvalsPerCycle: number;
+  evalMaxRounds: number;
+  evalProvider: string;
+  categories: string[];
+  scanMinLiquidityUsd: number;
+  scanMinVolume24hUsd: number;
+  scanPerCategory: number;
+  hybridMarketRatio: number;
+  limitTtlHours: number;
+  fillCheckMinutes: number;
+  saturatedHoldEnabled: boolean;
+}
+
+function envNum(name: string, fallback: number, min = 0): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= min ? n : fallback;
+}
+
+// MIRROR of services/paper-agent/src/config.ts loadPaperConfig — every
+// container shares deploy/raven/.env, so reading the same env with the same
+// defaults yields the paper-agent's effective config. Keep the two in sync
+// when a new PAPER_* knob lands.
+export function readPaperConfigView(): PaperConfigView {
+  const times = (process.env.PAPER_EVAL_TIMES_UTC ?? "00:10,08:10,16:10")
+    .split(",")
+    .map((t) => t.trim())
+    .filter((t) => /^\d{2}:\d{2}$/.test(t));
+  return {
+    bankrollUsd: envNum("PAPER_BANKROLL_USD", 1000, 1),
+    evalTimesUtc: times.length ? times : ["00:10", "08:10", "16:10"],
+    entryNotionalUsd: envNum("PAPER_ENTRY_NOTIONAL_USD", 50, 1),
+    entryEdgePp: envNum("PAPER_ENTRY_EDGE_PP", 8, 0.5),
+    exitEdgePp: envNum("PAPER_EXIT_EDGE_PP", 0),
+    stopLossPct: envNum("PAPER_STOP_LOSS_PCT", 0.35, 0.01),
+    maxPositions: envNum("PAPER_MAX_POSITIONS", 10, 1),
+    maxPerEvent: envNum("PAPER_MAX_PER_EVENT", 1, 1),
+    maxEvalsPerCycle: envNum("PAPER_MAX_EVALS_PER_CYCLE", 12, 1),
+    evalMaxRounds: envNum("PAPER_EVAL_MAX_ROUNDS", 1, 1),
+    evalProvider: process.env.PAPER_EVAL_PROVIDER?.trim() === "deepseek" ? "deepseek" : "claude",
+    categories: (process.env.PAPER_CATEGORIES ?? "")
+      .split(",")
+      .map((c) => c.trim().toLowerCase())
+      .filter(Boolean),
+    scanMinLiquidityUsd: envNum("PAPER_SCAN_MIN_LIQUIDITY_USD", 5000, 0),
+    scanMinVolume24hUsd: envNum("PAPER_SCAN_MIN_VOLUME24H_USD", 10000, 0),
+    scanPerCategory: envNum("PAPER_SCAN_PER_CATEGORY", 8, 1),
+    hybridMarketRatio: Math.min(1, envNum("PAPER_HYBRID_MARKET_RATIO", 0.5)),
+    limitTtlHours: envNum("PAPER_LIMIT_TTL_HOURS", 8, 0.1),
+    fillCheckMinutes: envNum("PAPER_FILL_CHECK_MINUTES", 10, 1),
+    saturatedHoldEnabled: !["0", "false", "off", "no"].includes(
+      (process.env.PAPER_SATURATED_HOLD ?? "").trim().toLowerCase()
+    )
+  };
+}
 
 function paperRoot(): string {
   // Explicit override first (tests), then the ARTIFACT_STORAGE_ROOT convention
@@ -322,6 +389,7 @@ export function buildPaperSnapshot(rootDir: string = paperRoot()): PaperSnapshot
 
   return {
     generatedAtUtc: new Date().toISOString(),
+    config: readPaperConfigView(),
     startedUtc: typeof firstCycle?.ts === "string" ? firstCycle.ts : null,
     lastEvalCycleUtc: (() => {
       const last = cycleEnds[cycleEnds.length - 1];


### PR DESCRIPTION
User request: list all paper-agent parameters and show them on the page. /paper/snapshot now carries a `config` block (env + mirrored defaults; all containers share deploy/raven/.env so forecast-api reads the agent's effective values), and the page renders a 运行参数 table (15 knobs incl. PAPER_MAX_POSITIONS=10 and the new PAPER_MAX_EVALS_PER_CYCLE=16) with env keys, live per request with per-field baked fallback. 67/67 vitest, web build green, local E2E screenshot verified.