### PR TITLE
feat(paper): /live-predict-raven 2026-08-05 数据刷新 + 回合盈亏计入入场费

### DIFF
--- a/apps/web/components/live-predict-raven/report-tables.tsx
+++ b/apps/web/components/live-predict-raven/report-tables.tsx
@@ -146,8 +146,10 @@ export function BrierTable({ rows }: { rows: readonly BrierRow[] }) {
           </tr>
         </thead>
         <tbody>
-          {rows.map((r) => (
-            <tr key={r.question}>
+          {rows.map((r, i) => (
+            // The same market can appear more than once (one row per resolved
+            // position episode), so the question alone is not a unique key.
+            <tr key={`${r.question}-${r.resolvedUtc}-${i}`}>
               <td>{r.question}</td>
               <td className={styles.num}>{fmtProb(r.agentProb)}</td>
               <td className={styles.num}>{fmtProb(r.marketProb)}</td>

--- a/apps/web/components/live-predict-raven/report.tsx
+++ b/apps/web/components/live-predict-raven/report.tsx
@@ -108,16 +108,16 @@ export function PaperReport({
           <Tile
             label="现金"
             value={fmtUsd(s.cashUsd)}
-            sub={`占总权益 ${openBook.cashSharePct.toFixed(1)}% · 费用 $0（本批市场费率 0 bps）`}
+            sub={`占总权益 ${openBook.cashSharePct.toFixed(1)}% · 累计费用 ${fmtUsd(s.feesUsd)}（按 CLOB 逐市场费率）`}
           />
         </div>
         <p className={styles.callout}>
           一句话：{equity.returnPct >= 0 ? "赚了" : "亏了"} {Math.abs(equity.returnPct).toFixed(1)}%
-          ，结构上是"高胜率小盈利 + 低频大亏损"——平均单笔亏损（{fmtUsd(trade.avgLossUsd)}
+          ——已平仓 {trade.closedCount} 回合 {trade.wins} 胜 {trade.losses} 负（胜率{" "}
+          {trade.winRatePct.toFixed(1)}%），平均单笔亏损（{fmtUsd(trade.avgLossUsd)}
           ）约为平均单笔盈利（{fmtUsd(trade.avgWinUsd)}）的{" "}
-          {trade.avgWinUsd > 0 ? (trade.avgLossUsd / trade.avgWinUsd).toFixed(1) : "—"} 倍，目前靠{" "}
-          {trade.winRatePct.toFixed(1)}% 的胜率和浮盈扛住。
-          {s.realizedPnlUsd < 0 ? "已实现部分整体仍是负数。" : ""}
+          {trade.avgWinUsd > 0 ? (trade.avgLossUsd / trade.avgWinUsd).toFixed(1) : "—"} 倍。
+          {s.realizedPnlUsd < 0 ? "已实现部分整体为负数。" : ""}
         </p>
       </section>
 
@@ -129,8 +129,9 @@ export function PaperReport({
           <EquityChart curve={s.equityCurve} bankrollUsd={s.bankrollUsd} />
         </div>
         <p className={styles.sectionNote}>
-          复盘注（2026-07-24）：7/14 冲到峰值 +8.0% 后，7/15–16 被同一市场的两次止损（合计
-          -$460）拖低，低点出现在 7/21，随后回稳。
+          复盘注（2026-08-05）：两段行情。7/14 冲到峰值 +8.0%（$10,799）后靠浮盈横盘到
+          7/24；7/25 起连续下台阶——11 天里 10 次止损，几乎全是以伊停火题材，8/4 跌到
+          $8,112，自峰值最大回撤 −26%。
         </p>
         <details className={styles.details}>
           <summary>查看逐日数值表</summary>
@@ -144,9 +145,11 @@ export function PaperReport({
         </h2>
         <ClosedTradesTable trades={s.closedTrades} />
         <p className={styles.callout}>
-          复盘注（2026-07-24）：两笔亏损是同一个论点买了两次："伊朗 7/17 前退出 MOU 谈判"。第一次 agent 估 19.5%（市场只给
-          6.4%）买 YES，4 小时后止损；当晚在更低价位原方向重进，次日再止损。这是整个模拟盘唯一一次显著偏离市场定价的独立判断，也是全部已实现亏损的来源。反事实检验显示两次止损本身都是对的（死扛到归零会多亏
-          $540）——错在入场与止损后无冷却期的重进。
+          复盘注（2026-08-05）：7/24 时"4 胜 2 负"的结构已被 7/26–8/4 的止损串彻底改写——新增 11
+          回合里 10 次止损。7/24 复盘提出的"止损后同市场冷却期"未落地，同样的错误以更大规模重演："以伊停火延续至
+          7/31"同一市场三进三止损（合计 −$601），"美伊 7/31 有效停火"二进二止损（−$400）。最贵的一笔是英伟达：0.22 买
+          YES 一天后止损，市场最终以 YES 结算（反事实 α −$1,838）。唯一亮点：霍尔木兹 7/31 被 saturated-hold
+          护着持有到临近结算，+$170 落袋。
         </p>
       </section>
 
@@ -161,9 +164,10 @@ export function PaperReport({
           mark，随每次评估周期更新。
         </p>
         <p className={styles.callout}>
-          复盘注（2026-07-24）风险集中：六仓全是地缘政治 NO，其中四仓共享"伊朗局势"单一驱动（霍尔木兹 ×2 + 核协议 +
-          入侵伊朗）。一次中东局势突变会同时打穿多仓。亮点是霍尔木兹 12/31：市场定价 72% 会恢复通航时逆势买
-          NO @ 0.28，现在市场已向 agent 靠拢（+75%），是目前唯一在赢的真正逆市场立场（未结算）。
+          复盘注（2026-08-05）风险集中：满仓 10/10，全是地缘政治 NO，其中五仓共享"伊朗局势"单一驱动（霍尔木兹
+          ×2 + 核协议 + 入侵伊朗 + 解除封锁）——正是这个题材在 7 月末打穿了已平仓账。亮点仍是霍尔木兹
+          12/31：市场定价 72% 会恢复通航时逆势买 NO @ 0.28，现价 0.38（+$179），是唯一在赢的真正逆市场立场（未结算）。8/4
+          新开的"解除封锁"仓一天浮亏 −$116，是当前最大的红仓。
         </p>
       </section>
 
@@ -174,7 +178,12 @@ export function PaperReport({
 
         <h3 className={styles.subTitle}>退出质量：α 合计 {fmtSignedUsd(s.exitAlpha.totalUsd)}</h3>
         <p className={styles.sectionNote}>
-          α = 卖出所得 −（若持有到现在/结算的价值），正数 = 卖对了。结论：退出决策整体明显加分。
+          α = 卖出所得 −（若持有到现在/结算的价值），正数 = 卖对了。
+          {s.exitAlpha.totalUsd >= 0
+            ? "合计为正：退出决策整体加分。"
+            : "合计为负：退出决策整体在减分。"}{" "}
+          复盘注（2026-08-05）：合计从 7/24 的 +$1,077 转负——英伟达（止损后市场以 YES 结算，−$1,838）与哈马斯（止损后
+          NO 价反弹近 4 倍，−$869）两笔反事实巨亏，压过了停火系列止损救回的约 +$1,400。
         </p>
         <ExitAlphaTable rows={s.exitAlpha.rows} />
 
@@ -183,8 +192,9 @@ export function PaperReport({
         </h3>
         <p className={styles.sectionNote}>
           skill score = 1 − Brier_agent / Brier_market，&gt;0 才算跑赢市场。当前为负（agent {s.brier.agentScore.toFixed(3)} vs 市场{" "}
-          {s.brier.marketScore.toFixed(3)}），样本仅 {s.brier.n} 个已结算市场——尚不能下结论。7/31
-          有一批持仓集中到期，样本很快会上来。
+          {s.brier.marketScore.toFixed(3)}，n={s.brier.n}）。复盘注（2026-08-05）：7/31
+          结算潮后样本首次够量，初步结论是 agent 落后于市场——大额失分集中在以伊停火系列（对"停火延续"的方向判断与结果相反）与"停止对伊军事行动"（agent
+          15% vs 市场 94%，事件发生）。
         </p>
         <BrierTable rows={s.brier.rows} />
 
@@ -206,7 +216,10 @@ export function PaperReport({
             饱和持有拦截 <strong>{s.saturatedHolds}</strong> 次——saturated-hold 修复（PR #91）阻止 99%
             钳位把接近满值的赢家提前卖掉，改为持有到结算。
           </li>
-          <li>费用 $0：本批地缘市场 taker/maker 均为 0 bps，费用拖累尚未被真正测试。</li>
+          <li>
+            累计费用 {fmtUsd(s.feesUsd)}：早期地缘市场费率均为 0 bps，7 月下旬起部分新市场（英伟达、马杜罗）带真实费率——英伟达回合
+            $45 入场费 + $23 卖出费已计入该回合成本与盈亏。
+          </li>
         </ul>
       </section>
 
@@ -224,37 +237,38 @@ export function PaperReport({
 
       <section className={styles.section} aria-labelledby="sec-verdict">
         <h2 id="sec-verdict" className={styles.sectionTitle}>
-          结论与建议（2026-07-24 复盘）
+          结论与建议（2026-08-05 复盘）
         </h2>
         <ul className={styles.list}>
           <li>
-            <strong>盈利构成：</strong>收"大概率不发生"的权利金（4 笔已验证有效）+ 一个在赢的逆市场仓（霍尔木兹
-            12/31，未结算）− 一次输掉的独立判断（MOU，-$460）。
+            <strong>亏损构成：</strong>−20% ≈ 已实现 −$2,114（12 个负回合、其中 10
+            次止损）+ 浮盈 +$134 的微弱缓冲。7 月上旬收权利金攒下的 +8%
+            浮盈，在 7/25 后的止损串里全部回吐并转亏。
           </li>
           <li>
-            <strong>与基准一致：</strong>贴着市场先验做小幅修正能稳定小赚；真正偏离市场的判断才是分水岭——目前
-            1 胜（浮盈）1 负（已实现）。
+            <strong>与基准：</strong>Brier skill −0.53（n=12）——首批足量样本显示独立判断整体落后市场。7/24
+            时"贴市场小修正稳定小赚"的通道，在短到期、高波动的停火系列上失效：agent 反复给出与市场大幅背离的方向判断，结果站在错的一边。
           </li>
           <li>
-            <strong>建议 ①（最高优先级）：</strong>止损后对同市场/同事件加冷却期。MOU 的第二次进场距第一次止损仅
-            4 小时，多亏 $227。
+            <strong>建议 ①（7/24 已提、仍未落地，代价已现）：</strong>止损后对同市场/同事件加冷却期。以伊停火 7/31
+            三进三止损（−$601）、美伊停火二进二止损（−$400）、哈马斯止损后 24 小时内重进（现持仓中）——全部是这一个缺口。
           </li>
           <li>
-            <strong>建议 ②：</strong>加题材级相关性敞口上限（或先在反思报告里显式呈现相关暴露）。事件级上限没挡住
-            4 仓共享伊朗驱动。
+            <strong>建议 ②：</strong>题材级相关性敞口上限。事件级 maxPerEvent=1 没挡住停火/封锁/军事行动这组强相关市场同向暴露，7
+            月末一个题材打穿整本账；当前在持 10 仓里仍有 5 仓共享伊朗驱动。
           </li>
           <li>
-            <strong>建议 ③（已部分落地）：</strong>饱和钳位导致的错误卖出已由 saturated-hold 修复（PR
-            #91）拦截，赢家可持有到结算；饱和 edge 的名义值展示仍待改进。等 7/31 结算潮把 Brier
-            样本攒起来再评价预测能力。
+            <strong>建议 ③：</strong>止损规则与低价单适配。−35% 价格止损对 0.1–0.3
+            区间的单子过于敏感（波动天然大），英伟达止损后市场以 YES 结算（α
+            −$1,838）；考虑按剩余净 edge 退出而非纯价格回撤，或对低价单缩小仓位而不是收紧止损。
           </li>
         </ul>
       </section>
 
       <footer className={styles.footer}>
         <p>
-          模拟盘——无真实订单、无真实资金。费用按 CLOB 逐市场实时元数据计（本批均为 0）。金额合计与总权益之间存在
-          &lt;$1 的取整差（报告 mark 保留两位）。
+          模拟盘——无真实订单、无真实资金。费用按 CLOB 逐市场实时元数据计（多数地缘市场为
+          0，个别市场带真实费率，已计入回合成本）。金额合计与总权益之间存在 &lt;$1 的取整差（报告 mark 保留两位）。
         </p>
         <p>
           数据来源：raven-paper-agent-1 容器 portfolio.json / ledger.jsonl（{s.fills.total} 笔成交，其中 1

--- a/apps/web/lib/live-predict-raven/labels.ts
+++ b/apps/web/lib/live-predict-raven/labels.ts
@@ -26,19 +26,67 @@ const QUESTION_ZH: Record<string, string> = {
   "Putin out as President of Russia by December 31, 2026?": "普京 2027 年前卸任俄罗斯总统？",
   "US-Iran Final Nuclear Deal by September 30, 2026?": "美伊 9/30 前达成最终核协议？",
   "Will Ukraine recapture Crimean territory by December 31, 2026?": "乌克兰 12/31 前收复克里米亚领土？",
-  "Will the U.S. invade Iran before 2027?": "美国 2027 年前入侵伊朗？"
+  "Will the U.S. invade Iran before 2027?": "美国 2027 年前入侵伊朗？",
+  "us-x-iran-effective-ceasfire-by-july-31-20260715194822045": "美伊 7/31 前达成有效停火？",
+  "israel-x-iran-ceasefire-continues-through-july-31-20260716224448968-384-155-519-798-243":
+    "以伊停火延续至 7/31？",
+  "israel-x-iran-ceasefire-continues-through-august-15-20260716224448969-246-815-987-693":
+    "以伊停火延续至 8/15？",
+  "will-the-us-announce-an-iran-ceasefire-by-july-31-20260718000915875": "美国 7/31 前宣布停止对伊军事行动？",
+  "will-nvidia-be-the-largest-company-in-the-world-by-market-cap-on-july-31-20260624192329841":
+    "英伟达 7/31 全球市值第一？",
+  "will-hamas-agree-to-disarm-by-december-31": "哈马斯 12/31 前同意解除武装？",
+  "iran-leadership-change-by-august-31-669": "伊朗 8/31 前领导层更替？",
+  "strait-of-hormuz-traffic-returns-to-normal-by-august-31-20260702154212320":
+    "霍尔木兹海峡 8/31 前恢复正常通航？",
+  "strait-of-hormuz-traffic-returns-to-normal-by-september-30-20260702154339440":
+    "霍尔木兹海峡 9/30 前恢复正常通航？",
+  "will-nicols-maduro-be-the-leader-of-venezuela-end-of-2026": "马杜罗 2026 年底仍是委内瑞拉领导人？",
+  "us-announces-end-of-iranian-blockade-by-august-7-2026-20260727171523690": "美国 8/7 前宣布解除对伊封锁？",
+  "US x Iran Effective Ceasefire by July 31?": "美伊 7/31 前达成有效停火？",
+  "Israel x Iran ceasefire continues through July 31?": "以伊停火延续至 7/31？",
+  "Israel x Iran ceasefire continues through August 15?": "以伊停火延续至 8/15？",
+  "US announces halt in Iran offensive operations by July 31?": "美国 7/31 前宣布停止对伊军事行动？",
+  "Will NVIDIA be the largest company in the world by market cap on July 31?": "英伟达 7/31 全球市值第一？",
+  "Will Hamas agree to disarm by December 31?": "哈马斯 12/31 前同意解除武装？",
+  "Iran leadership change by August 31?": "伊朗 8/31 前领导层更替？",
+  "Strait of Hormuz traffic returns to normal by August 31?": "霍尔木兹海峡 8/31 前恢复正常通航？",
+  "Strait of Hormuz traffic returns to normal by September 30?": "霍尔木兹海峡 9/30 前恢复正常通航？",
+  "Will Nicolás Maduro be the leader of Venezuela end of 2026?": "马杜罗 2026 年底仍是委内瑞拉领导人？",
+  "US announces end of Iranian blockade by August 7, 2026?": "美国 8/7 前宣布解除对伊封锁？",
+  "Will WTI Crude Oil (WTI) hit (HIGH) $95 in July?": "WTI 原油 7 月最高价触及 $95？"
 };
 
 // Editorial context for known closed round trips, keyed by slug@closedDate.
 const TRADE_NOTES: Record<string, string> = {
   "us-x-iran-diplomatic-meeting-by-july-31-2026-20260622191708361@2026-07-05":
-    "退出后价格跌到 0.065 — 反事实检验里最赚的一次退出（α +$542）",
+    "退出后市场以 NO 结算——反事实检验里最赚的一次常规退出（α +$594）",
   "mojtaba-khamenei-seen-in-public-by-july-15-155@2026-07-15":
     "持有 12 天到临近结算；这次 0.994 卖出正是 99% 钳位强制的（saturated-hold 修复的起因）",
   "will-iran-announce-withdrawal-from-mou-negotiations-by-july-17@2026-07-15":
     "agent 估 19.5% vs 市场 6.4%，4 小时后止损",
   "will-iran-announce-withdrawal-from-mou-negotiations-by-july-17@2026-07-16":
-    "止损 4 小时后原方向重新进场，再次止损；事件最终未发生"
+    "止损 4 小时后原方向重新进场，再次止损；事件最终未发生",
+  "strait-of-hormuz-traffic-returns-to-normal-by-july-31@2026-07-27":
+    "saturated-hold 多次拦截负 edge 强卖后持有到临近结算，0.9945 清仓——修复（PR #91）上线后的代表性赢单",
+  "us-x-iran-effective-ceasfire-by-july-31-20260715194822045@2026-07-26":
+    "开仓次日止损；7/27 又在 0.466 重进同市场（第二回合 8/4 再止损）",
+  "israel-x-iran-ceasefire-continues-through-july-31-20260716224448968-384-155-519-798-243@2026-07-27":
+    "以伊停火系列第一次止损",
+  "will-the-us-announce-an-iran-ceasefire-by-july-31-20260718000915875@2026-07-27":
+    "开仓 73 分钟即止损——本轮最快的一笔",
+  "israel-x-iran-ceasefire-continues-through-july-31-20260716224448968-384-155-519-798-243@2026-07-28":
+    "止损后 7 小时原方向重进，再止损（冷却期缺口重演）",
+  "will-nvidia-be-the-largest-company-in-the-world-by-market-cap-on-july-31-20260624192329841@2026-07-29":
+    "止损后市场最终以 YES 结算——反事实最差的一次退出（α −$1,838）；成本含 $45 入场费",
+  "israel-x-iran-ceasefire-continues-through-july-31-20260716224448968-384-155-519-798-243@2026-07-30":
+    "同一市场第三次进场第三次止损；三回合合计 −$601",
+  "israel-x-iran-ceasefire-continues-through-august-15-20260716224448969-246-815-987-693@2026-07-31":
+    "以伊停火题材换 8/15 到期日再进，第四次止损",
+  "will-hamas-agree-to-disarm-by-december-31@2026-07-31":
+    "止损卖在 0.11 后 NO 价反弹到 ~0.40（α −$869）；8/1 又在 0.36 重进同市场（现持仓中）",
+  "us-x-iran-effective-ceasfire-by-july-31-20260715194822045@2026-08-04":
+    "7/27 重进的第二回合，拖过到期日后 8/4 止损离场"
 };
 
 export function zhQuestion(slugOrQuestion: string, fallback?: string): string {

--- a/apps/web/lib/live-predict-raven/snapshot.ts
+++ b/apps/web/lib/live-predict-raven/snapshot.ts
@@ -153,22 +153,22 @@ export const PAPER_PARAMS_FALLBACK: PaperParams = {
 };
 
 export const PAPER_SNAPSHOT: PaperSnapshot = {
-  generatedAtUtc: "2026-07-24T11:15Z",
+  generatedAtUtc: "2026-08-05T06:45Z",
   config: PAPER_PARAMS_FALLBACK,
-  reflectionReportUtc: "2026-07-23T18:19Z",
-  lastEvalCycleUtc: "2026-07-24T10:13Z",
+  reflectionReportUtc: "2026-08-04T18:44Z",
+  lastEvalCycleUtc: "2026-08-05T02:33Z",
   startedUtc: "2026-07-03T07:17Z",
   bankrollUsd: 10000,
-  cashUsd: 6821.18,
-  realizedPnlUsd: -178.82,
-  equityUsd: 10406.37,
-  feesUsd: 0,
-  fills: { total: 32, buys: 13, sells: 19 },
+  cashUsd: 2890.63,
+  realizedPnlUsd: -2114.37,
+  equityUsd: 7974.23,
+  feesUsd: 113.05,
+  fills: { total: 59, buys: 28, sells: 31 },
   droppedBuyFills: 1,
-  evalCycles: 66,
-  saturatedHolds: 1,
+  evalCycles: 101,
+  saturatedHolds: 8,
   equityCurve: [
-    { date: "07-03开盘", equityUsd: 10000 },
+    { date: "起点", equityUsd: 10000 },
     { date: "07-03", equityUsd: 9995.28 },
     { date: "07-04", equityUsd: 10272.05 },
     { date: "07-05", equityUsd: 10268.78 },
@@ -190,7 +190,19 @@ export const PAPER_SNAPSHOT: PaperSnapshot = {
     { date: "07-21", equityUsd: 10374.44 },
     { date: "07-22", equityUsd: 10417.31 },
     { date: "07-23", equityUsd: 10440.04 },
-    { date: "07-24", equityUsd: 10406.37 }
+    { date: "07-24", equityUsd: 10420.01 },
+    { date: "07-25", equityUsd: 10305.74 },
+    { date: "07-26", equityUsd: 9976.81 },
+    { date: "07-27", equityUsd: 9680.51 },
+    { date: "07-28", equityUsd: 9378.39 },
+    { date: "07-29", equityUsd: 9611.21 },
+    { date: "07-30", equityUsd: 9434.13 },
+    { date: "07-31", equityUsd: 9432.9 },
+    { date: "08-01", equityUsd: 9125.06 },
+    { date: "08-02", equityUsd: 8441.88 },
+    { date: "08-03", equityUsd: 8431.65 },
+    { date: "08-04", equityUsd: 8111.81 },
+    { date: "现在", equityUsd: 7974.23 }
   ],
   closedTrades: [
     {
@@ -214,7 +226,7 @@ export const PAPER_SNAPSHOT: PaperSnapshot = {
       closedUtc: "2026-07-05T18:18Z",
       entryPrice: 0.79,
       exitPrice: 0.82,
-      shares: 632.9,
+      shares: 632.91,
       costUsd: 500,
       pnlUsd: 18.99,
       exitReason: "negative_edge"
@@ -227,11 +239,11 @@ export const PAPER_SNAPSHOT: PaperSnapshot = {
       closedUtc: "2026-07-05T22:28Z",
       entryPrice: 0.6185,
       exitPrice: 0.735,
-      shares: 808.4,
+      shares: 808.36,
       costUsd: 500,
       pnlUsd: 94.15,
       exitReason: "negative_edge",
-      note: "退出后价格跌到 0.065 — 反事实检验里最赚的一次退出（α +$542）"
+      note: "退出后市场以 NO 结算——反事实检验里最赚的一次常规退出（α +$594）"
     },
     {
       question: "Mojtaba Khamenei 7/15 前公开露面？",
@@ -241,7 +253,7 @@ export const PAPER_SNAPSHOT: PaperSnapshot = {
       closedUtc: "2026-07-15T09:54Z",
       entryPrice: 0.8556,
       exitPrice: 0.9945,
-      shares: 584.4,
+      shares: 584.38,
       costUsd: 500,
       pnlUsd: 81.17,
       exitReason: "negative_edge",
@@ -255,7 +267,7 @@ export const PAPER_SNAPSHOT: PaperSnapshot = {
       closedUtc: "2026-07-15T14:04Z",
       entryPrice: 0.1448,
       exitPrice: 0.0772,
-      shares: 3453.1,
+      shares: 3453.06,
       costUsd: 500,
       pnlUsd: -233.38,
       exitReason: "stop_loss",
@@ -269,37 +281,177 @@ export const PAPER_SNAPSHOT: PaperSnapshot = {
       closedUtc: "2026-07-16T00:14Z",
       entryPrice: 0.0744,
       exitPrice: 0.0406,
-      shares: 6723.3,
+      shares: 6723.29,
       costUsd: 500,
       pnlUsd: -226.8,
       exitReason: "stop_loss",
       note: "止损 4 小时后原方向重新进场，再次止损；事件最终未发生"
-    }
-  ],
-  openPositions: [
+    },
+    {
+      question: "美伊 7/31 前达成有效停火？（第一回合）",
+      slug: "us-x-iran-effective-ceasfire-by-july-31-20260715194822045",
+      side: "NO",
+      openedUtc: "2026-07-25T18:43Z",
+      closedUtc: "2026-07-26T17:07Z",
+      entryPrice: 0.6814,
+      exitPrice: 0.4375,
+      shares: 733.8,
+      costUsd: 500,
+      pnlUsd: -178.96,
+      exitReason: "stop_loss",
+      note: "开仓次日止损；7/27 又在 0.466 重进同市场（第二回合 8/4 再止损）"
+    },
     {
       question: "霍尔木兹海峡 7/31 前恢复正常通航？",
       slug: "strait-of-hormuz-traffic-returns-to-normal-by-july-31",
       side: "NO",
       openedUtc: "2026-07-03T10:12Z",
-      shares: 674.2,
-      entryPrice: 0.742,
-      markPrice: 0.992,
-      unrealizedUsd: 168.55,
-      agentProb: 0.99,
-      flag: "saturated",
-      saturatedHold: true
+      closedUtc: "2026-07-27T09:57Z",
+      entryPrice: 0.7417,
+      exitPrice: 0.9945,
+      shares: 674.17,
+      costUsd: 500,
+      pnlUsd: 170.46,
+      exitReason: "negative_edge",
+      note: "saturated-hold 多次拦截负 edge 强卖后持有到临近结算，0.9945 清仓——修复（PR #91）上线后的代表性赢单"
     },
     {
+      question: "以伊停火延续至 7/31？（第一次）",
+      slug: "israel-x-iran-ceasefire-continues-through-july-31-20260716224448968-384-155-519-798-243",
+      side: "NO",
+      openedUtc: "2026-07-26T18:34Z",
+      closedUtc: "2026-07-27T18:29Z",
+      entryPrice: 0.14,
+      exitPrice: 0.0892,
+      shares: 3571.43,
+      costUsd: 500,
+      pnlUsd: -181.46,
+      exitReason: "stop_loss",
+      note: "以伊停火系列第一次止损"
+    },
+    {
+      question: "美国 7/31 前宣布停止对伊军事行动？",
+      slug: "will-the-us-announce-an-iran-ceasefire-by-july-31-20260718000915875",
+      side: "NO",
+      openedUtc: "2026-07-27T18:44Z",
+      closedUtc: "2026-07-27T19:57Z",
+      entryPrice: 0.0765,
+      exitPrice: 0.0422,
+      shares: 6533.65,
+      costUsd: 500,
+      pnlUsd: -224.32,
+      exitReason: "stop_loss",
+      note: "开仓 73 分钟即止损——本轮最快的一笔"
+    },
+    {
+      question: "以伊停火延续至 7/31？（第二次）",
+      slug: "israel-x-iran-ceasefire-continues-through-july-31-20260716224448968-384-155-519-798-243",
+      side: "NO",
+      openedUtc: "2026-07-28T02:30Z",
+      closedUtc: "2026-07-28T07:47Z",
+      entryPrice: 0.0725,
+      exitPrice: 0.04,
+      shares: 6898.03,
+      costUsd: 500,
+      pnlUsd: -224.08,
+      exitReason: "stop_loss",
+      note: "止损后 7 小时原方向重进，再止损（冷却期缺口重演）"
+    },
+    {
+      question: "英伟达 7/31 全球市值第一？",
+      slug: "will-nvidia-be-the-largest-company-in-the-world-by-market-cap-on-july-31-20260624192329841",
+      side: "YES",
+      openedUtc: "2026-07-28T10:49Z",
+      closedUtc: "2026-07-29T08:17Z",
+      entryPrice: 0.22,
+      exitPrice: 0.1014,
+      shares: 2045.45,
+      costUsd: 495,
+      pnlUsd: -287.55,
+      exitReason: "stop_loss",
+      note: "止损后市场最终以 YES 结算——反事实最差的一次退出（α −$1,838）；成本含 $45 入场费"
+    },
+    {
+      question: "以伊停火延续至 7/31？（第三次）",
+      slug: "israel-x-iran-ceasefire-continues-through-july-31-20260716224448968-384-155-519-798-243",
+      side: "NO",
+      openedUtc: "2026-07-29T10:45Z",
+      closedUtc: "2026-07-30T06:27Z",
+      entryPrice: 0.1135,
+      exitPrice: 0.0692,
+      shares: 4405.04,
+      costUsd: 500,
+      pnlUsd: -195.29,
+      exitReason: "stop_loss",
+      note: "同一市场第三次进场第三次止损；三回合合计 −$601"
+    },
+    {
+      question: "以伊停火延续至 8/15？",
+      slug: "israel-x-iran-ceasefire-continues-through-august-15-20260716224448969-246-815-987-693",
+      side: "NO",
+      openedUtc: "2026-07-30T10:38Z",
+      closedUtc: "2026-07-31T17:47Z",
+      entryPrice: 0.3238,
+      exitPrice: 0.1906,
+      shares: 1544,
+      costUsd: 500,
+      pnlUsd: -205.73,
+      exitReason: "stop_loss",
+      note: "以伊停火题材换 8/15 到期日再进，第四次止损"
+    },
+    {
+      question: "哈马斯 12/31 前同意解除武装？",
+      slug: "will-hamas-agree-to-disarm-by-december-31",
+      side: "NO",
+      openedUtc: "2026-07-31T18:38Z",
+      closedUtc: "2026-07-31T18:47Z",
+      entryPrice: 0.1697,
+      exitPrice: 0.11,
+      shares: 2947.09,
+      costUsd: 500,
+      pnlUsd: -175.82,
+      exitReason: "stop_loss",
+      note: "止损卖在 0.11 后 NO 价反弹到 ~0.40（α −$869）；8/1 又在 0.36 重进同市场（现持仓中）"
+    },
+    {
+      question: "伊朗 8/31 前领导层更替？",
+      slug: "iran-leadership-change-by-august-31-669",
+      side: "YES",
+      openedUtc: "2026-08-01T02:42Z",
+      closedUtc: "2026-08-01T10:57Z",
+      entryPrice: 0.0568,
+      exitPrice: 0.0327,
+      shares: 8805.67,
+      costUsd: 500,
+      pnlUsd: -211.68,
+      exitReason: "stop_loss"
+    },
+    {
+      question: "美伊 7/31 前达成有效停火？（第二回合）",
+      slug: "us-x-iran-effective-ceasfire-by-july-31-20260715194822045",
+      side: "NO",
+      openedUtc: "2026-07-27T10:37Z",
+      closedUtc: "2026-08-04T13:27Z",
+      entryPrice: 0.4662,
+      exitPrice: 0.26,
+      shares: 1072.57,
+      costUsd: 500,
+      pnlUsd: -221.13,
+      exitReason: "stop_loss",
+      note: "7/27 重进的第二回合，拖过到期日后 8/4 止损离场"
+    }
+  ],
+  openPositions: [
+    {
       question: "普京 2027 年前卸任俄罗斯总统？",
-      slug: "putin-out-before-2027",
+      slug: "putin-out-before-2027-346",
       side: "NO",
       openedUtc: "2026-07-04T02:12Z",
-      shares: 555.6,
+      shares: 555.56,
       entryPrice: 0.9,
-      markPrice: 0.91,
-      unrealizedUsd: 5.56,
-      agentProb: 0.986,
+      markPrice: 0.92,
+      unrealizedUsd: 11.11,
+      agentProb: 0.8429,
       flag: "contaminated"
     },
     {
@@ -307,34 +459,34 @@ export const PAPER_SNAPSHOT: PaperSnapshot = {
       slug: "us-iran-final-nuclear-deal-by-september-30-2026",
       side: "NO",
       openedUtc: "2026-07-05T02:20Z",
-      shares: 704.2,
+      shares: 704.23,
       entryPrice: 0.71,
-      markPrice: 0.86,
-      unrealizedUsd: 105.63,
-      agentProb: 0.99,
-      flag: "saturated"
+      markPrice: 0.85,
+      unrealizedUsd: 98.59,
+      agentProb: 0.9869,
+      flag: null
     },
     {
       question: "霍尔木兹海峡 12/31 前恢复正常通航？",
       slug: "strait-of-hormuz-traffic-returns-to-normal-by-december-31",
       side: "NO",
       openedUtc: "2026-07-06T02:19Z",
-      shares: 1785.7,
+      shares: 1785.71,
       entryPrice: 0.28,
-      markPrice: 0.48,
-      unrealizedUsd: 357.14,
-      agentProb: 0.99,
-      flag: "saturated"
+      markPrice: 0.38,
+      unrealizedUsd: 178.57,
+      agentProb: 0.9884,
+      flag: null
     },
     {
       question: "乌克兰 12/31 前收复克里米亚领土？",
       slug: "will-ukraine-recapture-crimean-territory-by-december-31-2026",
       side: "NO",
       openedUtc: "2026-07-07T02:25Z",
-      shares: 555.6,
+      shares: 555.56,
       entryPrice: 0.9,
-      markPrice: 0.9,
-      unrealizedUsd: 0,
+      markPrice: 0.91,
+      unrealizedUsd: 5.56,
       agentProb: 0.99,
       flag: "saturated"
     },
@@ -343,59 +495,119 @@ export const PAPER_SNAPSHOT: PaperSnapshot = {
       slug: "will-the-us-invade-iran-before-2027",
       side: "NO",
       openedUtc: "2026-07-16T10:22Z",
-      shares: 649.4,
+      shares: 649.35,
       entryPrice: 0.77,
+      markPrice: 0.83,
+      unrealizedUsd: 38.96,
+      agentProb: 0.99,
+      flag: "saturated"
+    },
+    {
+      question: "霍尔木兹海峡 8/31 前恢复正常通航？",
+      slug: "strait-of-hormuz-traffic-returns-to-normal-by-august-31-20260702154212320",
+      side: "NO",
+      openedUtc: "2026-07-25T18:31Z",
+      shares: 581.4,
+      entryPrice: 0.86,
+      markPrice: 0.83,
+      unrealizedUsd: -17.44,
+      agentProb: 0.9848,
+      flag: null
+    },
+    {
+      question: "马杜罗 2026 年底仍是委内瑞拉领导人？",
+      slug: "will-nicols-maduro-be-the-leader-of-venezuela-end-of-2026",
+      side: "NO",
+      openedUtc: "2026-07-25T18:50Z",
+      shares: 2429.22,
+      entryPrice: 0.1852,
+      markPrice: 0.173,
+      unrealizedUsd: -29.74,
+      agentProb: 0.99,
+      flag: "saturated"
+    },
+    {
+      question: "霍尔木兹海峡 9/30 前恢复正常通航？",
+      slug: "strait-of-hormuz-traffic-returns-to-normal-by-september-30-20260702154339440",
+      side: "NO",
+      openedUtc: "2026-07-25T18:57Z",
+      shares: 652.3,
+      entryPrice: 0.7665,
       markPrice: 0.69,
-      unrealizedUsd: -51.95,
-      agentProb: 0.93,
+      unrealizedUsd: -49.91,
+      agentProb: 0.99,
+      flag: "saturated"
+    },
+    {
+      question: "哈马斯 12/31 前同意解除武装？",
+      slug: "will-hamas-agree-to-disarm-by-december-31",
+      side: "NO",
+      openedUtc: "2026-08-01T18:33Z",
+      shares: 1389.75,
+      entryPrice: 0.3598,
+      markPrice: 0.37,
+      unrealizedUsd: 14.21,
+      agentProb: 0.9757,
+      flag: null
+    },
+    {
+      question: "美国 8/7 前宣布解除对伊封锁？",
+      slug: "us-announces-end-of-iranian-blockade-by-august-7-2026-20260727171523690",
+      side: "NO",
+      openedUtc: "2026-08-04T18:44Z",
+      shares: 850.73,
+      entryPrice: 0.5877,
+      markPrice: 0.451,
+      unrealizedUsd: -116.32,
+      agentProb: 0.9586,
       flag: null
     }
   ],
   exitAlpha: {
-    totalUsd: 1076.73,
+    totalUsd: -134.29,
     rows: [
       {
-        question: "美伊 7/10 前外交会晤？",
+        question: "美伊 7/10 前举行外交会晤？",
         side: "NO",
         soldUtc: "07-04 02:06",
         exitStyle: "市价+限价两腿",
-        avgExitPrice: 0.977,
+        avgExitPrice: 0.9765,
         priceNow: 1,
         alphaUsd: -14.13,
         reason: "负 edge 退出"
       },
       {
-        question: "NATO×俄罗斯年底前冲突？",
+        question: "NATO 与俄罗斯年底前军事冲突？",
         side: "NO",
         soldUtc: "07-05 10:08",
-        exitStyle: "市价（限价超时回落）",
+        exitStyle: "市价",
         avgExitPrice: 0.82,
-        priceNow: 0.8,
-        alphaUsd: 12.66,
+        priceNow: 0,
+        alphaUsd: 0,
         reason: "负 edge 退出+限价单超时回落"
       },
       {
-        question: "美伊 7/31 前外交会晤？",
+        question: "美伊 7/31 前举行外交会晤？",
         side: "YES",
         soldUtc: "07-05 18:15",
         exitStyle: "市价+限价两腿",
         avgExitPrice: 0.735,
-        priceNow: 0.065,
-        alphaUsd: 541.6,
+        priceNow: 0,
+        alphaUsd: 594.15,
         reason: "负 edge 退出"
       },
       {
-        question: "Mojtaba Khamenei 7/15 前露面？",
+        question: "Mojtaba Khamenei 7/15 前公开露面？",
         side: "NO",
         soldUtc: "07-15 02:04",
         exitStyle: "市价+限价两腿",
-        avgExitPrice: 0.995,
+        avgExitPrice: 0.9945,
         priceNow: 1,
         alphaUsd: -3.21,
         reason: "负 edge 退出"
       },
       {
-        question: "伊朗 7/17 前退出 MOU 谈判？（两回合合并）",
+        question: "伊朗 7/17 前宣布退出 MOU 谈判？",
         side: "YES",
         soldUtc: "07-15 14:04",
         exitStyle: "市价",
@@ -403,24 +615,153 @@ export const PAPER_SNAPSHOT: PaperSnapshot = {
         priceNow: 0,
         alphaUsd: 539.82,
         reason: "止损"
+      },
+      {
+        question: "美伊 7/31 前达成有效停火？",
+        side: "NO",
+        soldUtc: "07-26 17:07",
+        exitStyle: "市价",
+        avgExitPrice: 0.3321,
+        priceNow: 0.235,
+        alphaUsd: 175.42,
+        reason: "止损"
+      },
+      {
+        question: "霍尔木兹海峡 7/31 前恢复正常通航？",
+        side: "NO",
+        soldUtc: "07-27 02:02",
+        exitStyle: "市价+限价两腿",
+        avgExitPrice: 0.9945,
+        priceNow: 1,
+        alphaUsd: -3.71,
+        reason: "负 edge 退出"
+      },
+      {
+        question: "以伊停火延续至 7/31？",
+        side: "NO",
+        soldUtc: "07-27 18:29",
+        exitStyle: "市价",
+        avgExitPrice: 0.0605,
+        priceNow: 0,
+        alphaUsd: 899.17,
+        reason: "止损"
+      },
+      {
+        question: "美国 7/31 前宣布停止对伊军事行动？",
+        side: "NO",
+        soldUtc: "07-27 19:57",
+        exitStyle: "市价",
+        avgExitPrice: 0.0422,
+        priceNow: 0,
+        alphaUsd: 275.68,
+        reason: "止损"
+      },
+      {
+        question: "英伟达 7/31 全球市值第一？",
+        side: "YES",
+        soldUtc: "07-29 08:17",
+        exitStyle: "市价",
+        avgExitPrice: 0.1127,
+        priceNow: 1,
+        alphaUsd: -1838,
+        reason: "止损"
+      },
+      {
+        question: "以伊停火延续至 8/15？",
+        side: "NO",
+        soldUtc: "07-31 17:47",
+        exitStyle: "市价",
+        avgExitPrice: 0.1906,
+        priceNow: 0.155,
+        alphaUsd: 54.96,
+        reason: "止损"
+      },
+      {
+        question: "哈马斯 12/31 前同意解除武装？",
+        side: "NO",
+        soldUtc: "07-31 18:47",
+        exitStyle: "市价",
+        avgExitPrice: 0.11,
+        priceNow: 0.405,
+        alphaUsd: -869.39,
+        reason: "止损"
+      },
+      {
+        question: "伊朗 8/31 前领导层更替？",
+        side: "YES",
+        soldUtc: "08-01 10:57",
+        exitStyle: "市价",
+        avgExitPrice: 0.0327,
+        priceNow: 0.0265,
+        alphaUsd: 54.97,
+        reason: "止损"
       }
     ]
   },
   brier: {
-    n: 4,
-    agentScore: 0.2175,
-    marketScore: 0.1882,
-    skillScore: -0.16,
+    n: 12,
+    agentScore: 0.3245,
+    marketScore: 0.2117,
+    skillScore: -0.5327,
     rows: [
       {
-        question: "伊朗 7/17 前退出 MOU 谈判？",
-        agentProb: 0.195,
-        marketProb: 0.064,
+        question: "以伊停火延续至 7/31？",
+        agentProb: 0.692,
+        marketProb: 0.12,
+        happened: false,
+        resolvedUtc: "2026-07-30"
+      },
+      {
+        question: "以伊停火延续至 7/31？",
+        agentProb: 0.2751,
+        marketProb: 0.9,
+        happened: true,
+        resolvedUtc: "2026-07-29"
+      },
+      {
+        question: "WTI 原油 7 月最高价触及 $95？",
+        agentProb: 0.0463,
+        marketProb: 0.0505,
+        happened: false,
+        resolvedUtc: "2026-07-29"
+      },
+      {
+        question: "英伟达 7/31 全球市值第一？",
+        agentProb: 0.2443,
+        marketProb: 0.22,
+        happened: true,
+        resolvedUtc: "2026-07-29"
+      },
+      {
+        question: "英伟达 7/31 全球市值第一？",
+        agentProb: 0.4753,
+        marketProb: 0.215,
+        happened: true,
+        resolvedUtc: "2026-07-28"
+      },
+      {
+        question: "美国 7/31 前宣布停止对伊军事行动？",
+        agentProb: 0.1492,
+        marketProb: 0.941,
+        happened: true,
+        resolvedUtc: "2026-07-27"
+      },
+      {
+        question: "霍尔木兹海峡 7/31 前恢复正常通航？",
+        agentProb: 0.989,
+        marketProb: 0.994,
+        happened: true,
+        resolvedUtc: "2026-07-27"
+      },
+      {
+        question: "伊朗 7/17 前宣布退出 MOU 谈判？",
+        agentProb: 0.1948,
+        marketProb: 0.0635,
         happened: false,
         resolvedUtc: "2026-07-15"
       },
       {
-        question: "Mojtaba Khamenei 7/15 前露面？",
+        question: "Mojtaba Khamenei 7/15 前公开露面？",
         agentProb: 0.99,
         marketProb: 0.994,
         happened: true,
@@ -428,14 +769,21 @@ export const PAPER_SNAPSHOT: PaperSnapshot = {
       },
       {
         question: "中菲 2027 前军事冲突？",
-        agentProb: 0.088,
+        agentProb: 0.0881,
         marketProb: 0.135,
         happened: true,
         resolvedUtc: "2026-07-07"
       },
       {
-        question: "美伊 7/10 前外交会晤？",
-        agentProb: 0.976,
+        question: "美伊 7/31 前举行外交会晤？",
+        agentProb: 0.669,
+        marketProb: 0.73,
+        happened: false,
+        resolvedUtc: "2026-07-05"
+      },
+      {
+        question: "美伊 7/10 前举行外交会晤？",
+        agentProb: 0.9755,
         marketProb: 0.976,
         happened: true,
         resolvedUtc: "2026-07-04"
@@ -445,12 +793,12 @@ export const PAPER_SNAPSHOT: PaperSnapshot = {
   // Ledger-count basis (same basis the live endpoint uses, so live and
   // fallback never disagree on the counting method).
   engineQuality: {
-    evaluations: 351,
-    saturated: 200,
-    contaminated: 50,
-    evalErrors: 9,
-    limitOrdersPlaced: 4,
-    limitFills: 12,
-    limitVsMarketPp: 0.46
+    evaluations: 672,
+    saturated: 398,
+    contaminated: 85,
+    evalErrors: 11,
+    limitOrdersPlaced: 5,
+    limitFills: 13,
+    limitVsMarketPp: 0.37
   }
 };

--- a/apps/web/lib/live-predict-raven/stats.test.ts
+++ b/apps/web/lib/live-predict-raven/stats.test.ts
@@ -4,12 +4,12 @@ import { deriveEquityStats, deriveOpenBookStats, deriveReportStats, deriveTradeS
 
 describe("live-predict-raven stats", () => {
   describe("deriveTradeStats", () => {
-    it("computes 4 wins / 2 losses = 66.67% on the baked closed trades", () => {
+    it("computes 5 wins / 12 losses = 29.41% on the baked closed trades", () => {
       const stats = deriveTradeStats(PAPER_SNAPSHOT.closedTrades);
-      expect(stats.closedCount).toBe(6);
-      expect(stats.wins).toBe(4);
-      expect(stats.losses).toBe(2);
-      expect(stats.winRatePct).toBeCloseTo(66.67, 1);
+      expect(stats.closedCount).toBe(17);
+      expect(stats.wins).toBe(5);
+      expect(stats.losses).toBe(12);
+      expect(stats.winRatePct).toBeCloseTo(29.41, 1);
     });
 
     it("matches the book's realized PnL within per-fill rounding drift", () => {
@@ -17,12 +17,12 @@ describe("live-predict-raven stats", () => {
       expect(stats.realizedPnlUsd).toBeCloseTo(PAPER_SNAPSHOT.realizedPnlUsd, 0);
     });
 
-    it("shows the loss-size problem: avg loss ~3x avg win, profit factor < 1", () => {
+    it("shows the loss-size problem: avg loss ~2.4x avg win, profit factor far below 1", () => {
       const stats = deriveTradeStats(PAPER_SNAPSHOT.closedTrades);
-      expect(stats.avgWinUsd).toBeCloseTo(70.35, 1);
-      expect(stats.avgLossUsd).toBeCloseTo(230.09, 1);
+      expect(stats.avgWinUsd).toBeCloseTo(90.37, 1);
+      expect(stats.avgLossUsd).toBeCloseTo(213.85, 1);
       expect(stats.profitFactor).toBeLessThan(1);
-      expect(stats.profitFactor).toBeCloseTo(0.61, 2);
+      expect(stats.profitFactor).toBeCloseTo(0.18, 2);
     });
 
     it("handles an empty trade list without dividing by zero", () => {
@@ -37,15 +37,15 @@ describe("live-predict-raven stats", () => {
   describe("deriveEquityStats", () => {
     it("reads current equity, peak, and return off the curve", () => {
       const stats = deriveEquityStats(PAPER_SNAPSHOT.equityCurve, PAPER_SNAPSHOT.bankrollUsd);
-      expect(stats.currentUsd).toBe(10406.37);
+      expect(stats.currentUsd).toBe(7974.23);
       expect(stats.peakUsd).toBe(10799.24);
       expect(stats.peakDate).toBe("07-14");
-      expect(stats.returnPct).toBeCloseTo(4.06, 2);
+      expect(stats.returnPct).toBeCloseTo(-20.26, 2);
     });
 
-    it("computes max drawdown as the worst peak-to-trough drop (7/14 -> 7/21)", () => {
+    it("computes max drawdown as the worst peak-to-trough drop (7/14 peak -> now)", () => {
       const stats = deriveEquityStats(PAPER_SNAPSHOT.equityCurve, PAPER_SNAPSHOT.bankrollUsd);
-      expect(stats.maxDrawdownPct).toBeCloseTo(-3.93, 1);
+      expect(stats.maxDrawdownPct).toBeCloseTo(-26.16, 1);
     });
 
     it("is monotonic-safe: a flat curve has zero drawdown", () => {
@@ -58,29 +58,29 @@ describe("live-predict-raven stats", () => {
   });
 
   describe("deriveOpenBookStats", () => {
-    it("sums cost basis (~$3000) and unrealized (+$584.93) across the 6 open positions", () => {
+    it("sums cost basis (~$4950) and unrealized (+$133.59) across the 10 open positions", () => {
       const stats = deriveOpenBookStats(PAPER_SNAPSHOT.openPositions, PAPER_SNAPSHOT.cashUsd);
-      expect(stats.positionCount).toBe(6);
-      expect(stats.costUsd).toBeCloseTo(3000, 0);
-      expect(stats.unrealizedUsd).toBeCloseTo(584.93, 1);
-      expect(stats.green).toBe(4);
-      expect(stats.flat).toBe(1);
-      expect(stats.red).toBe(1);
+      expect(stats.positionCount).toBe(10);
+      expect(stats.costUsd).toBeCloseTo(4950, 0);
+      expect(stats.unrealizedUsd).toBeCloseTo(133.59, 1);
+      expect(stats.green).toBe(6);
+      expect(stats.flat).toBe(0);
+      expect(stats.red).toBe(4);
     });
 
-    it("reports the cash share of marked book value (~65%)", () => {
+    it("reports the cash share of marked book value (~36%)", () => {
       const stats = deriveOpenBookStats(PAPER_SNAPSHOT.openPositions, PAPER_SNAPSHOT.cashUsd);
-      expect(stats.cashSharePct).toBeGreaterThan(63);
-      expect(stats.cashSharePct).toBeLessThan(68);
+      expect(stats.cashSharePct).toBeGreaterThan(34);
+      expect(stats.cashSharePct).toBeLessThan(39);
     });
   });
 
   describe("deriveReportStats", () => {
     it("assembles all three sections from the snapshot", () => {
       const stats = deriveReportStats(PAPER_SNAPSHOT);
-      expect(stats.trade.closedCount).toBe(6);
-      expect(stats.equity.currentUsd).toBe(10406.37);
-      expect(stats.openBook.positionCount).toBe(6);
+      expect(stats.trade.closedCount).toBe(17);
+      expect(stats.equity.currentUsd).toBe(7974.23);
+      expect(stats.openBook.positionCount).toBe(10);
     });
   });
 });

--- a/services/forecast-api/src/paper-snapshot.test.ts
+++ b/services/forecast-api/src/paper-snapshot.test.ts
@@ -149,6 +149,31 @@ const ledgerLines = [
     shares: 200,
     avgEntryPrice: 0.4
   },
+  // Fee-bearing market (the NVDA pattern): entry fee must land in the round's
+  // cost basis and pnl, or the closed-trades table drifts from realized PnL.
+  {
+    ts: "2026-07-09T00:00:00.000Z",
+    type: "trade",
+    side: "buy",
+    positionId: "fee-market:1",
+    slug: "fee-market",
+    outcome: "Yes",
+    shares: 1000,
+    avgPrice: 0.2,
+    feeUsd: 20
+  },
+  {
+    ts: "2026-07-09T06:00:00.000Z",
+    type: "trade",
+    side: "sell",
+    style: "market",
+    positionId: "fee-market:1",
+    slug: "fee-market",
+    shares: 1000,
+    avgPrice: 0.1,
+    feeUsd: 10,
+    reason: "stop_loss"
+  },
   { ts: "2026-07-06T18:00:00.000Z", type: "cycle_end", positions: 1, cashUsd: 9500 }
 ];
 
@@ -238,7 +263,7 @@ describe("buildPaperSnapshot", () => {
 
   it("counts fills, cycles, evals and the saturated-hold interventions", () => {
     const s = buildPaperSnapshot(root);
-    expect(s.fills).toEqual({ total: 9, buys: 5, sells: 4 });
+    expect(s.fills).toEqual({ total: 11, buys: 6, sells: 5 });
     expect(s.droppedBuyFills).toBe(1);
     expect(s.evalCycles).toBe(1);
     expect(s.evaluations).toBe(2);
@@ -254,7 +279,7 @@ describe("buildPaperSnapshot", () => {
 
   it("pairs round trips sequentially, supporting re-entry on the same positionId", () => {
     const s = buildPaperSnapshot(root);
-    expect(s.closedTrades).toHaveLength(4);
+    expect(s.closedTrades).toHaveLength(5);
     const [first, second] = s.closedTrades;
     expect(first?.pnlUsd).toBeCloseTo(10, 2); // 100 sh: 0.8 -> 0.9
     expect(first?.exitReason).toBe("negative_edge"); // ttl-fallback suffix stripped
@@ -276,6 +301,15 @@ describe("buildPaperSnapshot", () => {
     // cost 200×0.4 = 80; refund 200×$0.50 = 100
     expect(voided?.exitReason).toBe("settled_voided");
     expect(voided?.pnlUsd).toBeCloseTo(20, 2);
+  });
+
+  it("folds entry fees into the round's cost basis and pnl", () => {
+    const s = buildPaperSnapshot(root);
+    const fee = s.closedTrades.find((t) => t.slug === "fee-market");
+    expect(fee?.costUsd).toBeCloseTo(220, 2); // 1000×0.2 notional + $20 entry fee
+    expect(fee?.pnlUsd).toBeCloseTo(-130, 2); // (100 − $10 sell fee) − 220
+    expect(fee?.entryPrice).toBeCloseTo(0.2, 4); // true fill price, fee excluded
+    expect(fee?.exitPrice).toBeCloseTo(0.09, 4);
   });
 
   it("maps open positions with flags and saturatedHold", () => {

--- a/services/forecast-api/src/paper-snapshot.ts
+++ b/services/forecast-api/src/paper-snapshot.ts
@@ -217,9 +217,13 @@ const SETTLEMENT_PER_SHARE: Record<string, number> = { won: 1, lost: 0, voided: 
 // can round-trip more than once (MOU did), and a partial exit whose residual
 // settles produces ONE episode with combined sell + settlement economics.
 function pairClosedTrades(events: Array<Record<string, unknown>>): ApiClosedTrade[] {
+  // costUsd tracks notional (shares × price) so entryPrice stays the true fill
+  // price; buyFeesUsd is carried separately and folded into the reported cost
+  // basis and pnl at close time, so per-round pnl sums to the book's realized
+  // PnL even on fee-bearing markets (entry fees went unbooked before).
   const open = new Map<
     string,
-    { shares: number; costUsd: number; proceedsUsd: number; soldShares: number; openedUtc: string; side: string; lastSellUtc: string; lastReason: string }
+    { shares: number; costUsd: number; buyFeesUsd: number; proceedsUsd: number; soldShares: number; openedUtc: string; side: string; lastSellUtc: string; lastReason: string }
   >();
   const closed: ApiClosedTrade[] = [];
   for (const t of events) {
@@ -243,8 +247,8 @@ function pairClosedTrades(events: Array<Record<string, unknown>>): ApiClosedTrad
         entryPrice: round4(cur.costUsd / soldShares),
         exitPrice: round4(proceedsUsd / soldShares),
         shares: round2(soldShares),
-        costUsd: round2(cur.costUsd),
-        pnlUsd: round2(proceedsUsd - cur.costUsd),
+        costUsd: round2(cur.costUsd + cur.buyFeesUsd),
+        pnlUsd: round2(proceedsUsd - cur.costUsd - cur.buyFeesUsd),
         exitReason: `settled_${String(t.kind)}`
       });
       open.delete(id);
@@ -257,6 +261,7 @@ function pairClosedTrades(events: Array<Record<string, unknown>>): ApiClosedTrad
       const cur = open.get(id) ?? {
         shares: 0,
         costUsd: 0,
+        buyFeesUsd: 0,
         proceedsUsd: 0,
         soldShares: 0,
         openedUtc: String(t.ts ?? ""),
@@ -264,7 +269,12 @@ function pairClosedTrades(events: Array<Record<string, unknown>>): ApiClosedTrad
         lastSellUtc: "",
         lastReason: ""
       };
-      open.set(id, { ...cur, shares: cur.shares + shares, costUsd: cur.costUsd + shares * price });
+      open.set(id, {
+        ...cur,
+        shares: cur.shares + shares,
+        costUsd: cur.costUsd + shares * price,
+        buyFeesUsd: cur.buyFeesUsd + Number(t.feeUsd ?? 0)
+      });
     } else if (t.side === "sell") {
       const cur = open.get(id);
       if (!cur) continue;
@@ -286,8 +296,8 @@ function pairClosedTrades(events: Array<Record<string, unknown>>): ApiClosedTrad
           entryPrice: round4(next.costUsd / next.soldShares),
           exitPrice: round4(next.proceedsUsd / next.soldShares),
           shares: round2(next.soldShares),
-          costUsd: round2(next.costUsd),
-          pnlUsd: round2(next.proceedsUsd - next.costUsd),
+          costUsd: round2(next.costUsd + next.buyFeesUsd),
+          pnlUsd: round2(next.proceedsUsd - next.costUsd - next.buyFeesUsd),
           exitReason: next.lastReason
         });
         open.delete(id);


### PR DESCRIPTION
## 概要

用户指令:更新 Raven 模拟盘收益率与网页。

### 数据刷新(截至 2026-08-05 02:33Z,第 101 周期)
- 权益 **$7,974.23(−20.3%)**,峰值回撤 −26.2%;已平 17 回合 **5 胜 12 负**(7/26–8/4 十止损,以伊停火同市场三进三止损)
- 退出 α 由 +$1,077 转 **−$134**(NVDA 止损后市场以 YES 结算 α −$1,838;哈马斯 −$869)
- Brier n=12、skill **−0.53**——样本首次够量,agent 落后市场
- 烘焙回退快照、中文标签(11 个新市场)、编者注全部重写为 2026-08-05 复盘;费用文案改数据驱动(累计 $113.05,不再硬编码 "$0")

### forecast-api 修复:回合盈亏漏计入场费
`pairClosedTrades` 买入腿只累计名义成本、忽略 `feeUsd`(卖出腿已扣)——费用为零时代不可见,NVDA/Maduro 的 $45 入场费出现后,已平仓表合计与账面已实现盈亏差 $45。现入场费计入回合成本基与 pnl(结算路径同步),`entryPrice` 保持真实成交价;新增 fee-market 回归测试。**需重新部署 VM forecast-api 容器。**

### 其他
- BrierTable 行 key 去重(同一市场两次结算导致 React 重复 key 报错)
- stats 测试更新到新烘焙期望值

## 验证
- [x] forecast-api vitest 13/13、typecheck 绿
- [x] web live-predict-raven vitest 23/23
- [x] `pnpm --filter @autopoly/web build` 绿
- [x] 实时模式 + 烘焙回退模式 × 桌面/移动 四组截图 0 console error / 0 pageerror(归档 `runtime-artifacts/screenshots/20260805-live-predict-raven-refresh/`)
- [ ] 合并后:`gh workflow run wc-results.yml --ref main` 发布 web;VM clean-untar + `up -d --no-deps forecast-api`;生产 E2E