### PR TITLE
docs(readme): refresh to 2026-08 state (hosted engine, paper agent, WC track record)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,23 @@
 
 > English is the primary README. 中文版见 [docs/README.zh-CN.md](docs/README.zh-CN.md).
 
-Last updated: 2026-06-12
+Last updated: 2026-08-20
 
 ---
 
-**predict-raven** is an open-source **forecasting agent framework**: it lets an AI agent estimate the probability of real-world events, gather and weigh evidence continuously, and act on the result. The same agent core powers two very different applications today:
+**predict-raven** is an open-source **forecasting agent framework**: it lets an AI agent estimate the probability of real-world events, gather and weigh evidence continuously, and act on the result. The same agent core powers a family of applications today:
 
 - **Autonomous prediction-market trading** — the first autonomous, continuously-running trading agent on [Polymarket](https://polymarket.com). It estimates fair probabilities, compares them to market-implied odds, and trades the edge under hard, service-layer risk controls.
-- **Market-blind public forecasting** — transparent, Brier-scored probabilities for all 48 teams at the 2026 World Cup, deliberately produced **without ever reading a market price**. Live at **[forecasting-agent.com](https://forecasting-agent.com/world-cup)**.
+- **Market-blind public forecasting** — transparent, Brier-scored probabilities for all 48 teams at the 2026 World Cup, deliberately produced **without ever reading a market price**. Live at **[forecasting-agent.com](https://forecasting-agent.com/world-cup)**, scored in public on the [track record page](https://forecasting-agent.com/world-cup/performance).
+- **Hosted Forecasting Engine** — the same iterative forecaster as hosted products: an interactive research console at [/engine](https://forecasting-agent.com/engine), the Raven Delta news-impact engine at [/delta](https://forecasting-agent.com/delta), and a forecast API + MCP service (probability + reasoning + evidence as JSON, plain text, or PDF). See [Forecasting Engine (hosted)](#forecasting-engine-hosted).
+- **Autonomous paper trading** — a simulation-only twin of the trading agent running unattended in the cloud: market-blind position evaluations three times a day, net-edge exits, and a daily self-review with a Brier skill score against the market. See [Autonomous paper trading](#autonomous-paper-trading-simulation).
 
 Watch live:
 
-- **World Cup forecasts (market-blind)**: [forecasting-agent.com](https://forecasting-agent.com/world-cup)
+- **World Cup forecasts (market-blind)**: [forecasting-agent.com/world-cup](https://forecasting-agent.com/world-cup) · [track record](https://forecasting-agent.com/world-cup/performance)
+- **Forecasting Engine console**: [forecasting-agent.com/engine](https://forecasting-agent.com/engine) (browsing is public; new runs are invite-gated)
+- **Raven Delta news-impact engine**: [forecasting-agent.com/delta](https://forecasting-agent.com/delta) (invite-gated)
+- **Paper-trading book review**: [forecasting-agent.com/live-predict-raven](https://forecasting-agent.com/live-predict-raven) (invite-gated, live VM snapshot)
 - **Trading decision log / equity curve**: [autopoly-pizza-spectator.vercel.app](https://autopoly-pizza-spectator.vercel.app)
 - **On-chain positions / fills (Polymarket profile)**: [`0x6664...614e`](https://polymarket.com/profile/0x6664e32f79aee42639f73633e40b5a842b07614e)
 
@@ -29,7 +34,7 @@ Watch live:
 
 The trading side is built around a single core component, **Market Pulse**: it lets the AI independently estimate the probability of an event, dynamically gathers evidence from information sources, compares that evidence against the market's implied odds, and issues trading instructions that combine edge with capital return efficiency.
 
-The same evidence-gathering core also runs in a **market-blind** mode that never reads odds at all — used for the public World Cup forecasting product (see [Market-blind forecasting](#market-blind-forecasting) below).
+The same evidence-gathering core is packaged as a standalone engine ([`packages/forecast-engine`](packages/forecast-engine)) and also runs in a **market-blind** mode that never reads odds at all — used for the public World Cup forecasting product (see [Market-blind forecasting](#market-blind-forecasting) below) and the hosted Forecasting Engine surfaces.
 
 ### Why let an Agent do this
 
@@ -51,9 +56,34 @@ The 2026 World Cup deployment is the public showcase — 87 questions (champion,
 
 - **Statistical prior**: live Elo ratings feed a Davidson three-way model for single matches; tournament questions run 100,000 Monte-Carlo simulations over the official bracket.
 - **Bayesian update**: key evidence (injuries, lineups, form, venue/altitude/weather) is converted into a bounded adjustment on the prior — at most ±8 percentage points per match, and nothing moves without a cited source.
-- **Public scoring**: every forecast is Brier-scored in public after the match settles; wrong calls stay on the record.
+- **Public scoring**: every forecast is Brier-scored in public after the match settles; wrong calls stay on the record. The [track record page](https://forecasting-agent.com/world-cup/performance) benchmarks the blind forecasts *after the fact* against Polymarket's implied probabilities at forecast time — Mock PNL, Brier skill score vs the market, calibration (ECE), and hit rate — for both the group stage and the knockout round of 32.
 
 Market data is used only for event structure and settlement mapping (slug / conditionId / resolution rules); price fields are stripped at cache-write time. Code lives in `scripts/world-cup/`, `packages/sports-data/`, `packages/sports-model/`, and `apps/web/app/world-cup/`. This is probability research, not betting advice.
+
+## Forecasting Engine (hosted)
+
+The evidence-gathering core is packaged as a reusable **iterative event forecaster** in [`packages/forecast-engine`](packages/forecast-engine): given a binary question, it frames the event, runs bounded evidence rounds with cited sources, and produces a traceable probability plus a decision-first report. Correctness guardrails are built in — a framing audit, a model self-estimated prior, independence-aware evidence aggregation (cluster discounting), a mandatory disconfirmation pass, consequential source verification, and an explicit `saturated` status when a probability pins at the engine's floor/ceiling. A market-blind mode (`FORECAST_MARKET_BLIND=1`) bans betting-market prices from prompts, search, and evidence weighting.
+
+Three hosted surfaces run this engine on a cloud VM, all under [forecasting-agent.com](https://forecasting-agent.com):
+
+| Surface | What it is | Code |
+| --- | --- | --- |
+| [`/engine`](https://forecasting-agent.com/engine) | Interactive research console (EN / 中文) — watch a run unfold step by step: plan checklist, evidence cards, verdict dossier | `apps/raven` |
+| [`/delta`](https://forecasting-agent.com/delta) | **Raven Delta** news-impact engine — paste a news item, get an attention verdict (with first-seen timing), 0–5 impacted US stocks with direction / magnitude / confidence, and a trading plan; email + WebSocket push | `apps/raven-delta` |
+| Forecast API + MCP | `POST /v1/forecasts {question}` → probability + reasoning + evidence as JSON, plain text, or a PDF dossier; also exposed as MCP tools (`forecast_start` / `forecast_status` / `forecast_result`) | `services/forecast-api` |
+
+Engine runs are metered: a daily quota plus file-backed invite codes with per-code limits and usage metering.
+
+## Autonomous paper trading (simulation)
+
+A **simulation-only** twin of the trading agent ([`services/paper-agent`](services/paper-agent)) runs a $10k paper book unattended on the same VM — zero private keys, zero order endpoints; its only network surface is public market-data reads:
+
+- **Market-blind evaluations, 3×/day** — each position is re-forecast by an isolated engine process that sees only the market question and settlement rules — never the position, cost basis, or order book.
+- **Net-edge exits + model-free stop-loss** — a position is closed when its fee-adjusted edge turns negative; a hard stop-loss overrides the model. Saturated winners (price pinned at the ceiling on the position's favorable side) are held to resolution instead of ceiling-sold.
+- **Realistic fills** — simulated orders walk the real order book (real slippage) and pay real per-market CLOB fees, with entry fees folded into round PnL; exits use a hybrid 50% market + 50% maker-limit split.
+- **Daily reflection** — the agent writes a daily self-review: counterfactual exit alpha, Brier calibration, and a **Brier skill score vs the market** — the standing answer to "is the agent actually beating the market?".
+
+The book is reviewed publicly at [forecasting-agent.com/live-predict-raven](https://forecasting-agent.com/live-predict-raven) (invite-gated): a live snapshot pulled from the VM at request time, the equity curve, the closed-round table, and the effective run parameters.
 
 ## Quick Start
 
@@ -113,7 +143,7 @@ run the pulse with real money
 
 Expected: the Agent places real orders based on the recommendations from step 3 and tells you which ones filled and which got rejected.
 
-> For concrete pnpm commands, env vars, and archive directories, see [docs/diagrams/dev-reference.md](docs/diagrams/dev-reference.md).
+> For concrete pnpm commands (`forecast:*`; the old `pulse:*` names remain as compatibility aliases), env vars, and archive directories, see [docs/diagrams/dev-reference.md](docs/diagrams/dev-reference.md).
 
 ## Architecture Overview
 
@@ -168,8 +198,7 @@ This is a thin **alias / mapping layer** (`@autopoly/norns`), not a rewrite. Any
 
 Where it applies:
 
-- **Deep Research console** (`apps/web` `/research`): the UI tier selector picks per run; `RESEARCH_DEFAULT_TIER` is the server default; `RESEARCH_API_MODEL` accepts a tier name *or* a raw id; the token budget defaults to the tier's.
-- **Existing engine / provider-runtime**: `CODEX_MODEL` / `CLAUDE_CODE_MODEL` / `OPENCLAW_MODEL` accept a tier name (e.g. `CLAUDE_CODE_MODEL=skuld`), resolved per provider family (codex → openai, claude-code / openclaw → anthropic).
+- **Trading engine / provider-runtime**: `CODEX_MODEL` / `CLAUDE_CODE_MODEL` / `OPENCLAW_MODEL` accept a tier name (e.g. `CLAUDE_CODE_MODEL=skuld`), resolved per provider family (codex → openai, claude-code / openclaw → anthropic).
 
 The tier table is the single source of truth in [`packages/norns/src/index.ts`](packages/norns/src/index.ts); all model ids are env-overridable.
 
@@ -302,6 +331,8 @@ All run artifacts are written to `runtime-artifacts/` (already in `.gitignore`),
 | `live-test/<timestamp>-<runId>/` | Stateful run artifacts (includes `error.json` on failure) |
 | `checkpoints/trial-recommend/` | Paper recommendation resume checkpoints |
 | `world-cup/` | Market-blind forecast archive, event list, Elo / Monte-Carlo backbone |
+| `paper-agent/` | Paper-trading book: ledger, dossiers, daily reflection reports |
+| `raven-delta/runs/` | Raven Delta news-impact analysis archive |
 | `local/paper-state.json` | Default paper state file |
 
 Failure archives (per the AGENTS convention) go to `run-error/` with the failing stage, core context, root-cause summary, and next-step command.

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -10,18 +10,23 @@
 
 > 英文主版见 [README.md](../README.md)。
 
-最后更新：2026-06-12
+最后更新：2026-08-20
 
 ---
 
-**predict-raven** 是一个开源的 **forecasting agent 框架**：让 AI agent 自主评估真实世界事件发生的概率，持续收集并权衡证据，并据此行动。同一套 agent 内核目前驱动两个截然不同的应用：
+**predict-raven** 是一个开源的 **forecasting agent 框架**：让 AI agent 自主评估真实世界事件发生的概率，持续收集并权衡证据，并据此行动。同一套 agent 内核目前驱动一族应用：
 
 - **预测市场自主交易** — [Polymarket](https://polymarket.com) 上第一个自主、持续运行的交易 agent。它评估事件的 fair probability，与市场隐含赔率对比，在服务层硬风控约束下交易其中的 edge。
-- **市场盲测公开预测** — 对 2026 世界杯全部 48 支球队给出透明、用 Brier 公开记分的概率，全程**不读取任何市场价格**。线上：**[forecasting-agent.com](https://forecasting-agent.com/world-cup)**。
+- **市场盲测公开预测** — 对 2026 世界杯全部 48 支球队给出透明、用 Brier 公开记分的概率，全程**不读取任何市场价格**。线上：**[forecasting-agent.com](https://forecasting-agent.com/world-cup)**，并在[预测效果页](https://forecasting-agent.com/world-cup/performance)公开记分。
+- **托管 Forecasting Engine** — 同一套迭代式预测引擎的托管产品形态：交互式研究控制台 [/engine](https://forecasting-agent.com/engine)、Raven Delta 新闻影响引擎 [/delta](https://forecasting-agent.com/delta)，以及 forecast API + MCP 服务（概率 + 分析思路 + 证据，输出 JSON / 纯文字 / PDF）。详见下文 [Forecasting Engine（托管服务）](#forecasting-engine托管服务)。
+- **自主模拟盘交易** — 交易 agent 的纯模拟孪生体，在云端无人值守运行：每日 3 次市场盲测持仓评估、净 edge 退出、每日自省并给出相对市场的 Brier 技巧分。详见下文 [自主模拟盘交易](#自主模拟盘交易纯模拟)。
 
 实盘 / 预测公开：
 
-- **世界杯预测（市场盲测）**：[forecasting-agent.com](https://forecasting-agent.com/world-cup)
+- **世界杯预测（市场盲测）**：[forecasting-agent.com/world-cup](https://forecasting-agent.com/world-cup) · [预测效果](https://forecasting-agent.com/world-cup/performance)
+- **Forecasting Engine 控制台**：[forecasting-agent.com/engine](https://forecasting-agent.com/engine)（浏览公开；发起新预测需邀请码）
+- **Raven Delta 新闻影响引擎**：[forecasting-agent.com/delta](https://forecasting-agent.com/delta)（邀请码门）
+- **模拟盘复盘页**：[forecasting-agent.com/live-predict-raven](https://forecasting-agent.com/live-predict-raven)（邀请码门，实时 VM 快照）
 - **交易决策记录 / 净值曲线**：[autopoly-pizza-spectator.vercel.app](https://autopoly-pizza-spectator.vercel.app)
 - **链上持仓 / 成交（Polymarket profile）**：[`0x6664...614e`](https://polymarket.com/profile/0x6664e32f79aee42639f73633e40b5a842b07614e)
 
@@ -29,7 +34,7 @@
 
 交易侧围绕 **Market Pulse** 这一核心组件设计：让 AI 自主评估事件发生的概率，动态地从信息源收集证据，将其与市场隐含的赔率对比，综合交易的 edge 和资金回报效率给出交易指示。
 
-同一套证据收集内核也能以**市场盲测**模式运行——完全不读取任何赔率，用于公开的世界杯预测产品（见下文 [市场盲测预测](#市场盲测预测)）。
+同一套证据收集内核已抽成独立引擎包（[`packages/forecast-engine`](../packages/forecast-engine)），也能以**市场盲测**模式运行——完全不读取任何赔率，用于公开的世界杯预测产品（见下文 [市场盲测预测](#市场盲测预测)）和托管的 Forecasting Engine 各产品面。
 
 ### 为什么让 Agent 来做这件事
 
@@ -51,9 +56,34 @@
 
 - **统计先验**：实时 Elo 评级进入 Davidson 三路模型算单场；晋级 / 夺冠类问题在官方对阵树上跑 10 万次蒙特卡洛模拟。
 - **贝叶斯更新**：关键证据（伤停、首发、状态、场地 / 海拔 / 天气）折算成对先验的有界修正——单场最多 ±8 个百分点，且没有来源就不动数。
-- **公开记分**：每条预测在比赛结算后用 Brier 公开记分，错了也照样留档。
+- **公开记分**：每条预测在比赛结算后用 Brier 公开记分，错了也照样留档。[预测效果页](https://forecasting-agent.com/world-cup/performance)对盲测预测做*事后*基准评测——以预测时刻的 Polymarket 隐含概率为基线，给出 Mock PNL、相对市场的 Brier 技巧分、校准（ECE）与命中率，覆盖小组赛与淘汰赛 32 强两个阶段。
 
 市场数据仅用于事件结构与结算映射（slug / conditionId / 结算规则）；价格字段在写缓存时就被剥离。代码位于 `scripts/world-cup/`、`packages/sports-data/`、`packages/sports-model/`、`apps/web/app/world-cup/`。这是概率研究，不构成投注建议。
+
+## Forecasting Engine（托管服务）
+
+证据收集内核已打包成可复用的**迭代式事件预测引擎**（[`packages/forecast-engine`](../packages/forecast-engine)）：给定一个二元问题，它先做事件 framing，再跑若干轮带引用来源的证据收集，最终产出可追溯的概率和一份结论先行的报告。正确性护栏内建其中——framing 审计、模型自估先验、考虑独立性的证据聚合（同源簇折扣）、强制反证轮、来源核验直接影响权重，以及概率打到引擎上下限时的显式 `saturated` 状态。市场盲测模式（`FORECAST_MARKET_BLIND=1`）在 prompt、搜索、证据加权三个环节全面禁用博彩市场价格。
+
+三个托管产品面在云端 VM 上运行这套引擎，统一挂在 [forecasting-agent.com](https://forecasting-agent.com) 下：
+
+| 产品面 | 是什么 | 代码 |
+| --- | --- | --- |
+| [`/engine`](https://forecasting-agent.com/engine) | 交互式研究控制台（EN / 中文）——逐步看一次预测如何展开：计划清单、证据卡、判决档案 | `apps/raven` |
+| [`/delta`](https://forecasting-agent.com/delta) | **Raven Delta** 新闻影响引擎——粘贴一条新闻，得到关注度判定（含全网首现时间）、0–5 只受影响美股（方向 / 幅度 / 置信度）和操作计划；邮件 + WebSocket 推送 | `apps/raven-delta` |
+| Forecast API + MCP | `POST /v1/forecasts {question}` → 概率 + 分析思路 + 证据，输出 JSON、纯文字或 PDF 档案；同时以 MCP 工具形态暴露（`forecast_start` / `forecast_status` / `forecast_result`） | `services/forecast-api` |
+
+引擎运行有计量：每日配额 + 文件事件库邀请码（每码可设次数上限并计量用量）。
+
+## 自主模拟盘交易（纯模拟）
+
+交易 agent 的**纯模拟**孪生体（[`services/paper-agent`](../services/paper-agent)）在同一台 VM 上无人值守地跑一个 $10k 模拟盘——零私钥、零下单端点，唯一网络面是公开市场数据的只读请求：
+
+- **市场盲测评估，每日 3 次** — 每个持仓由独立引擎进程重新预测，进程只看到市场问题和结算规则——不知道持仓、成本价、盘口。
+- **净 edge 退出 + 模型无关止损** — 扣费后 edge 转负即平仓；硬止损优先级压过模型。饱和的赢面仓位（价格钉死在持仓有利侧的上限）持有到结算，而不是在天花板上卖出。
+- **拟真成交** — 模拟订单按真实盘口逐档成交（真实滑点），并按逐市场 CLOB 实时费率付费，入场费计入回合盈亏；退出用 50% 市价 + 50% maker 限价的混合执行。
+- **每日反思** — agent 每天写一份自省报告：退出决策的反事实 α、Brier 校准，以及**相对市场的 Brier 技巧分**——持续回答"agent 到底有没有跑赢市场"。
+
+模拟盘在 [forecasting-agent.com/live-predict-raven](https://forecasting-agent.com/live-predict-raven) 公开复盘（邀请码门）：请求时实时拉取 VM 快照、权益曲线、已平仓回合表、生效中的运行参数。
 
 ## 快速开始
 
@@ -113,7 +143,7 @@ OKX Agentic Wallet 模式不需要 `PRIVATE_KEY`，但要先用 `onchainos walle
 
 预期：Agent 会按上一步的推荐真实下单，完成后告诉你成交了哪几笔、哪些被拒。
 
-> 想看具体的 pnpm 命令、环境变量、归档目录，见 [diagrams/dev-reference.md](diagrams/dev-reference.md)。
+> 想看具体的 pnpm 命令（`forecast:*`；旧 `pulse:*` 名保留为兼容别名）、环境变量、归档目录，见 [diagrams/dev-reference.md](diagrams/dev-reference.md)。
 
 ## 架构总览
 
@@ -153,6 +183,24 @@ AGENT_RUNTIME_PROVIDER=codex        # 可选：codex / claude-code / openclaw
 ```
 
 自定义 Agent 通过 `<PROVIDER>_COMMAND` 配置模板命令，示例和占位符见 [.env.example](../.env.example)。
+
+## 能力档位 — Norns（Urd / Verdandi / Skuld）
+
+模型能力按北欧命运三女神命名为三档，"用哪个模型"从散落在各处 env 的裸 model id 变成一个好记的选择：
+
+| 档位 | Norn | 用途 | Anthropic | OpenAI |
+| --- | --- | --- | --- | --- |
+| **Urd** | 过去 / 起源 | 轻快——预筛、高频调用 | `claude-haiku-4-5-20251001` | `gpt-4o-mini` |
+| **Verdandi** | 现在 | 均衡默认档 | `claude-sonnet-4-6` | `gpt-4o` |
+| **Skuld** | 未来 | 旗舰——最深推理、最高质量 | `claude-opus-4-8` | `gpt-4o` |
+
+这是一层轻薄的**别名 / 映射层**（`@autopoly/norns`），不是重写。任何读 model id 的地方都可以改用档位名，按 provider 家族解析成具体模型。**裸 model id 和空默认值原样透传**，所有既有配置行为不变——只有显式使用档位名时才生效。每档还带软深度参数（token 预算、证据/轮次数），驱动方可按档缩放。
+
+适用范围：
+
+- **交易引擎 / provider-runtime**：`CODEX_MODEL` / `CLAUDE_CODE_MODEL` / `OPENCLAW_MODEL` 接受档位名（如 `CLAUDE_CODE_MODEL=skuld`），按 provider 家族解析（codex → openai，claude-code / openclaw → anthropic）。
+
+档位表的单一事实源在 [`packages/norns/src/index.ts`](../packages/norns/src/index.ts)；所有 model id 都可用 env 覆盖。
 
 ## 决策引擎
 
@@ -283,6 +331,8 @@ Agent 每次 preflight 都会打印当前 `ENV_FILE`、钱包地址、collateral
 | `live-test/<timestamp>-<runId>/` | Stateful 运行产物（失败时含 `error.json`） |
 | `checkpoints/trial-recommend/` | Paper 推荐断点续跑检查点 |
 | `world-cup/` | 市场盲测预测归档、事件清单、Elo / 蒙特卡洛骨干 |
+| `paper-agent/` | 模拟盘账本、dossier、每日反思报告 |
+| `raven-delta/runs/` | Raven Delta 新闻影响分析归档 |
 | `local/paper-state.json` | Paper 默认状态文件 |
 
 失败归档（按 AGENTS 约定）写入 `run-error/`，包含失败阶段、核心上下文、原因摘要和下一步命令。


### PR DESCRIPTION
## Summary

README (EN + zh-CN) was last refreshed 2026-06-14; ~140 commits have landed since. This brings both versions up to the current product surface:

- **Intro & watch-live links**: add the four new public surfaces — `/engine` (Raven console), `/delta` (Raven Delta news-impact), `/live-predict-raven` (paper-book review, live VM snapshot), `/world-cup/performance` (track record).
- **New section — Forecasting Engine (hosted)**: iterative event forecaster in `packages/forecast-engine`, correctness guardrails (framing audit, self-estimated prior, cluster discounting, disconfirmation pass, saturated status, market-blind mode), and the three hosted surfaces incl. forecast API + MCP with quota/invite metering.
- **New section — Autonomous paper trading (simulation)**: `services/paper-agent` design (market-blind 3×/day evals, net-edge exits, saturated-hold, real book-walk fills + CLOB fees, daily reflection with Brier skill score) and the public review page.
- **Fixes**: stale Norns bullet pointing at the deleted `/research` console; note `forecast:*` command naming (`pulse:*` kept as aliases); archive table rows for `paper-agent/` and `raven-delta/runs/`; WC section now mentions the after-the-fact market benchmark page.
- **zh-CN**: mirrored 1:1, plus backfilled the Norns section that was missing from the Chinese copy (pre-existing drift).

Docs-only change — no code touched.

## Test plan
- [x] Links/anchors spot-checked (GitHub anchor rules for EN + zh headings)
- [x] Facts cross-checked against git log, agent-handoff, package.json scripts, and repo layout