### PR TITLE
feat(paper-review): 建仓/退出决策拆分、Brier 公平性口径、案例 walk-through、结论自动推导

### DIFF
--- a/apps/web/app/live-predict-raven/page.tsx
+++ b/apps/web/app/live-predict-raven/page.tsx
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 import { PaperReport } from "../../components/live-predict-raven/report";
 import { UnlockGate } from "../../components/live-predict-raven/unlock-gate";
 import { ACCESS_COOKIE_NAME, isValidAccessToken } from "../../lib/live-predict-raven/access";
+import { fetchPaperCases } from "../../lib/live-predict-raven/cases";
 import { fetchLiveSnapshot } from "../../lib/live-predict-raven/live";
 import { PAPER_SNAPSHOT } from "../../lib/live-predict-raven/snapshot";
 
@@ -28,6 +29,9 @@ export default async function LivePredictRavenPage({
   }
   // Live book from the Tokyo VM (refreshed by the agent after every evaluation
   // cycle); the baked snapshot is the labeled fallback when the VM is down.
-  const live = await fetchLiveSnapshot();
-  return <PaperReport snapshot={live ?? PAPER_SNAPSHOT} dataSource={live ? "live" : "baked"} />;
+  // Case walk-throughs are a separate, heavier endpoint: fetched alongside the
+  // snapshot, and simply omitted when unavailable (no baked fallback — a stale
+  // walk-through would misrepresent decisions the agent has since revised).
+  const [live, cases] = await Promise.all([fetchLiveSnapshot(), fetchPaperCases()]);
+  return <PaperReport snapshot={live ?? PAPER_SNAPSHOT} dataSource={live ? "live" : "baked"} cases={cases} />;
 }

--- a/apps/web/components/live-predict-raven/case-chart.tsx
+++ b/apps/web/components/live-predict-raven/case-chart.tsx
@@ -1,0 +1,156 @@
+import type { CaseTimelineEvent, PaperCase } from "../../lib/live-predict-raven/cases";
+import styles from "./report.module.css";
+
+// Belief-vs-price chart for one case: what the engine thought our side was
+// worth (from the dossier's round history) against what the market was paying
+// for it (the bid recorded at each review), with the harness's own actions
+// marked on the time axis.
+//
+// Everything is expressed for the side we HELD, not for YES — "we said 88%,
+// the market paid 22¢" is the comparison the position was taken on. The
+// dossier stores P(YES), so a NO position's curve is mirrored on the way in.
+
+const VIEW_W = 720;
+const VIEW_H = 260;
+const MARGIN = { top: 20, right: 108, bottom: 34, left: 46 };
+const PLOT_W = VIEW_W - MARGIN.left - MARGIN.right;
+const PLOT_H = VIEW_H - MARGIN.top - MARGIN.bottom;
+
+interface Pt {
+  t: number;
+  v: number;
+}
+
+const MARKERS: Record<string, { glyph: string; label: string }> = {
+  buy: { glyph: "▲", label: "买入" },
+  sell: { glyph: "▼", label: "卖出" },
+  stop_loss: { glyph: "✕", label: "止损" },
+  resolution: { glyph: "◆", label: "结算" },
+  screen_enter: { glyph: "◇", label: "选中" }
+};
+
+function toPath(points: readonly Pt[], t0: number, t1: number): string {
+  if (points.length === 0) return "";
+  const span = t1 - t0 || 1;
+  return points
+    .map((p, i) => {
+      const x = MARGIN.left + ((p.t - t0) / span) * PLOT_W;
+      const y = MARGIN.top + (1 - Math.min(1, Math.max(0, p.v))) * PLOT_H;
+      return `${i === 0 ? "M" : "L"}${x.toFixed(1)} ${y.toFixed(1)}`;
+    })
+    .join(" ");
+}
+
+const dayLabel = (ms: number): string => new Date(ms).toISOString().slice(5, 10);
+
+export function CaseChart({ paperCase }: { paperCase: PaperCase }): React.ReactElement | null {
+  const isNo = paperCase.side === "NO";
+  // Dossier probabilities are P(YES); mirror them onto the held side.
+  const belief: Pt[] = (paperCase.dossier?.beliefCurve ?? []).flatMap((p) => {
+    const t = Date.parse(p.ts);
+    return Number.isFinite(t) ? [{ t, v: isNo ? 1 - p.prob : p.prob }] : [];
+  });
+  const price: Pt[] = paperCase.marketCurve.flatMap((p) => {
+    const t = Date.parse(p.ts);
+    return Number.isFinite(t) ? [{ t, v: p.price }] : [];
+  });
+  const markers = paperCase.timeline.flatMap((e: CaseTimelineEvent) => {
+    const marker = MARKERS[e.kind];
+    const t = Date.parse(e.ts);
+    return marker && Number.isFinite(t) ? [{ ...e, t, marker }] : [];
+  });
+
+  const all = [...belief, ...price];
+  if (all.length < 2) return null;
+  const t0 = Math.min(...all.map((p) => p.t));
+  const t1 = Math.max(...all.map((p) => p.t), ...markers.map((m) => m.t));
+  const span = t1 - t0 || 1;
+  const xOf = (t: number): number => MARGIN.left + ((t - t0) / span) * PLOT_W;
+  const yOf = (v: number): number => MARGIN.top + (1 - Math.min(1, Math.max(0, v))) * PLOT_H;
+
+  const lastBelief = belief[belief.length - 1];
+  const lastPrice = price[price.length - 1];
+  const gridlines = [0, 0.25, 0.5, 0.75, 1];
+  const xTicks = [0, 0.25, 0.5, 0.75, 1].map((f) => t0 + f * span);
+
+  return (
+    <div className={styles.chartWrap}>
+      <svg
+        viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+        width="100%"
+        role="img"
+        aria-label={`${paperCase.question}：引擎对我方方向的概率判断与市场报价随时间的对比`}
+      >
+        {gridlines.map((g) => (
+          <g key={g}>
+            <line
+              x1={MARGIN.left}
+              x2={MARGIN.left + PLOT_W}
+              y1={yOf(g)}
+              y2={yOf(g)}
+              stroke="var(--line)"
+              strokeWidth="1"
+            />
+            <text x={MARGIN.left - 8} y={yOf(g) + 4} textAnchor="end" fontSize="11" fill="var(--muted)">
+              {`${g * 100}%`}
+            </text>
+          </g>
+        ))}
+        {xTicks.map((t) => (
+          <text
+            key={t}
+            x={xOf(t)}
+            y={MARGIN.top + PLOT_H + 20}
+            textAnchor="middle"
+            fontSize="11"
+            fill="var(--muted)"
+          >
+            {dayLabel(t)}
+          </text>
+        ))}
+
+        <path d={toPath(price, t0, t1)} fill="none" stroke="var(--muted)" strokeWidth="2" strokeDasharray="5 4" />
+        <path
+          d={toPath(belief, t0, t1)}
+          fill="none"
+          stroke="var(--accent)"
+          strokeWidth="2"
+          strokeLinejoin="round"
+          strokeLinecap="round"
+        />
+
+        {markers.map((m, i) => (
+          <g key={`${m.ts}-${i}`}>
+            <line
+              x1={xOf(m.t)}
+              x2={xOf(m.t)}
+              y1={MARGIN.top}
+              y2={MARGIN.top + PLOT_H}
+              stroke="var(--line-strong)"
+              strokeWidth="1"
+            />
+            <text x={xOf(m.t)} y={MARGIN.top - 6} textAnchor="middle" fontSize="11" fill="var(--muted)">
+              {m.marker.glyph}
+              <title>{`${m.ts.slice(5, 16)} ${m.label}`}</title>
+            </text>
+          </g>
+        ))}
+
+        {lastBelief ? (
+          <text x={MARGIN.left + PLOT_W + 8} y={yOf(lastBelief.v) + 4} fontSize="12" fill="var(--accent)">
+            {`引擎 ${(lastBelief.v * 100).toFixed(0)}%`}
+          </text>
+        ) : null}
+        {lastPrice ? (
+          <text x={MARGIN.left + PLOT_W + 8} y={yOf(lastPrice.v) + 4} fontSize="12" fill="var(--muted)">
+            {`市场 ${(lastPrice.v * 100).toFixed(0)}¢`}
+          </text>
+        ) : null}
+      </svg>
+      <p className={styles.chartLegend}>
+        实线 = 引擎认为「{paperCase.side}」这一边成立的概率（每轮研究后更新）；虚线 = 市场当时愿意为这一边出的价。
+        竖线标记依次是 {markers.map((m) => `${m.marker.glyph} ${m.marker.label}`).filter((v, i, a) => a.indexOf(v) === i).join("、") || "无"}。
+      </p>
+    </div>
+  );
+}

--- a/apps/web/components/live-predict-raven/case-walkthrough.tsx
+++ b/apps/web/components/live-predict-raven/case-walkthrough.tsx
@@ -1,0 +1,267 @@
+import type { CaseRound, PaperCase } from "../../lib/live-predict-raven/cases";
+import { fmtSignedUsd } from "./format";
+import { CaseChart } from "./case-chart";
+import styles from "./report.module.css";
+
+// One case, end to end: the position's economics, the belief-vs-price chart,
+// the research rounds that moved the number (with every source's link), the
+// engine's own closing synthesis, and the harness's decision log.
+//
+// The rounds are the point of this section. Each card answers: what did it go
+// looking for, what did it find, how much did that move the number, and why.
+
+const SOURCE_TYPE_ZH: Record<string, string> = {
+  official: "官方",
+  press: "媒体",
+  insider: "行业/内部",
+  analysis: "分析",
+  social: "社交",
+  aggregator: "聚合",
+  unknown: "未标注"
+};
+
+const CREDIBILITY_ZH: Record<string, string> = { high: "高", medium: "中", low: "低" };
+
+const EXIT_REASON_ZH: Record<string, string> = {
+  stop_loss: "止损",
+  negative_edge: "净边际转负",
+  settled_won: "结算获胜",
+  settled_lost: "结算判负",
+  settled_voided: "市场作废"
+};
+
+const STATUS_ZH: Record<string, string> = {
+  saturated: "饱和（概率打到 1%/99% 钳位）",
+  converged: "收敛",
+  max_rounds: "达到轮次上限",
+  no_new_info: "无新信息",
+  aborted: "中止",
+  resolved: "已结算",
+  open: "进行中"
+};
+
+const hostOf = (url: string): string => {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url.slice(0, 40);
+  }
+};
+
+const pp = (n: number): string => `${n >= 0 ? "+" : "−"}${Math.abs(n).toFixed(1)}pp`;
+
+function RoundCard({ round, side }: { round: CaseRound; side: string }): React.ReactElement {
+  // Dossier probabilities are P(YES); show them from the held side so they line
+  // up with the chart and with the position itself.
+  const flip = side === "NO";
+  const prior = flip ? 1 - round.priorProb : round.priorProb;
+  const post = flip ? 1 - round.postProb : round.postProb;
+  const net = flip ? -round.netPp : round.netPp;
+  return (
+    <li className={styles.roundCard}>
+      <div className={styles.roundHead}>
+        <span className={styles.roundNo}>
+          第 {round.round} 轮
+          {round.anchor === "first" ? "（首轮）" : round.anchor === "last" ? "（最后一轮）" : ""}
+        </span>
+        <span className={styles.roundMove}>
+          {(prior * 100).toFixed(1)}% → {(post * 100).toFixed(1)}%
+          <strong className={net >= 0 ? styles.pos : styles.neg}> {pp(net)}</strong>
+        </span>
+        <span className={styles.roundMeta}>
+          {round.ts.slice(5, 16).replace("T", " ")} UTC · 新增源 {round.newSourceCount} · 置信度 {round.confidence || "—"}
+        </span>
+      </div>
+
+      {round.searchQueries.length > 0 ? (
+        <p className={styles.roundQueries}>
+          <span className={styles.roundLabel}>搜了什么</span>
+          {round.searchQueries.slice(0, 6).map((q, i) => (
+            <code key={`${q}-${i}`} className={styles.queryChip}>
+              {q}
+            </code>
+          ))}
+          {round.searchQueries.length > 6 ? (
+            <span className={styles.rowNote}>…共 {round.searchQueries.length} 条检索</span>
+          ) : null}
+        </p>
+      ) : null}
+
+      {round.sources.length > 0 ? (
+        <ul className={styles.sourceList}>
+          {round.sources.map((s, i) => {
+            const delta = flip ? -s.deltaPp : s.deltaPp;
+            // The same URL can appear twice in one round: once as new evidence
+            // and once as a reflection correcting an earlier reading of it.
+            return (
+              <li key={`${s.url}-${s.kind}-${i}`} className={styles.sourceItem}>
+                <span className={`${styles.sourceDelta} ${delta >= 0 ? styles.pos : styles.neg}`}>{pp(delta)}</span>
+                <span className={styles.sourceBody}>
+                  <a href={s.url} target="_blank" rel="noreferrer noopener" className={styles.sourceLink}>
+                    {s.title || hostOf(s.url)}
+                  </a>
+                  <span className={styles.sourceTags}>
+                    {hostOf(s.url)} · {SOURCE_TYPE_ZH[s.sourceType] ?? s.sourceType} · 可信度{" "}
+                    {CREDIBILITY_ZH[s.credibility] ?? s.credibility}
+                    {s.verified ? " · ✓ 检索链路可核" : " · ⚠ 未在检索结果中出现"}
+                    {s.kind === "reflection" ? " · 对旧证据的修正" : ""}
+                    {s.excluded ? " · ⛔ 市场价格来源，权重归零" : ""}
+                  </span>
+                  {s.explanation ? <span className={styles.sourceWhy}>{s.explanation}</span> : null}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+
+      {round.reasoning ? (
+        <p className={styles.roundReasoning}>
+          <span className={styles.roundLabel}>这一轮的判断</span>
+          {round.reasoning}
+        </p>
+      ) : null}
+    </li>
+  );
+}
+
+export function CaseWalkthrough({ paperCase }: { paperCase: PaperCase }): React.ReactElement {
+  const c = paperCase;
+  const d = c.dossier;
+  const won = (c.pnlUsd ?? 0) >= 0;
+  return (
+    <article className={styles.caseCard}>
+      <header className={styles.caseHead}>
+        <span className={`${styles.caseBadge} ${won ? styles.badgePos : styles.badgeNeg}`}>
+          {c.bucket === "winner" ? `盈利第 ${c.rank}` : `亏损第 ${c.rank}`}
+        </span>
+        <h4 className={styles.caseTitle}>{c.question}</h4>
+        <p className={styles.caseSub}>
+          买 <strong>{c.side}</strong> @ ${c.entryPrice.toFixed(3)} · {c.shares.toFixed(0)} 股 ·{" "}
+          {c.openedUtc.slice(0, 10)} 建仓
+          {c.closedUtc ? ` · ${c.closedUtc.slice(0, 10)} 平仓（${EXIT_REASON_ZH[c.exitReason ?? ""] ?? c.exitReason ?? "—"}）` : " · 仍在持"}
+          {c.entryEdgePp !== null ? ` · 建仓时声称 edge ${c.entryEdgePp.toFixed(1)}pp` : ""}
+        </p>
+      </header>
+
+      <div className={styles.caseTiles}>
+        <div className={styles.caseTile}>
+          <span className={styles.tileLabel}>这笔的盈亏</span>
+          <strong className={`${styles.caseTileValue} ${won ? styles.pos : styles.neg}`}>
+            {fmtSignedUsd(c.pnlUsd ?? 0)}
+          </strong>
+        </div>
+        <div className={styles.caseTile}>
+          <span className={styles.tileLabel}>建仓贡献</span>
+          <strong className={`${styles.caseTileValue} ${(c.entryAlphaUsd ?? 0) >= 0 ? styles.pos : styles.neg}`}>
+            {fmtSignedUsd(c.entryAlphaUsd ?? 0)}
+          </strong>
+          <span className={styles.tileSub}>买了一直拿到{c.benchmarkSource === "settled" ? "结算" : "现在"}会是这个数</span>
+        </div>
+        <div className={styles.caseTile}>
+          <span className={styles.tileLabel}>退出贡献</span>
+          <strong className={`${styles.caseTileValue} ${(c.exitAlphaUsd ?? 0) >= 0 ? styles.pos : styles.neg}`}>
+            {c.status === "open" ? "—" : fmtSignedUsd(c.exitAlphaUsd ?? 0)}
+          </strong>
+          <span className={styles.tileSub}>
+            {c.status === "open" ? "尚未退出" : `卖在 $${(c.exitPrice ?? 0).toFixed(3)}，基准价 $${(c.benchmarkPrice ?? 0).toFixed(3)}`}
+          </span>
+        </div>
+      </div>
+
+      <CaseChart paperCase={c} />
+
+      {d ? (
+        <>
+          <p className={styles.sectionNote}>
+            引擎档案 <code>{d.forecastId}</code>：{d.rounds} 轮研究、{d.evidenceCount} 条证据、状态{" "}
+            {STATUS_ZH[d.status] ?? d.status}
+            {d.provider ? ` · 模型 ${d.provider}` : ""}
+            {d.marketBlind?.enabled
+              ? ` · 市场盲测已开（屏蔽 ${d.marketBlind.blockedCount} 个价格来源${d.marketBlind.priorSuspect ? "，先验疑似受价格锚定" : ""}）`
+              : ""}
+          </p>
+          {d.normalizedQuestion ? (
+            <p className={styles.sectionNote}>
+              <span className={styles.roundLabel}>它实际在预测的问题</span>
+              {d.normalizedQuestion}
+            </p>
+          ) : null}
+
+          <h5 className={styles.caseSubTitle}>关键研究轮次（按对概率的影响挑出）</h5>
+          <ol className={styles.roundList}>
+            {d.keyRounds.map((r) => (
+              <RoundCard key={r.round} round={r} side={c.side} />
+            ))}
+          </ol>
+
+          {d.verdict ? (
+            <details className={styles.details}>
+              <summary>引擎最终的整体判断（原文）</summary>
+              <div className={styles.verdictBox}>
+                {d.whySentence ? <p className={styles.verdictWhy}>{d.whySentence}</p> : null}
+                <p>{d.verdict}</p>
+                {d.keyFactorsYes.length > 0 ? (
+                  <p>
+                    <span className={styles.roundLabel}>支持 YES 的因素</span>
+                    {d.keyFactorsYes.join("；")}
+                  </p>
+                ) : null}
+                {d.keyFactorsNo.length > 0 ? (
+                  <p>
+                    <span className={styles.roundLabel}>支持 NO 的因素</span>
+                    {d.keyFactorsNo.join("；")}
+                  </p>
+                ) : null}
+                {d.mainUncertainties ? (
+                  <p>
+                    <span className={styles.roundLabel}>它自己说不确定的地方</span>
+                    {d.mainUncertainties}
+                  </p>
+                ) : null}
+              </div>
+            </details>
+          ) : null}
+        </>
+      ) : (
+        <p className={styles.sectionNote}>该市场的引擎档案在当前主机上不可读，仅显示交易与复审记录。</p>
+      )}
+
+      <details className={styles.details}>
+        <summary>决策记录（{c.timeline.length} 条：扫描 → 建仓 → 每次复审 → 退出）</summary>
+        <div className={styles.tableWrap}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th scope="col">时间 (UTC)</th>
+                <th scope="col">动作</th>
+                <th scope="col" className={styles.num}>
+                  引擎概率
+                </th>
+                <th scope="col" className={styles.num}>
+                  市场价
+                </th>
+                <th scope="col" className={styles.num}>
+                  净 edge
+                </th>
+                <th scope="col">说明</th>
+              </tr>
+            </thead>
+            <tbody>
+              {c.timeline.map((t, i) => (
+                <tr key={`${t.ts}-${i}`}>
+                  <td>{t.ts.slice(5, 16).replace("T", " ")}</td>
+                  <td>{t.label}</td>
+                  <td className={styles.num}>{t.agentProb === null ? "—" : `${(t.agentProb * 100).toFixed(1)}%`}</td>
+                  <td className={styles.num}>{t.marketPrice === null ? "—" : `$${t.marketPrice.toFixed(3)}`}</td>
+                  <td className={styles.num}>{t.netEdgePp === null ? "—" : `${t.netEdgePp.toFixed(1)}pp`}</td>
+                  <td>{t.detail ?? "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </details>
+    </article>
+  );
+}

--- a/apps/web/components/live-predict-raven/quality-sections.tsx
+++ b/apps/web/components/live-predict-raven/quality-sections.tsx
@@ -1,0 +1,423 @@
+import type { Finding } from "../../lib/live-predict-raven/findings";
+import type { DecisionQuality, PaperSnapshot } from "../../lib/live-predict-raven/snapshot";
+import { fmtSignedUsd, fmtUsd } from "./format";
+import styles from "./report.module.css";
+
+// The three analysis blocks the review page is built around:
+//   DecisionQualitySection  the agent only makes two decisions — what to buy
+//                           and when to sell — so its PnL is split into exactly
+//                           those two contributions, against one shared "what
+//                           if we had just held" benchmark
+//   CalibrationSection      the Brier score plus the context needed to read it
+//                           without over-claiming: horizon, clustering, and the
+//                           unresolved markets it structurally cannot see
+//   FindingsSection         conclusions recomputed from the current snapshot
+
+const BENCHMARK_ZH: Record<string, string> = {
+  settled: "已结算",
+  mark: "最新评估价",
+  live: "实时价",
+  exit: "无基准（按卖出价）"
+};
+
+const REASON_ZH: Record<string, string> = {
+  stop_loss: "止损",
+  negative_edge: "净边际转负",
+  settled_won: "结算获胜",
+  settled_lost: "结算判负",
+  settled_voided: "作废"
+};
+
+/** Proportional bar: two contributions on a shared scale, so the split reads at a glance. */
+function SplitBar({ entryUsd, exitUsd }: { entryUsd: number; exitUsd: number }): React.ReactElement {
+  const scale = Math.max(Math.abs(entryUsd), Math.abs(exitUsd), 1);
+  const row = (label: string, value: number): React.ReactElement => (
+    <div className={styles.splitRow}>
+      <span className={styles.splitLabel}>{label}</span>
+      <span className={styles.splitTrack}>
+        <span
+          className={`${styles.splitFill} ${value >= 0 ? styles.splitPos : styles.splitNeg}`}
+          style={{ width: `${(Math.abs(value) / scale) * 100}%` }}
+        />
+      </span>
+      <span className={`${styles.splitValue} ${value >= 0 ? styles.pos : styles.neg}`}>{fmtSignedUsd(value)}</span>
+    </div>
+  );
+  return (
+    <div className={styles.splitBars}>
+      {row("建仓决定", entryUsd)}
+      {row("退出决定", exitUsd)}
+    </div>
+  );
+}
+
+export function DecisionQualitySection({ dq }: { dq: DecisionQuality }): React.ReactElement {
+  const rows = [...dq.episodes].sort((a, b) => Math.abs(b.pnlUsd ?? 0) - Math.abs(a.pnlUsd ?? 0));
+  const total = dq.entry.totalUsd + dq.exit.totalUsd;
+  return (
+    <section className={styles.section} aria-labelledby="sec-decisions">
+      <h2 id="sec-decisions" className={styles.sectionTitle}>
+        决策质量：建仓 vs 退出
+      </h2>
+      <p className={styles.sectionNote}>
+        这个 agent 一共只做两个决定：<strong>买什么、什么价买</strong>（建仓），和<strong>什么时候卖</strong>（退出）。
+        把每个仓位放在同一把尺子上量——“如果买了就一直拿到结算/现在”，得到的就是建仓贡献；实际卖出比这个基准多赚或少赚的部分，就是退出贡献。
+        两者相加正好等于这笔的真实盈亏，所以不会有第三个说法。
+      </p>
+      <SplitBar entryUsd={dq.entry.totalUsd} exitUsd={dq.exit.totalUsd} />
+      <div className={styles.tiles}>
+        <div className={styles.tile}>
+          <span className={styles.tileLabel}>建仓贡献</span>
+          <strong className={`${styles.tileValue} ${dq.entry.totalUsd >= 0 ? styles.pos : styles.neg}`}>
+            {fmtSignedUsd(dq.entry.totalUsd)}
+          </strong>
+          <span className={styles.tileSub}>
+            在持 {fmtSignedUsd(dq.entry.openUsd)} · 已平 {fmtSignedUsd(dq.entry.closedUsd)}
+          </span>
+        </div>
+        <div className={styles.tile}>
+          <span className={styles.tileLabel}>退出贡献</span>
+          <strong className={`${styles.tileValue} ${dq.exit.totalUsd >= 0 ? styles.pos : styles.neg}`}>
+            {fmtSignedUsd(dq.exit.totalUsd)}
+          </strong>
+          <span className={styles.tileSub}>
+            {dq.exit.scored} 次可评分
+            {dq.exit.unscored > 0 ? ` · ${dq.exit.unscored} 次缺基准价` : ""}
+          </span>
+        </div>
+        <div className={styles.tile}>
+          <span className={styles.tileLabel}>两者相加</span>
+          <strong className={`${styles.tileValue} ${total >= 0 ? styles.pos : styles.neg}`}>
+            {fmtSignedUsd(total)}
+          </strong>
+          <span className={styles.tileSub}>覆盖 {dq.episodes.length} 个仓位周期</span>
+        </div>
+        <div className={styles.tile}>
+          <span className={styles.tileLabel}>账目校验</span>
+          <strong className={styles.tileValue}>
+            {Math.abs(dq.reconciliation.deltaUsd) < 1 ? "一致" : fmtSignedUsd(dq.reconciliation.deltaUsd)}
+          </strong>
+          <span className={styles.tileSub}>
+            已平仓合计 {fmtUsd(dq.reconciliation.closedPnlUsd)} vs 账本已实现{" "}
+            {fmtUsd(dq.reconciliation.realizedPnlUsd)}
+          </span>
+        </div>
+      </div>
+
+      <details className={styles.details} open>
+        <summary>逐仓位拆分（按盈亏绝对值排序）</summary>
+        <div className={styles.tableWrap}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th scope="col">市场</th>
+                <th scope="col">方向 / 状态</th>
+                <th scope="col" className={styles.num}>
+                  建仓价
+                </th>
+                <th scope="col" className={styles.num}>
+                  基准价
+                </th>
+                <th scope="col" className={styles.num}>
+                  建仓贡献
+                </th>
+                <th scope="col" className={styles.num}>
+                  退出贡献
+                </th>
+                <th scope="col" className={styles.num}>
+                  盈亏
+                </th>
+                <th scope="col" className={styles.num}>
+                  建仓时 edge / 研究轮次
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((e) => (
+                <tr key={`${e.positionId}-${e.openedUtc}`}>
+                  <td>
+                    {e.question}
+                    <span className={styles.rowNote}>
+                      {e.openedUtc.slice(0, 10)}
+                      {e.closedUtc ? ` → ${e.closedUtc.slice(0, 10)}` : " → 在持"}
+                      {e.holdDays !== null ? `（${e.holdDays} 天）` : ""}
+                    </span>
+                  </td>
+                  <td>
+                    {e.side}
+                    <span className={styles.rowNote}>
+                      {e.status === "open" ? "在持" : (REASON_ZH[e.exitReason ?? ""] ?? e.exitReason ?? "已平")}
+                    </span>
+                  </td>
+                  <td className={styles.num}>${e.entryPrice.toFixed(3)}</td>
+                  <td className={styles.num}>
+                    {e.benchmarkPrice === null ? "—" : `$${e.benchmarkPrice.toFixed(3)}`}
+                    <span className={styles.rowNote}>{BENCHMARK_ZH[e.benchmarkSource] ?? e.benchmarkSource}</span>
+                  </td>
+                  <td className={`${styles.num} ${(e.entryAlphaUsd ?? 0) >= 0 ? styles.pos : styles.neg}`}>
+                    {e.entryAlphaUsd === null ? "—" : fmtSignedUsd(e.entryAlphaUsd)}
+                  </td>
+                  <td className={`${styles.num} ${(e.exitAlphaUsd ?? 0) >= 0 ? styles.pos : styles.neg}`}>
+                    {e.status === "open" ? "—" : e.exitAlphaUsd === null ? "—" : fmtSignedUsd(e.exitAlphaUsd)}
+                  </td>
+                  <td className={`${styles.num} ${(e.pnlUsd ?? 0) >= 0 ? styles.pos : styles.neg}`}>
+                    {e.pnlUsd === null ? "—" : fmtSignedUsd(e.pnlUsd)}
+                  </td>
+                  <td className={styles.num}>
+                    {e.entryEdgePp === null ? "—" : `${e.entryEdgePp.toFixed(1)}pp`}
+                    <span className={styles.rowNote}>
+                      {e.roundsAtEntry === null ? "轮次未记录" : `${e.roundsAtEntry} 轮 / ${e.evidenceAtEntry ?? "—"} 源`}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </details>
+      <p className={styles.sectionNote}>
+        基准价含义：已结算市场用结算值（$1 / $0 / $0.50），未结算的用最近一次观察到的价格。
+        {dq.benchmarkAsOfUtc ? `已平仓位的基准价取自 ${dq.benchmarkAsOfUtc.slice(0, 10)} 的反思报告。` : ""}
+      </p>
+    </section>
+  );
+}
+
+function skillText(skill: number | null): string {
+  return skill === null ? "—" : skill.toFixed(2);
+}
+
+export function CalibrationSection({ snapshot }: { snapshot: PaperSnapshot }): React.ReactElement {
+  const b = snapshot.brier;
+  const horizon = b.horizon;
+  const clusters = b.clusters;
+  const pending = b.pending;
+  const pendingUnrealized = pending.reduce((s, r) => s + (r.unrealizedUsd ?? 0), 0);
+  return (
+    <>
+      <h3 className={styles.subTitle}>
+        校准（Brier）：技巧分 {b.skillScore.toFixed(2)}，n={b.n}
+        {clusters ? `（来自 ${clusters.effectiveN} 个独立事件）` : ""}
+      </h3>
+      <p className={styles.sectionNote}>
+        技巧分 = 1 − Brier<sub>agent</sub> / Brier<sub>市场</sub>，&gt;0 才算跑赢市场。当前 agent{" "}
+        {b.agentScore.toFixed(3)} vs 市场 {b.marketScore.toFixed(3)}。
+        <strong>这个数字有三个结构性的不公平，下面逐个拆开看。</strong>
+      </p>
+
+      <div className={styles.fairGrid}>
+        <div className={styles.fairCard}>
+          <h4 className={styles.fairTitle}>① 只算已结算的，赚钱的还没结算</h4>
+          <p>
+            Brier 只能给已经出结果的市场打分。目前还有 <strong>{pending.length}</strong> 个已评估但未结算的市场不在样本里，
+            其中在持仓的浮动盈亏合计 <strong className={pendingUnrealized >= 0 ? styles.pos : styles.neg}>
+              {fmtSignedUsd(pendingUnrealized)}
+            </strong>
+            。长周期、赢面大的判断天然结算得晚，所以短期内 Brier 会系统性偏向“只看到了亏的那批”。
+            这部分表现体现在上面的<strong>建仓贡献</strong>里，不在这个分数里。
+          </p>
+        </div>
+        {horizon?.atEntry && horizon.atLast ? (
+          <div className={styles.fairCard}>
+            <h4 className={styles.fairTitle}>② 打分打在最容易的那一刻</h4>
+            <p>
+              头部那个数字用的是<strong>结算前最后一次</strong>判断——离揭晓最近、也最容易。换成
+              <strong>第一次</strong>判断（真正提前量，中位 {(horizon.atEntry.medianHorizonDays ?? 0).toFixed(1)} 天）：
+              技巧分 <strong>{skillText(horizon.atEntry.skill)}</strong>；最后一次（中位{" "}
+              {(horizon.atLast.medianHorizonDays ?? 0).toFixed(1)} 天）：{skillText(horizon.atLast.skill)}。
+              临近结算时市场报价会非常锐利，而引擎概率被 1%/99% 钳住，差距被放大。
+            </p>
+          </div>
+        ) : null}
+        {clusters ? (
+          <div className={styles.fairCard}>
+            <h4 className={styles.fairTitle}>③ n={b.n} 不是 {b.n} 个独立样本</h4>
+            <p>
+              同一个故事的不同到期日（停火 7/31、8/15…）会被算成多条，但它们赌的是同一件事。按 Polymarket 事件归并后，
+              真正独立的样本只有 <strong>{clusters.effectiveN}</strong> 个。样本这么少时，技巧分的波动本来就很大，
+              单个极端样本能主导整个数字。
+            </p>
+          </div>
+        ) : null}
+      </div>
+
+      {horizon && horizon.buckets.length > 0 ? (
+        <>
+          <h4 className={styles.subTitle}>按提前量分开看</h4>
+          <p className={styles.sectionNote}>
+            每个市场在每个跨度里只取一次判断，避免被复审次数多的市场刷屏。
+            {horizon.weighted?.skill !== null && horizon.weighted !== null
+              ? ` 若按「难度随天数^${horizon.weighted.exponent} 增长」给长跨度更高权重，整体技巧分为 ${skillText(
+                  horizon.weighted.skill
+                )}（对比不加权的 ${skillText(horizon.atEntry?.skill ?? null)}）。`
+              : ""}
+          </p>
+          <div className={styles.tableWrap}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th scope="col">提前量</th>
+                  <th scope="col" className={styles.num}>
+                    样本
+                  </th>
+                  <th scope="col" className={styles.num}>
+                    agent Brier
+                  </th>
+                  <th scope="col" className={styles.num}>
+                    市场 Brier
+                  </th>
+                  <th scope="col" className={styles.num}>
+                    技巧分
+                  </th>
+                  <th scope="col">读法</th>
+                </tr>
+              </thead>
+              <tbody>
+                {horizon.buckets.map((bucket) => (
+                  <tr key={bucket.label}>
+                    <td>{bucket.label}</td>
+                    <td className={styles.num}>{bucket.n}</td>
+                    <td className={styles.num}>{bucket.brierAgent?.toFixed(3) ?? "—"}</td>
+                    <td className={styles.num}>{bucket.brierMarket?.toFixed(3) ?? "—"}</td>
+                    <td className={`${styles.num} ${(bucket.skill ?? 0) >= 0 ? styles.pos : styles.neg}`}>
+                      {skillText(bucket.skill)}
+                    </td>
+                    <td>
+                      {(bucket.skill ?? -1) > 0
+                        ? "这个跨度上跑赢了市场"
+                        : (bucket.brierMarket ?? 1) < 0.06
+                          ? "市场几乎已经确定，agent 的钳位概率无法跟上"
+                          : "落后于市场"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      ) : null}
+
+      {pending.length > 0 ? (
+        <details className={styles.details}>
+          <summary>还没结算的 {pending.length} 个判断（不进 Brier，仅供核对）</summary>
+          <div className={styles.tableWrap}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th scope="col">市场</th>
+                  <th scope="col">方向</th>
+                  <th scope="col" className={styles.num}>
+                    引擎概率
+                  </th>
+                  <th scope="col" className={styles.num}>
+                    市场价
+                  </th>
+                  <th scope="col" className={styles.num}>
+                    距结算
+                  </th>
+                  <th scope="col" className={styles.num}>
+                    浮动盈亏
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {pending.map((r, i) => (
+                  <tr key={`${r.slug}-${r.side ?? ""}-${i}`}>
+                    <td>{r.question}</td>
+                    <td>{r.side ?? "未持仓"}</td>
+                    <td className={styles.num}>{(r.agentProb * 100).toFixed(1)}%</td>
+                    <td className={styles.num}>${r.marketProb.toFixed(3)}</td>
+                    <td className={styles.num}>{r.horizonDays === null ? "—" : `${r.horizonDays.toFixed(0)} 天`}</td>
+                    <td
+                      className={`${styles.num} ${(r.unrealizedUsd ?? 0) >= 0 ? styles.pos : styles.neg}`}
+                    >
+                      {r.unrealizedUsd === null ? "—" : fmtSignedUsd(r.unrealizedUsd)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </details>
+      ) : null}
+
+      {clusters && clusters.rows.length > 0 ? (
+        <details className={styles.details}>
+          <summary>按事件归并后的 {clusters.effectiveN} 个独立样本</summary>
+          <div className={styles.tableWrap}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th scope="col">事件</th>
+                  <th scope="col" className={styles.num}>
+                    含市场数
+                  </th>
+                  <th scope="col" className={styles.num}>
+                    技巧分
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {clusters.rows.map((c) => (
+                  <tr key={c.eventSlug}>
+                    <td>{c.label}</td>
+                    <td className={styles.num}>{c.n}</td>
+                    <td className={`${styles.num} ${(c.skill ?? 0) >= 0 ? styles.pos : styles.neg}`}>
+                      {skillText(c.skill)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </details>
+      ) : null}
+    </>
+  );
+}
+
+const KIND_LABEL: Record<Finding["kind"], string> = {
+  headline: "总览",
+  strength: "做对的",
+  risk: "风险",
+  proposal: "待你拍板"
+};
+
+export function FindingsSection({
+  findings,
+  asOfUtc
+}: {
+  findings: readonly Finding[];
+  asOfUtc: string;
+}): React.ReactElement {
+  return (
+    <section className={styles.section} aria-labelledby="sec-verdict">
+      <h2 id="sec-verdict" className={styles.sectionTitle}>
+        结论与建议（数据截至 {asOfUtc.slice(0, 10)}，随每次评估周期自动重算）
+      </h2>
+      <p className={styles.sectionNote}>
+        下面每一条都是从当前这份账本算出来的，不是某次人工复盘留下的旧结论。标注「待你拍板」的是风控参数改动——
+        agent 不会自己改，需要你确认后写入配置。
+      </p>
+      <ul className={styles.findingList}>
+        {findings.map((f) => (
+          <li key={f.id} className={`${styles.findingCard} ${styles[`finding_${f.kind}`] ?? ""}`}>
+            <span className={styles.findingKind}>{KIND_LABEL[f.kind]}</span>
+            <h3 className={styles.findingTitle}>{f.title}</h3>
+            <p className={styles.findingBody}>{f.body}</p>
+            {f.metrics.length > 0 ? (
+              <ul className={styles.metricChips}>
+                {f.metrics.map((m) => (
+                  <li key={`${f.id}-${m.label}`} className={styles.metricChip}>
+                    <span className={styles.metricLabel}>{m.label}</span>
+                    <span className={styles.metricValue}>{m.value}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/components/live-predict-raven/report.module.css
+++ b/apps/web/components/live-predict-raven/report.module.css
@@ -224,3 +224,393 @@
     font-size: 22px;
   }
 }
+
+/* ---- Decision-quality split bars ---------------------------------------- */
+
+.splitBars {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 14px 0 18px;
+}
+
+.splitRow {
+  display: grid;
+  grid-template-columns: 92px 1fr 108px;
+  align-items: center;
+  gap: 12px;
+}
+
+.splitLabel {
+  font-size: 14.5px;
+  color: var(--muted);
+}
+
+.splitTrack {
+  height: 14px;
+  background: var(--panel-strong);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.splitFill {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+}
+
+.splitPos {
+  background: var(--positive);
+}
+
+.splitNeg {
+  background: var(--negative);
+}
+
+.splitValue {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-weight: 650;
+}
+
+/* ---- Calibration fairness cards ----------------------------------------- */
+
+.fairGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
+  margin: 14px 0 8px;
+}
+
+.fairCard {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 14px 16px;
+}
+
+.fairCard p {
+  margin: 6px 0 0;
+  font-size: 15px;
+}
+
+.fairTitle {
+  font-size: 16px;
+  margin: 0;
+}
+
+/* ---- Case walk-throughs -------------------------------------------------- */
+
+.caseCard {
+  background: var(--panel);
+  border: 1px solid var(--line-strong);
+  border-radius: 16px;
+  padding: 20px 20px 16px;
+  margin-top: 20px;
+}
+
+.caseHead {
+  margin-bottom: 12px;
+}
+
+.caseBadge {
+  display: inline-block;
+  font-size: 12.5px;
+  letter-spacing: 0.08em;
+  border-radius: 999px;
+  padding: 3px 12px;
+  margin-bottom: 8px;
+  border: 1px solid var(--line-strong);
+}
+
+.badgePos {
+  color: var(--positive);
+  border-color: var(--positive);
+}
+
+.badgeNeg {
+  color: var(--negative);
+  border-color: var(--negative);
+}
+
+.caseTitle {
+  font-family: var(--font-display);
+  font-size: 21px;
+  margin: 0 0 4px;
+}
+
+.caseSub {
+  color: var(--muted);
+  font-size: 14.5px;
+  margin: 0;
+}
+
+.caseSubTitle {
+  font-size: 17px;
+  margin: 20px 0 8px;
+}
+
+.caseTiles {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.caseTile {
+  background: var(--panel-strong);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.caseTileValue {
+  font-size: 21px;
+  font-weight: 650;
+  line-height: 1.2;
+}
+
+.chartLegend {
+  color: var(--muted);
+  font-size: 13.5px;
+  margin: 6px 4px 2px;
+}
+
+.roundList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.roundCard {
+  background: var(--panel-strong);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--accent-line);
+  border-radius: 12px;
+  padding: 14px 16px;
+}
+
+.roundHead {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px 14px;
+  margin-bottom: 8px;
+}
+
+.roundNo {
+  font-weight: 650;
+}
+
+.roundMove {
+  font-variant-numeric: tabular-nums;
+}
+
+.roundMeta {
+  color: var(--muted);
+  font-size: 13.5px;
+}
+
+.roundLabel {
+  display: inline-block;
+  font-size: 12.5px;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  background: var(--accent-soft);
+  border-radius: 6px;
+  padding: 1px 8px;
+  margin-right: 8px;
+}
+
+.roundQueries {
+  margin: 0 0 10px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.queryChip {
+  font-size: 13px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 2px 8px;
+  color: var(--muted);
+}
+
+.sourceList {
+  list-style: none;
+  margin: 0 0 10px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.sourceItem {
+  display: grid;
+  grid-template-columns: 66px 1fr;
+  gap: 10px;
+  align-items: start;
+}
+
+.sourceDelta {
+  font-variant-numeric: tabular-nums;
+  font-weight: 650;
+  font-size: 14.5px;
+  text-align: right;
+  padding-top: 1px;
+}
+
+.sourceBody {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.sourceLink {
+  color: var(--accent);
+  font-size: 15px;
+  overflow-wrap: anywhere;
+}
+
+.sourceTags {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.sourceWhy {
+  font-size: 14.5px;
+}
+
+.roundReasoning {
+  margin: 8px 0 0;
+  font-size: 15px;
+}
+
+.verdictBox {
+  background: var(--panel-strong);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 14px 16px;
+  margin-top: 8px;
+  font-size: 15px;
+}
+
+.verdictWhy {
+  font-weight: 650;
+}
+
+/* ---- Derived findings ---------------------------------------------------- */
+
+.findingList {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.findingCard {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--line-strong);
+  border-radius: 12px;
+  padding: 14px 18px;
+}
+
+.finding_headline {
+  border-left-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.finding_strength {
+  border-left-color: var(--positive);
+}
+
+.finding_risk {
+  border-left-color: var(--negative);
+}
+
+.finding_proposal {
+  border-left-color: var(--accent);
+  border-style: dashed;
+}
+
+.findingKind {
+  display: inline-block;
+  font-size: 12.5px;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  margin-bottom: 4px;
+}
+
+.findingTitle {
+  font-size: 17.5px;
+  margin: 0 0 6px;
+}
+
+.findingBody {
+  margin: 0;
+  font-size: 15.5px;
+}
+
+.metricChips {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 10px 0 0;
+  padding: 0;
+}
+
+.metricChip {
+  display: flex;
+  flex-direction: column;
+  background: var(--panel-strong);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 4px 10px;
+  max-width: 100%;
+}
+
+.metricLabel {
+  font-size: 12px;
+  color: var(--muted);
+  overflow-wrap: anywhere;
+}
+
+.metricValue {
+  font-size: 14.5px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+@media (max-width: 860px) {
+  .caseTiles {
+    grid-template-columns: 1fr;
+  }
+
+  .splitRow {
+    grid-template-columns: 76px 1fr 92px;
+    gap: 8px;
+  }
+
+  .sourceItem {
+    grid-template-columns: 56px 1fr;
+  }
+
+  .caseCard {
+    padding: 16px 14px 12px;
+  }
+}

--- a/apps/web/components/live-predict-raven/report.tsx
+++ b/apps/web/components/live-predict-raven/report.tsx
@@ -1,6 +1,10 @@
+import type { PaperCases } from "../../lib/live-predict-raven/cases";
+import { deriveFindings } from "../../lib/live-predict-raven/findings";
 import type { PaperSnapshot } from "../../lib/live-predict-raven/snapshot";
 import { deriveReportStats } from "../../lib/live-predict-raven/stats";
+import { CaseWalkthrough } from "./case-walkthrough";
 import { EquityChart } from "./equity-chart";
+import { CalibrationSection, DecisionQualitySection, FindingsSection } from "./quality-sections";
 import { fmtSignedPct, fmtSignedUsd, fmtUsd } from "./format";
 import {
   BrierTable,
@@ -26,12 +30,16 @@ const fmtUtcMinute = (iso: string): string => (iso.length >= 16 ? `${iso.slice(0
 
 export function PaperReport({
   snapshot,
-  dataSource
+  dataSource,
+  cases
 }: {
   snapshot: PaperSnapshot;
   dataSource: "live" | "baked";
+  /** Case walk-throughs from the VM; omitted when that endpoint is unavailable. */
+  cases?: PaperCases | null;
 }) {
   const s = snapshot;
+  const findings = deriveFindings(s);
   const { trade, equity, openBook } = deriveReportStats(s);
   const rawDays = Math.round((Date.parse(s.lastEvalCycleUtc) - Date.parse(s.startedUtc)) / 86_400_000);
   const runDaysLabel = Number.isFinite(rawDays) ? `${Math.max(1, rawDays)} 天` : "—";
@@ -129,9 +137,8 @@ export function PaperReport({
           <EquityChart curve={s.equityCurve} bankrollUsd={s.bankrollUsd} />
         </div>
         <p className={styles.sectionNote}>
-          复盘注（2026-08-05）：两段行情。7/14 冲到峰值 +8.0%（$10,799）后靠浮盈横盘到
-          7/24；7/25 起连续下台阶——11 天里 10 次止损，几乎全是以伊停火题材，8/4 跌到
-          $8,112，自峰值最大回撤 −26%。
+          峰值 {fmtUsd(equity.peakUsd)}（{equity.peakDate}），自峰值最大回撤 {fmtSignedPct(equity.maxDrawdownPct)}，
+          当前 {fmtUsd(equity.currentUsd)}（{fmtSignedPct(equity.returnPct)}）。每个点是当日反思报告的收盘权益，最后一点是最近一次评估。
         </p>
         <details className={styles.details}>
           <summary>查看逐日数值表</summary>
@@ -145,11 +152,9 @@ export function PaperReport({
         </h2>
         <ClosedTradesTable trades={s.closedTrades} />
         <p className={styles.callout}>
-          复盘注（2026-08-05）：7/24 时"4 胜 2 负"的结构已被 7/26–8/4 的止损串彻底改写——新增 11
-          回合里 10 次止损。7/24 复盘提出的"止损后同市场冷却期"未落地，同样的错误以更大规模重演："以伊停火延续至
-          7/31"同一市场三进三止损（合计 −$601），"美伊 7/31 有效停火"二进二止损（−$400）。最贵的一笔是英伟达：0.22 买
-          YES 一天后止损，市场最终以 YES 结算（反事实 α −$1,838）。唯一亮点：霍尔木兹 7/31 被 saturated-hold
-          护着持有到临近结算，+$170 落袋。
+          {trade.wins} 笔盈利平均 {fmtUsd(trade.avgWinUsd)}，{trade.losses} 笔亏损平均 {fmtUsd(trade.avgLossUsd)}，
+          已实现合计 {fmtSignedUsd(trade.realizedPnlUsd)}。每一笔"卖得对不对"的评价见下面的
+          <strong>决策质量</strong>一节——那里把同一笔拆成建仓和退出两部分。
         </p>
       </section>
 
@@ -164,39 +169,46 @@ export function PaperReport({
           mark，随每次评估周期更新。
         </p>
         <p className={styles.callout}>
-          复盘注（2026-08-05）风险集中：满仓 10/10，全是地缘政治 NO，其中五仓共享"伊朗局势"单一驱动（霍尔木兹
-          ×2 + 核协议 + 入侵伊朗 + 解除封锁）——正是这个题材在 7 月末打穿了已平仓账。亮点仍是霍尔木兹
-          12/31：市场定价 72% 会恢复通航时逆势买 NO @ 0.28，现价 0.38（+$179），是唯一在赢的真正逆市场立场（未结算）。8/4
-          新开的"解除封锁"仓一天浮亏 −$116，是当前最大的红仓。
+          仓位占用 {s.openPositions.length} / {s.config.maxPositions}，现金占总权益 {openBook.cashSharePct.toFixed(1)}%。
+          这些仓位都还没结算，因此不进入下面的 Brier 校准——它们的表现只体现在<strong>建仓贡献</strong>里。
+          题材集中度与方向一致性见页尾「结论与建议」。
         </p>
       </section>
+
+      {s.decisionQuality ? <DecisionQualitySection dq={s.decisionQuality} /> : null}
+
+      {cases && (cases.winners.length > 0 || cases.losers.length > 0) ? (
+        <section className={styles.section} aria-labelledby="sec-cases">
+          <h2 id="sec-cases" className={styles.sectionTitle}>
+            四个案例：它当时到底看到了什么
+          </h2>
+          <p className={styles.sectionNote}>
+            盈利最大和亏损最大的各两笔。每一笔都摊开：引擎每一轮搜了什么、找到哪条源、那条源把概率推了多少、
+            它当时怎么想的，以及 harness 在同一时间轴上做了什么。所有链接都是引擎当时真正引用的原文。
+          </p>
+          {[...cases.winners, ...cases.losers].map((c) => (
+            <CaseWalkthrough key={`${c.positionId}-${c.openedUtc}`} paperCase={c} />
+          ))}
+        </section>
+      ) : null}
 
       <section className={styles.section} aria-labelledby="sec-quality">
         <h2 id="sec-quality" className={styles.sectionTitle}>
           预测与执行质量
         </h2>
 
-        <h3 className={styles.subTitle}>退出质量：α 合计 {fmtSignedUsd(s.exitAlpha.totalUsd)}</h3>
+        <h3 className={styles.subTitle}>退出明细：逐次退出 vs 不卖的对照</h3>
         <p className={styles.sectionNote}>
-          α = 卖出所得 −（若持有到现在/结算的价值），正数 = 卖对了。
-          {s.exitAlpha.totalUsd >= 0
-            ? "合计为正：退出决策整体加分。"
-            : "合计为负：退出决策整体在减分。"}{" "}
-          复盘注（2026-08-05）：合计从 7/24 的 +$1,077 转负——英伟达（止损后市场以 YES 结算，−$1,838）与哈马斯（止损后
-          NO 价反弹近 4 倍，−$869）两笔反事实巨亏，压过了停火系列止损救回的约 +$1,400。
+          α = 卖出所得 −（若持有到现在/结算的价值），正数 = 卖对了。合计与上面「决策质量」一节的退出贡献同源，
+          这里按每次退出的方式（市价 / 限价 / 混合）展开。
         </p>
         <ExitAlphaTable rows={s.exitAlpha.rows} />
 
-        <h3 className={styles.subTitle}>
-          校准（Brier）：skill score {s.brier.skillScore.toFixed(2)}，n={s.brier.n}
-        </h3>
-        <p className={styles.sectionNote}>
-          skill score = 1 − Brier_agent / Brier_market，&gt;0 才算跑赢市场。当前为负（agent {s.brier.agentScore.toFixed(3)} vs 市场{" "}
-          {s.brier.marketScore.toFixed(3)}，n={s.brier.n}）。复盘注（2026-08-05）：7/31
-          结算潮后样本首次够量，初步结论是 agent 落后于市场——大额失分集中在以伊停火系列（对"停火延续"的方向判断与结果相反）与"停止对伊军事行动"（agent
-          15% vs 市场 94%，事件发生）。
-        </p>
-        <BrierTable rows={s.brier.rows} />
+        <CalibrationSection snapshot={s} />
+        <details className={styles.details}>
+          <summary>逐条已结算判断（{s.brier.rows.length} 条）</summary>
+          <BrierTable rows={s.brier.rows} />
+        </details>
 
         <h3 className={styles.subTitle}>引擎与执行</h3>
         <ul className={styles.list}>
@@ -235,35 +247,7 @@ export function PaperReport({
         <ParamsTable config={s.config} />
       </section>
 
-      <section className={styles.section} aria-labelledby="sec-verdict">
-        <h2 id="sec-verdict" className={styles.sectionTitle}>
-          结论与建议（2026-08-05 复盘）
-        </h2>
-        <ul className={styles.list}>
-          <li>
-            <strong>亏损构成：</strong>−20% ≈ 已实现 −$2,114（12 个负回合、其中 10
-            次止损）+ 浮盈 +$134 的微弱缓冲。7 月上旬收权利金攒下的 +8%
-            浮盈，在 7/25 后的止损串里全部回吐并转亏。
-          </li>
-          <li>
-            <strong>与基准：</strong>Brier skill −0.53（n=12）——首批足量样本显示独立判断整体落后市场。7/24
-            时"贴市场小修正稳定小赚"的通道，在短到期、高波动的停火系列上失效：agent 反复给出与市场大幅背离的方向判断，结果站在错的一边。
-          </li>
-          <li>
-            <strong>建议 ①（7/24 已提、仍未落地，代价已现）：</strong>止损后对同市场/同事件加冷却期。以伊停火 7/31
-            三进三止损（−$601）、美伊停火二进二止损（−$400）、哈马斯止损后 24 小时内重进（现持仓中）——全部是这一个缺口。
-          </li>
-          <li>
-            <strong>建议 ②：</strong>题材级相关性敞口上限。事件级 maxPerEvent=1 没挡住停火/封锁/军事行动这组强相关市场同向暴露，7
-            月末一个题材打穿整本账；当前在持 10 仓里仍有 5 仓共享伊朗驱动。
-          </li>
-          <li>
-            <strong>建议 ③：</strong>止损规则与低价单适配。−35% 价格止损对 0.1–0.3
-            区间的单子过于敏感（波动天然大），英伟达止损后市场以 YES 结算（α
-            −$1,838）；考虑按剩余净 edge 退出而非纯价格回撤，或对低价单缩小仓位而不是收紧止损。
-          </li>
-        </ul>
-      </section>
+      <FindingsSection findings={findings} asOfUtc={s.lastEvalCycleUtc} />
 
       <footer className={styles.footer}>
         <p>

--- a/apps/web/lib/live-predict-raven/cases.ts
+++ b/apps/web/lib/live-predict-raven/cases.ts
@@ -1,0 +1,299 @@
+// Case walk-throughs for /live-predict-raven: the VM's /paper/cases endpoint,
+// which pairs the book's biggest winners and losers with the engine dossier
+// behind them (research rounds, sources, the final synthesis) and the decision
+// timeline the harness recorded.
+//
+// Same failure policy as live.ts: any failure returns null and the page simply
+// omits the section — there is no baked fallback for case data, because a
+// stale walk-through would misrepresent decisions the agent has since revised.
+
+import { zhQuestion } from "./labels";
+
+const DEFAULT_UPSTREAM = "http://34.85.97.32:8787";
+const FETCH_TIMEOUT_MS = 8000;
+const SUCCESS_TTL_MS = 60_000;
+const FAILURE_BACKOFF_MS = 60_000;
+
+export interface CaseSource {
+  url: string;
+  title: string;
+  deltaPp: number;
+  explanation: string;
+  verified: boolean;
+  kind: string;
+  sourceType: string;
+  credibility: string;
+  excluded: string | null;
+}
+
+export interface CaseRound {
+  round: number;
+  ts: string;
+  priorProb: number;
+  postProb: number;
+  netPp: number;
+  dominantTitle: string | null;
+  dominantUrl: string | null;
+  newSourceCount: number;
+  confidence: string;
+  reasoning: string;
+  searchQueries: readonly string[];
+  sources: readonly CaseSource[];
+  anchor: "first" | "last" | null;
+}
+
+export interface CaseTimelineEvent {
+  ts: string;
+  kind: string;
+  label: string;
+  detail: string | null;
+  agentProb: number | null;
+  marketPrice: number | null;
+  netEdgePp: number | null;
+}
+
+export interface CaseDossier {
+  forecastId: string;
+  normalizedQuestion: string | null;
+  resolutionCriteria: string | null;
+  rounds: number;
+  evidenceCount: number;
+  status: string;
+  saturatedAt: string | null;
+  marketBlind: { enabled: boolean; blockedCount: number; priorSuspect: boolean } | null;
+  provider: string | null;
+  verdict: string | null;
+  whySentence: string | null;
+  keyFactorsYes: readonly string[];
+  keyFactorsNo: readonly string[];
+  mainUncertainties: string | null;
+  beliefCurve: ReadonlyArray<{ round: number; ts: string; prob: number }>;
+  keyRounds: readonly CaseRound[];
+}
+
+export interface PaperCase {
+  rank: number;
+  bucket: "winner" | "loser";
+  positionId: string;
+  slug: string;
+  question: string;
+  side: string;
+  status: "open" | "closed";
+  openedUtc: string;
+  closedUtc: string | null;
+  pnlUsd: number | null;
+  entryAlphaUsd: number | null;
+  exitAlphaUsd: number | null;
+  entryPrice: number;
+  exitPrice: number | null;
+  benchmarkPrice: number | null;
+  benchmarkSource: string;
+  shares: number;
+  entryEdgePp: number | null;
+  exitReason: string | null;
+  dossier: CaseDossier | null;
+  timeline: readonly CaseTimelineEvent[];
+  marketCurve: ReadonlyArray<{ ts: string; price: number; agentProb: number | null }>;
+}
+
+export interface PaperCases {
+  generatedAtUtc: string;
+  winners: readonly PaperCase[];
+  losers: readonly PaperCase[];
+}
+
+type Rec = Record<string, unknown>;
+const isRec = (v: unknown): v is Rec => typeof v === "object" && v !== null && !Array.isArray(v);
+const num = (v: unknown): number | null => (typeof v === "number" && Number.isFinite(v) ? v : null);
+const str = (v: unknown): string => (typeof v === "string" ? v : "");
+const strList = (v: unknown, max: number): string[] =>
+  Array.isArray(v) ? v.filter((x): x is string => typeof x === "string").slice(0, max) : [];
+
+function parseSources(raw: unknown): CaseSource[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((s) => {
+    if (!isRec(s)) return [];
+    const url = str(s.url);
+    if (!url) return [];
+    return [
+      {
+        url,
+        title: str(s.title),
+        deltaPp: num(s.deltaPp) ?? 0,
+        explanation: str(s.explanation),
+        verified: s.verified === true,
+        kind: str(s.kind),
+        sourceType: str(s.sourceType),
+        credibility: str(s.credibility),
+        excluded: typeof s.excluded === "string" ? s.excluded : null
+      }
+    ];
+  });
+}
+
+function parseRounds(raw: unknown): CaseRound[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((r) => {
+    if (!isRec(r)) return [];
+    const round = num(r.round);
+    if (round === null) return [];
+    return [
+      {
+        round,
+        ts: str(r.ts),
+        priorProb: num(r.priorProb) ?? 0,
+        postProb: num(r.postProb) ?? 0,
+        netPp: num(r.netPp) ?? 0,
+        dominantTitle: typeof r.dominantTitle === "string" ? r.dominantTitle : null,
+        dominantUrl: typeof r.dominantUrl === "string" ? r.dominantUrl : null,
+        newSourceCount: num(r.newSourceCount) ?? 0,
+        confidence: str(r.confidence),
+        reasoning: str(r.reasoning),
+        searchQueries: strList(r.searchQueries, 12),
+        sources: parseSources(r.sources),
+        anchor: r.anchor === "first" || r.anchor === "last" ? r.anchor : null
+      }
+    ];
+  });
+}
+
+function parseDossier(raw: unknown): CaseDossier | null {
+  if (!isRec(raw)) return null;
+  const forecastId = str(raw.forecastId);
+  if (!forecastId) return null;
+  const blind = isRec(raw.marketBlind) ? raw.marketBlind : null;
+  return {
+    forecastId,
+    normalizedQuestion: typeof raw.normalizedQuestion === "string" ? raw.normalizedQuestion : null,
+    resolutionCriteria: typeof raw.resolutionCriteria === "string" ? raw.resolutionCriteria : null,
+    rounds: num(raw.rounds) ?? 0,
+    evidenceCount: num(raw.evidenceCount) ?? 0,
+    status: str(raw.status),
+    saturatedAt: typeof raw.saturatedAt === "string" ? raw.saturatedAt : null,
+    marketBlind: blind
+      ? {
+          enabled: blind.enabled === true,
+          blockedCount: num(blind.blockedCount) ?? 0,
+          priorSuspect: blind.priorSuspect === true
+        }
+      : null,
+    provider: typeof raw.provider === "string" ? raw.provider : null,
+    verdict: typeof raw.verdict === "string" ? raw.verdict : null,
+    whySentence: typeof raw.whySentence === "string" ? raw.whySentence : null,
+    keyFactorsYes: strList(raw.keyFactorsYes, 6),
+    keyFactorsNo: strList(raw.keyFactorsNo, 6),
+    mainUncertainties: typeof raw.mainUncertainties === "string" ? raw.mainUncertainties : null,
+    beliefCurve: Array.isArray(raw.beliefCurve)
+      ? raw.beliefCurve.flatMap((p) => {
+          if (!isRec(p)) return [];
+          const prob = num(p.prob);
+          return prob === null ? [] : [{ round: num(p.round) ?? 0, ts: str(p.ts), prob }];
+        })
+      : [],
+    keyRounds: parseRounds(raw.keyRounds)
+  };
+}
+
+function parseCase(raw: unknown): PaperCase | null {
+  if (!isRec(raw)) return null;
+  const slug = str(raw.slug);
+  const shares = num(raw.shares);
+  const entryPrice = num(raw.entryPrice);
+  if (!slug || shares === null || entryPrice === null) return null;
+  return {
+    rank: num(raw.rank) ?? 0,
+    bucket: raw.bucket === "loser" ? "loser" : "winner",
+    positionId: str(raw.positionId),
+    slug,
+    question: zhQuestion(slug, str(raw.question)),
+    side: str(raw.side).toUpperCase(),
+    status: raw.status === "open" ? "open" : "closed",
+    openedUtc: str(raw.openedUtc),
+    closedUtc: typeof raw.closedUtc === "string" ? raw.closedUtc : null,
+    pnlUsd: num(raw.pnlUsd),
+    entryAlphaUsd: num(raw.entryAlphaUsd),
+    exitAlphaUsd: num(raw.exitAlphaUsd),
+    entryPrice,
+    exitPrice: num(raw.exitPrice),
+    benchmarkPrice: num(raw.benchmarkPrice),
+    benchmarkSource: str(raw.benchmarkSource),
+    shares,
+    entryEdgePp: num(raw.entryEdgePp),
+    exitReason: typeof raw.exitReason === "string" ? raw.exitReason : null,
+    dossier: parseDossier(raw.dossier),
+    timeline: Array.isArray(raw.timeline)
+      ? raw.timeline.flatMap((t) => {
+          if (!isRec(t)) return [];
+          const ts = str(t.ts);
+          return ts
+            ? [
+                {
+                  ts,
+                  kind: str(t.kind),
+                  label: str(t.label),
+                  detail: typeof t.detail === "string" ? t.detail : null,
+                  agentProb: num(t.agentProb),
+                  marketPrice: num(t.marketPrice),
+                  netEdgePp: num(t.netEdgePp)
+                }
+              ]
+            : [];
+        })
+      : [],
+    marketCurve: Array.isArray(raw.marketCurve)
+      ? raw.marketCurve.flatMap((p) => {
+          if (!isRec(p)) return [];
+          const price = num(p.price);
+          return price === null ? [] : [{ ts: str(p.ts), price, agentProb: num(p.agentProb) }];
+        })
+      : []
+  };
+}
+
+export function parseCasesPayload(json: unknown): PaperCases | null {
+  if (!isRec(json)) return null;
+  const winners = Array.isArray(json.winners) ? json.winners.flatMap((c) => parseCase(c) ?? []) : [];
+  const losers = Array.isArray(json.losers) ? json.losers.flatMap((c) => parseCase(c) ?? []) : [];
+  if (winners.length === 0 && losers.length === 0) return null;
+  return { generatedAtUtc: str(json.generatedAtUtc), winners, losers };
+}
+
+function upstreamUrl(): string {
+  const base = process.env.LIVE_PREDICT_RAVEN_UPSTREAM?.trim() || DEFAULT_UPSTREAM;
+  return `${base.replace(/\/+$/, "")}/paper/cases`;
+}
+
+// SECURITY: same wire as live.ts — plain HTTP to a bare-IP VM. Only the invite
+// code may travel it, never FORECAST_API_TOKEN / RAVEN_ACCESS_TOKEN.
+function upstreamToken(): string {
+  return process.env.LIVE_PREDICT_RAVEN_UPSTREAM_TOKEN?.trim() || "raven-labs";
+}
+
+let successMemo: { at: number; cases: PaperCases } | null = null;
+let lastFailureAt = 0;
+
+export async function fetchPaperCases(nowMs: number = Date.now()): Promise<PaperCases | null> {
+  if (successMemo && nowMs - successMemo.at < SUCCESS_TTL_MS) return successMemo.cases;
+  if (nowMs - lastFailureAt < FAILURE_BACKOFF_MS) return null;
+  try {
+    const res = await fetch(upstreamUrl(), {
+      headers: { authorization: `Bearer ${upstreamToken()}` },
+      cache: "no-store",
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
+    });
+    if (!res.ok) {
+      lastFailureAt = nowMs;
+      return null;
+    }
+    const cases = parseCasesPayload(await res.json());
+    if (cases) {
+      successMemo = { at: nowMs, cases };
+    } else {
+      lastFailureAt = nowMs;
+    }
+    return cases;
+  } catch {
+    lastFailureAt = nowMs;
+    return null;
+  }
+}

--- a/apps/web/lib/live-predict-raven/findings.test.ts
+++ b/apps/web/lib/live-predict-raven/findings.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { deriveFindings } from "./findings";
+import { PAPER_SNAPSHOT } from "./snapshot";
+import type { DecisionEpisode, PaperSnapshot } from "./snapshot";
+
+const episode = (over: Partial<DecisionEpisode> = {}): DecisionEpisode => ({
+  positionId: "mkt:1",
+  slug: "mkt",
+  question: "某市场？",
+  side: "NO",
+  status: "closed",
+  openedUtc: "2026-07-01T00:00:00.000Z",
+  closedUtc: "2026-07-05T00:00:00.000Z",
+  holdDays: 4,
+  shares: 1000,
+  entryPrice: 0.4,
+  costUsd: 400,
+  exitPrice: 0.3,
+  benchmarkPrice: 0.9,
+  benchmarkSource: "live",
+  entryAlphaUsd: 500,
+  exitAlphaUsd: -600,
+  pnlUsd: -100,
+  exitReason: "negative_edge",
+  exitStyle: "market",
+  entryEdgePp: 12,
+  agentProbAtEntry: 0.8,
+  marketProbAtEntry: 0.6,
+  roundsAtEntry: 3,
+  evidenceAtEntry: 11,
+  reviewCount: 4,
+  ...over
+});
+
+function snapshotWith(over: Partial<PaperSnapshot>): PaperSnapshot {
+  return { ...PAPER_SNAPSHOT, ...over } as PaperSnapshot;
+}
+
+const idsOf = (s: PaperSnapshot): string[] => deriveFindings(s).map((f) => f.id);
+
+describe("deriveFindings", () => {
+  it("always leads with the pnl composition, using the live numbers", () => {
+    const findings = deriveFindings(PAPER_SNAPSHOT);
+    expect(findings[0]?.id).toBe("pnl-composition");
+    expect(findings[0]?.title).toContain("$10,000");
+  });
+
+  it("degrades to a headline-only read when the decomposition is absent", () => {
+    const ids = idsOf(snapshotWith({ decisionQuality: null }));
+    expect(ids).not.toContain("entry-quality");
+    expect(ids).not.toContain("exit-quality");
+    expect(ids[0]).toBe("pnl-composition");
+  });
+
+  it("labels a positive entry contribution a strength and a negative exit a risk", () => {
+    const findings = deriveFindings(
+      snapshotWith({
+        decisionQuality: {
+          benchmarkAsOfUtc: null,
+          entry: { totalUsd: 988, openUsd: 1625, closedUsd: -637, scored: 30, unscored: 0 },
+          exit: { totalUsd: -455, scored: 18, unscored: 2 },
+          reconciliation: { closedPnlUsd: -1091.66, realizedPnlUsd: -1091.67, deltaUsd: 0.01 },
+          episodes: [episode()]
+        }
+      })
+    );
+    expect(findings.find((f) => f.id === "entry-quality")?.kind).toBe("strength");
+    expect(findings.find((f) => f.id === "exit-quality")?.kind).toBe("risk");
+  });
+
+  it("raises a cooldown proposal only when re-entries actually lost money", () => {
+    const losing = [
+      episode({ exitReason: "stop_loss", pnlUsd: -200 }),
+      episode({ openedUtc: "2026-07-06T00:00:00.000Z", pnlUsd: -150 })
+    ];
+    const winning = [
+      episode({ exitReason: "stop_loss", pnlUsd: -200 }),
+      episode({ openedUtc: "2026-07-06T00:00:00.000Z", pnlUsd: 400 })
+    ];
+    const withEpisodes = (episodes: DecisionEpisode[]): PaperSnapshot =>
+      snapshotWith({
+        decisionQuality: {
+          benchmarkAsOfUtc: null,
+          entry: { totalUsd: 0, openUsd: 0, closedUsd: 0, scored: 0, unscored: 0 },
+          exit: { totalUsd: 0, scored: 0, unscored: 0 },
+          reconciliation: { closedPnlUsd: 0, realizedPnlUsd: 0, deltaUsd: 0 },
+          episodes
+        }
+      });
+    expect(idsOf(withEpisodes(losing))).toContain("proposal-cooldown");
+    const winIds = idsOf(withEpisodes(winning));
+    expect(winIds).toContain("stop-loss-reentry");
+    expect(winIds).not.toContain("proposal-cooldown");
+  });
+
+  it("flags a low-price stop only when the contract recovered above the exit", () => {
+    const whipsaw = episode({ exitReason: "stop_loss", entryPrice: 0.22, exitPrice: 0.1, benchmarkPrice: 1 });
+    const justWrong = episode({ exitReason: "stop_loss", entryPrice: 0.22, exitPrice: 0.1, benchmarkPrice: 0 });
+    const withEpisodes = (e: DecisionEpisode): PaperSnapshot =>
+      snapshotWith({
+        decisionQuality: {
+          benchmarkAsOfUtc: null,
+          entry: { totalUsd: 0, openUsd: 0, closedUsd: 0, scored: 0, unscored: 0 },
+          exit: { totalUsd: 0, scored: 0, unscored: 0 },
+          reconciliation: { closedPnlUsd: 0, realizedPnlUsd: 0, deltaUsd: 0 },
+          episodes: [e]
+        }
+      });
+    expect(idsOf(withEpisodes(whipsaw))).toContain("stop-loss-lowprice");
+    expect(idsOf(withEpisodes(justWrong))).not.toContain("stop-loss-lowprice");
+  });
+
+  it("names the dominant theme when open positions cluster on one story", () => {
+    const finding = deriveFindings(PAPER_SNAPSHOT).find((f) => f.id === "theme-concentration");
+    // The baked snapshot is an all-Iran geopolitics book.
+    expect(finding?.title).toContain("伊朗");
+    expect(finding?.kind).toBe("risk");
+  });
+
+  it("keeps every risk-parameter change as a proposal, never an applied change", () => {
+    for (const f of deriveFindings(PAPER_SNAPSHOT)) {
+      if (f.id.startsWith("proposal-")) {
+        expect(f.kind).toBe("proposal");
+        expect(f.body).toMatch(/确认/);
+      }
+    }
+  });
+});

--- a/apps/web/lib/live-predict-raven/findings.ts
+++ b/apps/web/lib/live-predict-raven/findings.ts
@@ -1,0 +1,337 @@
+// Derived conclusions for the /live-predict-raven review page.
+//
+// Every bullet under "结论与建议" used to be prose written by hand on a given
+// review date, which went stale the moment the book moved (an August 5 note
+// describing a −20% book was still on the page when the book was +5%). These
+// rules recompute the same judgements from the current snapshot, so the
+// section always describes the book being displayed. Each finding carries the
+// numbers that triggered it — a reader can check the claim against the tables
+// on the same page.
+//
+// Rules only DESCRIBE. Anything that would change agent behaviour (stop-loss
+// rules, exposure caps, cooldowns) is emitted as a `proposal`, which the page
+// renders as "needs the owner's sign-off" — risk parameters are never changed
+// from here.
+
+import type { DecisionEpisode, PaperSnapshot } from "./snapshot";
+import { deriveEquityStats, deriveTradeStats } from "./stats";
+
+export type FindingKind = "headline" | "strength" | "risk" | "proposal";
+
+export interface Finding {
+  /** Stable id so a finding can be linked to / suppressed without matching prose. */
+  id: string;
+  kind: FindingKind;
+  title: string;
+  body: string;
+  /** The numbers behind the claim, shown as chips under the text. */
+  metrics: ReadonlyArray<{ label: string; value: string }>;
+}
+
+const usd = (n: number): string =>
+  `${n < 0 ? "−" : ""}$${Math.abs(Math.round(n)).toLocaleString("en-US")}`;
+const signedUsd = (n: number): string => `${n >= 0 ? "+" : "−"}$${Math.abs(Math.round(n)).toLocaleString("en-US")}`;
+const pct1 = (n: number): string => `${n >= 0 ? "+" : "−"}${Math.abs(n).toFixed(1)}%`;
+
+// Themes group markets that move together for the same real-world reason. The
+// agent's own exposure cap works on Gamma event slugs, which is strictly
+// narrower — "Hormuz reopening" and "US blockade ends" are different events but
+// one bet on how the Iran confrontation resolves.
+const THEMES: ReadonlyArray<{ id: string; label: string; test: RegExp }> = [
+  { id: "iran", label: "伊朗 / 中东对抗", test: /iran|hormuz|blockade|ceasefire|nuclear|khamenei|tehran|offensive/i },
+  { id: "israel", label: "以巴 / 加沙", test: /israel|hamas|gaza|disarm/i },
+  { id: "russia", label: "俄乌 / 北约", test: /russia|putin|ukraine|nato|crimea/i },
+  { id: "china", label: "台海 / 南海", test: /china|taiwan|philippines/i },
+  { id: "macro", label: "市场 / 宏观", test: /nvidia|fed|rate|oil|wti|crude|market cap|company|stock/i }
+];
+
+function themeOf(text: string): { id: string; label: string } {
+  for (const t of THEMES) {
+    if (t.test.test(text)) return { id: t.id, label: t.label };
+  }
+  return { id: "other", label: "其他" };
+}
+
+interface Concentration {
+  label: string;
+  costUsd: number;
+  sharePct: number;
+  count: number;
+}
+
+function topTheme(snapshot: PaperSnapshot): Concentration | null {
+  const totalCost = snapshot.openPositions.reduce((s, p) => s + p.shares * p.entryPrice, 0);
+  if (totalCost <= 0) return null;
+  const byTheme = new Map<string, { label: string; costUsd: number; count: number }>();
+  for (const p of snapshot.openPositions) {
+    const theme = themeOf(`${p.slug} ${p.question}`);
+    const prev = byTheme.get(theme.id) ?? { label: theme.label, costUsd: 0, count: 0 };
+    byTheme.set(theme.id, { label: theme.label, costUsd: prev.costUsd + p.shares * p.entryPrice, count: prev.count + 1 });
+  }
+  const top = [...byTheme.values()].sort((a, b) => b.costUsd - a.costUsd)[0];
+  if (!top) return null;
+  return { label: top.label, costUsd: top.costUsd, sharePct: (top.costUsd / totalCost) * 100, count: top.count };
+}
+
+/** Positions re-opened on a market that had already stopped us out. */
+interface Reentry {
+  slug: string;
+  question: string;
+  repeats: number;
+  pnlUsd: number;
+}
+
+function stopLossReentries(episodes: readonly DecisionEpisode[]): Reentry[] {
+  const bySlug = new Map<string, DecisionEpisode[]>();
+  for (const e of episodes) {
+    bySlug.set(e.slug, [...(bySlug.get(e.slug) ?? []), e]);
+  }
+  const out: Reentry[] = [];
+  for (const [slug, all] of bySlug) {
+    const ordered = [...all].sort((a, b) => (a.openedUtc < b.openedUtc ? -1 : 1));
+    let stopped = false;
+    let repeats = 0;
+    let pnl = 0;
+    for (const e of ordered) {
+      if (stopped) {
+        repeats += 1;
+        pnl += e.pnlUsd ?? 0;
+      }
+      if (e.exitReason === "stop_loss") stopped = true;
+    }
+    if (repeats > 0) {
+      out.push({ slug, question: ordered[0]?.question ?? slug, repeats, pnlUsd: pnl });
+    }
+  }
+  return out.sort((a, b) => a.pnlUsd - b.pnlUsd);
+}
+
+/** Stop-losses that fired on a cheap contract which then recovered above the exit. */
+function stopLossWhipsaws(episodes: readonly DecisionEpisode[], maxEntryPrice: number): DecisionEpisode[] {
+  return episodes.filter(
+    (e) =>
+      e.exitReason === "stop_loss" &&
+      e.entryPrice <= maxEntryPrice &&
+      e.benchmarkPrice !== null &&
+      e.exitPrice !== null &&
+      e.benchmarkPrice > e.exitPrice
+  );
+}
+
+export function deriveFindings(snapshot: PaperSnapshot): Finding[] {
+  const findings: Finding[] = [];
+  const trade = deriveTradeStats(snapshot.closedTrades);
+  const equity = deriveEquityStats(snapshot.equityCurve, snapshot.bankrollUsd);
+  const dq = snapshot.decisionQuality;
+  const episodes = dq?.episodes ?? [];
+  const unrealized = snapshot.openPositions.reduce((s, p) => s + p.unrealizedUsd, 0);
+
+  // ---- 1. Where the current number comes from ----------------------------
+  findings.push({
+    id: "pnl-composition",
+    kind: "headline",
+    title: `本金 ${usd(snapshot.bankrollUsd)} → 权益 ${usd(snapshot.equityUsd)}（${pct1(equity.returnPct)}）`,
+    body: dq
+      ? `已实现 ${signedUsd(snapshot.realizedPnlUsd)}（${trade.closedCount} 个已平仓回合，${trade.wins} 胜 ${trade.losses} 负），未实现 ${signedUsd(unrealized)}（${snapshot.openPositions.length} 个在持仓）。` +
+        `按决策拆分：建仓贡献 ${signedUsd(dq.entry.totalUsd)}，退出贡献 ${signedUsd(dq.exit.totalUsd)}——` +
+        (dq.entry.totalUsd > 0 && dq.exit.totalUsd < 0
+          ? "选标的赚的钱，被提前退出还回去一部分。"
+          : dq.entry.totalUsd < 0 && dq.exit.totalUsd > 0
+            ? "建仓整体亏钱，靠退出（主要是止损）救回一部分。"
+            : "两个环节同向。")
+      : `已实现 ${signedUsd(snapshot.realizedPnlUsd)}，未实现 ${signedUsd(unrealized)}。`,
+    metrics: [
+      { label: "最大回撤", value: pct1(equity.maxDrawdownPct) },
+      { label: "峰值", value: `${usd(equity.peakUsd)}（${equity.peakDate}）` },
+      { label: "胜率", value: `${trade.winRatePct.toFixed(0)}%` },
+      { label: "累计费用", value: usd(snapshot.feesUsd) }
+    ]
+  });
+
+  // ---- 2. Which of the two decisions is working --------------------------
+  if (dq) {
+    const entryStrong = dq.entry.totalUsd > 0;
+    const worstExits = [...episodes]
+      .filter((e) => e.exitAlphaUsd !== null && e.exitAlphaUsd < 0)
+      .sort((a, b) => (a.exitAlphaUsd ?? 0) - (b.exitAlphaUsd ?? 0))
+      .slice(0, 2);
+    const bestEntries = [...episodes]
+      .filter((e) => e.entryAlphaUsd !== null)
+      .sort((a, b) => (b.entryAlphaUsd ?? 0) - (a.entryAlphaUsd ?? 0))
+      .slice(0, 2);
+    findings.push({
+      id: "entry-quality",
+      kind: entryStrong ? "strength" : "risk",
+      title: `建仓质量：${signedUsd(dq.entry.totalUsd)}`,
+      body:
+        `把每个仓位假设「买了就一直持有到结算/现在」，累计 ${signedUsd(dq.entry.totalUsd)}` +
+        `（在持部分 ${signedUsd(dq.entry.openUsd)}，已平部分 ${signedUsd(dq.entry.closedUsd)}）。` +
+        (bestEntries.length > 0
+          ? `最好的两笔建仓：${bestEntries
+              .map((e) => `${e.question}（${signedUsd(e.entryAlphaUsd ?? 0)}）`)
+              .join("、")}。`
+          : ""),
+      metrics: [
+        { label: "在持贡献", value: signedUsd(dq.entry.openUsd) },
+        { label: "已平贡献", value: signedUsd(dq.entry.closedUsd) },
+        { label: "计入仓位", value: `${dq.entry.scored} 个` }
+      ]
+    });
+    findings.push({
+      id: "exit-quality",
+      kind: dq.exit.totalUsd >= 0 ? "strength" : "risk",
+      title: `退出质量：${signedUsd(dq.exit.totalUsd)}`,
+      body:
+        `退出决定相对「不卖」的净增减。${dq.exit.totalUsd >= 0 ? "整体加分。" : "整体减分。"}` +
+        (worstExits.length > 0
+          ? `代价最大的两次提前退出：${worstExits
+              .map((e) => `${e.question}（${signedUsd(e.exitAlphaUsd ?? 0)}，${e.exitReason === "stop_loss" ? "止损" : "负边际"}）`)
+              .join("、")}。`
+          : ""),
+      metrics: [
+        { label: "可评分退出", value: `${dq.exit.scored} 次` },
+        ...(dq.exit.unscored > 0 ? [{ label: "无基准价", value: `${dq.exit.unscored} 次` }] : []),
+        {
+          label: "账目校验",
+          value:
+            Math.abs(dq.reconciliation.deltaUsd) < 1
+              ? "已平仓合计与账本一致"
+              : `与账本差 ${signedUsd(dq.reconciliation.deltaUsd)}`
+        }
+      ]
+    });
+  }
+
+  // ---- 3. Calibration, read honestly -------------------------------------
+  const horizon = snapshot.brier.horizon;
+  const clusters = snapshot.brier.clusters;
+  const pendingCount = snapshot.brier.pending.length;
+  if (snapshot.brier.n > 0) {
+    const beatsAnywhere = horizon?.buckets.filter((b) => (b.skill ?? -1) > 0) ?? [];
+    findings.push({
+      id: "calibration",
+      kind: (snapshot.brier.skillScore ?? 0) >= 0 ? "strength" : "risk",
+      title: `校准：技巧分 ${snapshot.brier.skillScore.toFixed(2)}（n=${snapshot.brier.n}${
+        clusters ? `，独立事件 ${clusters.effectiveN} 个` : ""
+      }）`,
+      body:
+        `agent Brier ${snapshot.brier.agentScore.toFixed(3)} vs 市场 ${snapshot.brier.marketScore.toFixed(3)}，` +
+        `>0 才算跑赢市场。这个数字只覆盖已结算市场——${pendingCount} 个已评估但未结算的市场（含目前浮盈最大的几个仓位）完全不在里面，` +
+        `它们的表现体现在上面的建仓质量里。` +
+        (horizon?.atEntry && horizon.atLast
+          ? `按「什么时候做的判断」分开看：首次判断（中位 ${(horizon.atEntry.medianHorizonDays ?? 0).toFixed(0)} 天前）技巧分 ${(horizon.atEntry.skill ?? 0).toFixed(2)}，临近结算的最后一次 ${(horizon.atLast.skill ?? 0).toFixed(2)}。`
+          : "") +
+        (beatsAnywhere.length > 0
+          ? `在 ${beatsAnywhere.map((b) => b.label).join(" / ")} 这个跨度上是跑赢市场的（技巧分 ${beatsAnywhere
+              .map((b) => (b.skill ?? 0).toFixed(2))
+              .join(" / ")}）。`
+          : ""),
+      metrics: [
+        ...(horizon?.weighted?.skill !== undefined && horizon?.weighted?.skill !== null
+          ? [{ label: `按天数^${horizon.weighted.exponent} 加权`, value: horizon.weighted.skill.toFixed(2) }]
+          : []),
+        { label: "未结算市场", value: `${pendingCount} 个` },
+        ...(clusters ? [{ label: "有效样本", value: `${clusters.effectiveN} 个独立事件 / ${snapshot.brier.n} 条` }] : [])
+      ]
+    });
+  }
+
+  // ---- 4. Concentration ---------------------------------------------------
+  const concentration = topTheme(snapshot);
+  if (concentration && concentration.sharePct >= 40) {
+    const sides = new Set(snapshot.openPositions.map((p) => p.side));
+    findings.push({
+      id: "theme-concentration",
+      kind: "risk",
+      title: `题材集中：${concentration.label}占在持成本 ${concentration.sharePct.toFixed(0)}%`,
+      body:
+        `${concentration.count} 个在持仓共享同一个宏观驱动，成本 ${usd(concentration.costUsd)}。` +
+        (sides.size === 1 ? `而且全部 ${snapshot.openPositions.length} 个仓位方向一致（都是 ${[...sides][0]}）。` : "") +
+        `事件级上限（maxPerEvent=${snapshot.config.maxPerEvent}）按 Gamma 事件切分，挡不住「同一个故事、不同市场」的叠加暴露。`,
+      metrics: [
+        { label: "同题材仓位", value: `${concentration.count} / ${snapshot.openPositions.length}` },
+        { label: "同题材成本", value: usd(concentration.costUsd) },
+        { label: "仓位占用", value: `${snapshot.openPositions.length} / ${snapshot.config.maxPositions}` }
+      ]
+    });
+    findings.push({
+      id: "proposal-theme-cap",
+      kind: "proposal",
+      title: "建议：加一层题材级敞口上限",
+      body: `在事件级 maxPerEvent 之上，按题材（而非 Gamma 事件）限制总成本占比。这是风控参数改动，需你确认后才写入 env。`,
+      metrics: [{ label: "当前最高题材占比", value: `${concentration.sharePct.toFixed(0)}%` }]
+    });
+  }
+
+  // ---- 5. Stop-loss behaviour --------------------------------------------
+  const reentries = stopLossReentries(episodes);
+  if (reentries.length > 0) {
+    const totalRepeat = reentries.reduce((s, r) => s + r.pnlUsd, 0);
+    findings.push({
+      id: "stop-loss-reentry",
+      kind: totalRepeat < 0 ? "risk" : "strength",
+      title: `止损后重进同一市场：${reentries.length} 个市场，合计 ${signedUsd(totalRepeat)}`,
+      body:
+        `止损平掉后又在同一个 slug 上重新建仓，累计 ${reentries.reduce((s, r) => s + r.repeats, 0)} 次。` +
+        `最贵的是 ${reentries[0]?.question}（${signedUsd(reentries[0]?.pnlUsd ?? 0)}）。` +
+        (totalRepeat < 0
+          ? "没有冷却期，同一个判断错误会被重复下注。"
+          : "重进整体是赚的——冷却期若一刀切会误伤这类修正。"),
+      metrics: reentries.slice(0, 3).map((r) => ({ label: r.question, value: signedUsd(r.pnlUsd) }))
+    });
+    if (totalRepeat < 0) {
+      findings.push({
+        id: "proposal-cooldown",
+        kind: "proposal",
+        title: "建议：止损后对同市场设冷却期",
+        body: "止损平仓后，同一 slug（或同一事件）在 N 小时内不得重新建仓。属于风控参数，需你确认。",
+        metrics: [{ label: "当前代价", value: signedUsd(totalRepeat) }]
+      });
+    }
+  }
+
+  const whipsaws = stopLossWhipsaws(episodes, 0.35);
+  if (whipsaws.length > 0) {
+    const cost = whipsaws.reduce((s, e) => s + (e.exitAlphaUsd ?? 0), 0);
+    findings.push({
+      id: "stop-loss-lowprice",
+      kind: "risk",
+      title: `低价合约止损被打脸：${whipsaws.length} 笔，退出贡献 ${signedUsd(cost)}`,
+      body:
+        `入场价 ≤ $0.35 的仓位触发 ${(snapshot.config.stopLossPct * 100).toFixed(0)}% 价格止损后，该合约价格又回到了卖出价之上。` +
+        `低价合约本身波动就大，固定百分比回撤对它过于敏感。典型例子：${whipsaws[0]?.question}（入场 $${whipsaws[0]?.entryPrice.toFixed(2)}，卖在 $${(whipsaws[0]?.exitPrice ?? 0).toFixed(2)}，现值 $${(whipsaws[0]?.benchmarkPrice ?? 0).toFixed(2)}）。`,
+      metrics: whipsaws.slice(0, 3).map((e) => ({ label: e.question, value: signedUsd(e.exitAlphaUsd ?? 0) }))
+    });
+    findings.push({
+      id: "proposal-stop-loss-sizing",
+      kind: "proposal",
+      title: "建议：止损规则按合约价位分档，或对低价单缩仓而非收紧止损",
+      body: "把纯价格回撤止损改为「剩余净 edge 转负才退出」，或对 $0.35 以下的合约降低单笔金额。风控参数改动，需你确认。",
+      metrics: [{ label: "受影响笔数", value: `${whipsaws.length} 笔` }]
+    });
+  }
+
+  // ---- 6. Engine health ---------------------------------------------------
+  const q = snapshot.engineQuality;
+  if (q.evaluations > 0) {
+    const satPct = (q.saturated / q.evaluations) * 100;
+    if (satPct >= 40) {
+      findings.push({
+        id: "engine-saturation",
+        kind: "risk",
+        title: `引擎饱和率 ${satPct.toFixed(0)}%`,
+        body:
+          `${q.saturated} / ${q.evaluations} 次评估的概率打到 1% / 99% 钳位。钳位状态下算出的 edge 只是下限，` +
+          `临近结算时市场能给出 0.995 这类精细报价，而 agent 最多说 0.99——这正是短跨度技巧分被拖累的机制原因，不完全是判断错。` +
+          `${snapshot.saturatedHolds} 次因此触发「饱和持有」保护，避免把接近满值的赢家提前卖掉。`,
+        metrics: [
+          { label: "饱和", value: `${q.saturated} 次` },
+          { label: "市场价污染", value: `${q.contaminated} 次` },
+          { label: "评估失败", value: `${q.evalErrors} 次（安全默认持有）` }
+        ]
+      });
+    }
+  }
+
+  return findings;
+}

--- a/apps/web/lib/live-predict-raven/labels.ts
+++ b/apps/web/lib/live-predict-raven/labels.ts
@@ -43,6 +43,11 @@ const QUESTION_ZH: Record<string, string> = {
     "霍尔木兹海峡 9/30 前恢复正常通航？",
   "will-nicols-maduro-be-the-leader-of-venezuela-end-of-2026": "马杜罗 2026 年底仍是委内瑞拉领导人？",
   "us-announces-end-of-iranian-blockade-by-august-7-2026-20260727171523690": "美国 8/7 前宣布解除对伊封锁？",
+  "us-announces-end-of-iranian-blockade-by-august-15-2026-20260713152715083-347-987-697-628-574-676":
+    "美国 8/15 前宣布解除对伊封锁？",
+  "us-announces-end-of-iranian-blockade-by-august-31-2026-20260713152715084-642-513-584-641-939-632-729":
+    "美国 8/31 前宣布解除对伊封锁？",
+  "us-x-iran-ceasefire-continues-through-august-31": "美国对伊停火延续至 8/31？",
   "US x Iran Effective Ceasefire by July 31?": "美伊 7/31 前达成有效停火？",
   "Israel x Iran ceasefire continues through July 31?": "以伊停火延续至 7/31？",
   "Israel x Iran ceasefire continues through August 15?": "以伊停火延续至 8/15？",
@@ -54,6 +59,9 @@ const QUESTION_ZH: Record<string, string> = {
   "Strait of Hormuz traffic returns to normal by September 30?": "霍尔木兹海峡 9/30 前恢复正常通航？",
   "Will Nicolás Maduro be the leader of Venezuela end of 2026?": "马杜罗 2026 年底仍是委内瑞拉领导人？",
   "US announces end of Iranian blockade by August 7, 2026?": "美国 8/7 前宣布解除对伊封锁？",
+  "US announces end of Iranian blockade by August 15, 2026?": "美国 8/15 前宣布解除对伊封锁？",
+  "US announces end of Iranian blockade by August 31, 2026?": "美国 8/31 前宣布解除对伊封锁？",
+  "US ceasefire against Iran continues through August 31?": "美国对伊停火延续至 8/31？",
   "Will WTI Crude Oil (WTI) hit (HIGH) $95 in July?": "WTI 原油 7 月最高价触及 $95？"
 };
 

--- a/apps/web/lib/live-predict-raven/live.ts
+++ b/apps/web/lib/live-predict-raven/live.ts
@@ -5,7 +5,19 @@
 // baked snapshot, so the page never breaks when the VM is unreachable.
 
 import { tradeNote, shortUtc, zhExitReason, zhExitStyle, zhQuestion } from "./labels";
-import type { ClosedTrade, ExitReasonKind, OpenPosition, PaperParams, PaperSnapshot } from "./snapshot";
+import type {
+  BrierBlock,
+  CalibrationCluster,
+  ClosedTrade,
+  DecisionEpisode,
+  DecisionQuality,
+  ExitReasonKind,
+  HorizonBucket,
+  OpenPosition,
+  PaperParams,
+  PaperSnapshot,
+  PendingCalibrationRow
+} from "./snapshot";
 import { PAPER_PARAMS_FALLBACK } from "./snapshot";
 
 const DEFAULT_UPSTREAM = "http://34.85.97.32:8787";
@@ -88,6 +100,153 @@ function parseConfig(raw: unknown): PaperParams {
       typeof raw.saturatedHoldEnabled === "boolean"
         ? raw.saturatedHoldEnabled
         : PAPER_PARAMS_FALLBACK.saturatedHoldEnabled
+  };
+}
+
+
+// ---- Optional analytics blocks -------------------------------------------
+// All lenient: an older API build simply omits them and the page hides the
+// matching sections instead of falling back to the baked snapshot wholesale.
+
+function parseBrierBlock(raw: unknown): BrierBlock | null {
+  if (!isRec(raw)) return null;
+  const n = num(raw.n);
+  if (n === null) return null;
+  return {
+    n,
+    brierAgent: num(raw.brierAgent),
+    brierMarket: num(raw.brierMarket),
+    skill: num(raw.skill),
+    medianHorizonDays: num(raw.medianHorizonDays)
+  };
+}
+
+function parseHorizon(raw: unknown): PaperSnapshot["brier"]["horizon"] {
+  if (!isRec(raw)) return null;
+  const bucketsRaw = Array.isArray(raw.buckets) ? raw.buckets : [];
+  const buckets: HorizonBucket[] = bucketsRaw.flatMap((b) => {
+    const block = parseBrierBlock(b);
+    if (!block || !isRec(b)) return [];
+    return [{ ...block, label: str(b.label), minDays: num(b.minDays) ?? 0, maxDays: num(b.maxDays) }];
+  });
+  const weightedRaw = isRec(raw.weighted) ? raw.weighted : null;
+  return {
+    atEntry: parseBrierBlock(raw.atEntry),
+    atLast: parseBrierBlock(raw.atLast),
+    buckets,
+    weighted: weightedRaw
+      ? { exponent: num(weightedRaw.exponent) ?? 1.5, skill: num(weightedRaw.skill), n: num(weightedRaw.n) ?? 0 }
+      : null
+  };
+}
+
+function parseClusters(raw: unknown): PaperSnapshot["brier"]["clusters"] {
+  if (!isRec(raw)) return null;
+  const rowsRaw = Array.isArray(raw.rows) ? raw.rows : [];
+  const rows: CalibrationCluster[] = rowsRaw.flatMap((r) => {
+    if (!isRec(r)) return [];
+    return [
+      {
+        eventSlug: str(r.eventSlug),
+        label: zhQuestion(str(r.eventSlug), str(r.label)),
+        n: num(r.n) ?? 0,
+        skill: num(r.skill)
+      }
+    ];
+  });
+  return { effectiveN: num(raw.effectiveN) ?? rows.length, rows };
+}
+
+function parsePending(raw: unknown): PendingCalibrationRow[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((r) => {
+    if (!isRec(r)) return [];
+    const agentProb = num(r.agentProb);
+    const marketProb = num(r.marketProb);
+    if (agentProb === null || marketProb === null) return [];
+    const slug = str(r.slug);
+    return [
+      {
+        question: zhQuestion(slug, str(r.question)),
+        slug,
+        side: typeof r.side === "string" ? r.side.toUpperCase() : null,
+        agentProb,
+        marketProb,
+        horizonDays: num(r.horizonDays),
+        unrealizedUsd: num(r.unrealizedUsd)
+      }
+    ];
+  });
+}
+
+function parseDecisionQuality(raw: unknown): DecisionQuality | null {
+  if (!isRec(raw)) return null;
+  const entry = isRec(raw.entry) ? raw.entry : null;
+  const exit = isRec(raw.exit) ? raw.exit : null;
+  const rec = isRec(raw.reconciliation) ? raw.reconciliation : null;
+  const episodesRaw = Array.isArray(raw.episodes) ? raw.episodes : [];
+  if (!entry || !exit || episodesRaw.length === 0) return null;
+  const episodes: DecisionEpisode[] = episodesRaw.flatMap((e) => {
+    if (!isRec(e)) return [];
+    const shares = num(e.shares);
+    const entryPrice = num(e.entryPrice);
+    if (shares === null || entryPrice === null) return [];
+    const slug = str(e.slug);
+    const benchmarkSource = str(e.benchmarkSource);
+    return [
+      {
+        positionId: str(e.positionId),
+        slug,
+        question: zhQuestion(slug, str(e.question)),
+        side: toSide(e.side),
+        status: e.status === "open" ? "open" : "closed",
+        openedUtc: str(e.openedUtc),
+        closedUtc: typeof e.closedUtc === "string" ? e.closedUtc : null,
+        holdDays: num(e.holdDays),
+        shares,
+        entryPrice,
+        costUsd: num(e.costUsd) ?? 0,
+        exitPrice: num(e.exitPrice),
+        benchmarkPrice: num(e.benchmarkPrice),
+        benchmarkSource:
+          benchmarkSource === "settled" || benchmarkSource === "live" || benchmarkSource === "mark"
+            ? benchmarkSource
+            : "exit",
+        entryAlphaUsd: num(e.entryAlphaUsd),
+        exitAlphaUsd: num(e.exitAlphaUsd),
+        pnlUsd: num(e.pnlUsd),
+        exitReason: typeof e.exitReason === "string" ? e.exitReason : null,
+        exitStyle: typeof e.exitStyle === "string" ? e.exitStyle : null,
+        entryEdgePp: num(e.entryEdgePp),
+        agentProbAtEntry: num(e.agentProbAtEntry),
+        marketProbAtEntry: num(e.marketProbAtEntry),
+        roundsAtEntry: num(e.roundsAtEntry),
+        evidenceAtEntry: num(e.evidenceAtEntry),
+        reviewCount: num(e.reviewCount) ?? 0
+      }
+    ];
+  });
+  if (episodes.length === 0) return null;
+  return {
+    benchmarkAsOfUtc: typeof raw.benchmarkAsOfUtc === "string" ? raw.benchmarkAsOfUtc : null,
+    entry: {
+      totalUsd: num(entry.totalUsd) ?? 0,
+      openUsd: num(entry.openUsd) ?? 0,
+      closedUsd: num(entry.closedUsd) ?? 0,
+      scored: num(entry.scored) ?? 0,
+      unscored: num(entry.unscored) ?? 0
+    },
+    exit: {
+      totalUsd: num(exit.totalUsd) ?? 0,
+      scored: num(exit.scored) ?? 0,
+      unscored: num(exit.unscored) ?? 0
+    },
+    reconciliation: {
+      closedPnlUsd: num(rec?.closedPnlUsd) ?? 0,
+      realizedPnlUsd: num(rec?.realizedPnlUsd) ?? 0,
+      deltaUsd: num(rec?.deltaUsd) ?? 0
+    },
+    episodes
   };
 }
 
@@ -225,11 +384,16 @@ export function parseLivePayload(json: unknown): PaperSnapshot | null {
             agentProb: num(r.agentProb) ?? 0,
             marketProb: num(r.marketProb) ?? 0,
             happened: r.happened === true,
-            resolvedUtc: str(r.resolvedUtc)
+            resolvedUtc: str(r.resolvedUtc),
+            horizonDays: num(r.horizonDays)
           }
         ];
-      })
+      }),
+      horizon: parseHorizon(brierRec.horizon),
+      clusters: parseClusters(brierRec.clusters),
+      pending: parsePending(brierRec.pending)
     },
+    decisionQuality: parseDecisionQuality(json.decisionQuality),
     engineQuality: {
       evaluations: num(quality.evaluations) ?? 0,
       saturated: num(quality.saturated) ?? 0,

--- a/apps/web/lib/live-predict-raven/snapshot.ts
+++ b/apps/web/lib/live-predict-raven/snapshot.ts
@@ -64,6 +64,78 @@ export interface BrierRow {
   marketProb: number;
   happened: boolean;
   resolvedUtc: string;
+  /** Days between the scored call and resolution; null when unknown. */
+  horizonDays?: number | null;
+}
+
+/** A pooled agent-vs-market Brier over one slice of the scored calls. */
+export interface BrierBlock {
+  n: number;
+  brierAgent: number | null;
+  brierMarket: number | null;
+  skill: number | null;
+  medianHorizonDays: number | null;
+}
+
+export interface HorizonBucket extends BrierBlock {
+  label: string;
+  minDays: number;
+  maxDays: number | null;
+}
+
+export interface CalibrationCluster {
+  eventSlug: string;
+  label: string;
+  n: number;
+  skill: number | null;
+}
+
+/** An evaluated market that has not resolved — never enters any Brier. */
+export interface PendingCalibrationRow {
+  question: string;
+  slug: string;
+  side: string | null;
+  agentProb: number;
+  marketProb: number;
+  horizonDays: number | null;
+  unrealizedUsd: number | null;
+}
+
+/** One position's life, split into the entry decision and the exit decision. */
+export interface DecisionEpisode {
+  positionId: string;
+  slug: string;
+  question: string;
+  side: string;
+  status: "open" | "closed";
+  openedUtc: string;
+  closedUtc: string | null;
+  holdDays: number | null;
+  shares: number;
+  entryPrice: number;
+  costUsd: number;
+  exitPrice: number | null;
+  benchmarkPrice: number | null;
+  benchmarkSource: "settled" | "live" | "mark" | "exit";
+  entryAlphaUsd: number | null;
+  exitAlphaUsd: number | null;
+  pnlUsd: number | null;
+  exitReason: string | null;
+  exitStyle: string | null;
+  entryEdgePp: number | null;
+  agentProbAtEntry: number | null;
+  marketProbAtEntry: number | null;
+  roundsAtEntry: number | null;
+  evidenceAtEntry: number | null;
+  reviewCount: number;
+}
+
+export interface DecisionQuality {
+  benchmarkAsOfUtc: string | null;
+  entry: { totalUsd: number; openUsd: number; closedUsd: number; scored: number; unscored: number };
+  exit: { totalUsd: number; scored: number; unscored: number };
+  reconciliation: { closedPnlUsd: number; realizedPnlUsd: number; deltaUsd: number };
+  episodes: readonly DecisionEpisode[];
 }
 
 export interface PaperParams {
@@ -116,7 +188,18 @@ export interface PaperSnapshot {
     marketScore: number;
     skillScore: number;
     rows: readonly BrierRow[];
+    /** Fairness views; null on payloads from an API build without them. */
+    horizon: {
+      atEntry: BrierBlock | null;
+      atLast: BrierBlock | null;
+      buckets: readonly HorizonBucket[];
+      weighted: { exponent: number; skill: number | null; n: number } | null;
+    } | null;
+    clusters: { effectiveN: number; rows: readonly CalibrationCluster[] } | null;
+    pending: readonly PendingCalibrationRow[];
   };
+  /** Entry-vs-exit contribution split; null on payloads without it. */
+  decisionQuality: DecisionQuality | null;
   engineQuality: {
     evaluations: number;
     saturated: number;
@@ -788,8 +871,14 @@ export const PAPER_SNAPSHOT: PaperSnapshot = {
         happened: true,
         resolvedUtc: "2026-07-04"
       }
-    ]
+    ],
+    // The baked fallback predates the fairness views; the page hides those
+    // sections rather than inventing numbers for them.
+    horizon: null,
+    clusters: null,
+    pending: []
   },
+  decisionQuality: null,
   // Ledger-count basis (same basis the live endpoint uses, so live and
   // fallback never disagree on the counting method).
   engineQuality: {

--- a/scripts/lpr-shots.mjs
+++ b/scripts/lpr-shots.mjs
@@ -1,0 +1,83 @@
+// One-off visual QA for the cookie-gated /live-predict-raven page.
+// scripts/visual-qa.mjs cannot reach it (the access cookie has to be set
+// first), so this unlocks via the real API route and then captures the page
+// at desktop and mobile widths.
+import { chromium } from "playwright";
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+
+const base = process.env.LPR_BASE ?? "http://localhost:3210";
+const code = process.env.LPR_CODE ?? "raven-labs";
+const outDir = process.env.LPR_OUT ?? "runtime-artifacts/lpr-shots";
+mkdirSync(outDir, { recursive: true });
+
+const VIEWPORTS = [
+  { name: "desktop", width: 1280, height: 1000 },
+  { name: "mobile", width: 390, height: 844 }
+];
+
+const browser = await chromium.launch();
+let failed = false;
+for (const vp of VIEWPORTS) {
+  const context = await browser.newContext({ viewport: { width: vp.width, height: vp.height } });
+  const page = await context.newPage();
+  const problems = [];
+  page.on("console", (m) => {
+    if (m.type() === "error") problems.push(`console: ${m.text()}`);
+  });
+  page.on("pageerror", (e) => problems.push(`pageerror: ${e.message}`));
+
+  await page.goto(`${base}/live-predict-raven`, { waitUntil: "domcontentloaded" });
+  await page.fill('input[name="code"]', code);
+  await page.click('button[type="submit"]');
+  await page.waitForURL(/live-predict-raven/, { waitUntil: "networkidle" });
+  // Open every <details> so the tables and walk-throughs are captured too.
+  await page.evaluate(() => document.querySelectorAll("details").forEach((d) => d.setAttribute("open", "")));
+  await page.waitForTimeout(400);
+
+  const full = path.join(outDir, `${vp.name}-full.png`);
+  await page.screenshot({ path: full, fullPage: true });
+
+  // Section crops: full-page shots of a report this long are unreadable.
+  for (const [key, heading] of [
+    ["decisions", "决策质量"],
+    ["cases", "四个案例"],
+    ["calibration", "校准（Brier）"],
+    ["findings", "结论与建议"]
+  ]) {
+    const handle = await page.evaluateHandle((text) => {
+      const h = [...document.querySelectorAll("h2, h3")].find((e) => e.textContent.includes(text));
+      return h ? h.closest("section") ?? h.parentElement : null;
+    }, heading);
+    const el = handle.asElement();
+    if (el) await el.screenshot({ path: path.join(outDir, `${vp.name}-${key}.png`) });
+  }
+
+  // The case section runs tens of thousands of pixels tall; capture the top of
+  // the first card (header → tiles → chart → first round) as the readable crop.
+  const box = await page.evaluate(() => {
+    const el = document.querySelector("[class*='caseCard']");
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    // Document coordinates: page.screenshot({fullPage,clip}) clips the full
+    // page image, not the viewport.
+    return { x: r.x + window.scrollX, y: r.y + window.scrollY, width: r.width, height: r.height };
+  });
+  if (box) {
+    await page.screenshot({
+      path: path.join(outDir, `${vp.name}-case-top.png`),
+      fullPage: true,
+      clip: { x: box.x, y: box.y, width: box.width, height: Math.min(box.height, 1600) }
+    });
+  }
+
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+  );
+  if (overflow > 1) problems.push(`horizontal overflow: ${overflow}px`);
+  console.log(`${vp.name}: ${full}  ${problems.length ? `PROBLEMS -> ${problems.join(" | ")}` : "clean"}`);
+  if (problems.length) failed = true;
+  await context.close();
+}
+await browser.close();
+process.exit(failed ? 1 : 0);

--- a/services/forecast-api/src/paper-cases.ts
+++ b/services/forecast-api/src/paper-cases.ts
@@ -1,0 +1,444 @@
+// Case walk-throughs for the /live-predict-raven review page: for the book's
+// biggest winners and biggest losers, the full chain from "what the engine
+// read" to "what the harness did about it".
+//
+// Two independent records are joined per case:
+//   the DOSSIER  <paper>/engine/forecasts/<forecastId>/state.json — the belief
+//                trail: every research round, the sources it found, how many
+//                percentage points each one moved P(YES), and the final synthesis
+//   the LEDGER   the decision trail: the watchlist screen that opened the
+//                position, each review's hold/sell verdict and net edge, the
+//                fills, the stop-loss, the settlement
+//
+// Dossiers run to 145 rounds / 1.4 MB, so rounds are selected (biggest movers
+// plus the first and last) and long prose is trimmed. Nothing is paraphrased:
+// every string is verbatim from the artifact, and every source keeps its URL
+// so a reader can check the citation.
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import type { DecisionEpisode } from "./paper-decisions";
+import type { PaperLedgerEvent } from "./paper-ledger";
+
+const MAX_KEY_ROUNDS = 8;
+const MAX_SOURCES_PER_ROUND = 5;
+const MAX_REASONING_CHARS = 900;
+const MAX_EXPLANATION_CHARS = 320;
+const MAX_VERDICT_CHARS = 1200;
+const MAX_TIMELINE_EVENTS = 60;
+const MAX_BELIEF_POINTS = 160;
+
+export interface CaseSource {
+  url: string;
+  title: string;
+  deltaPp: number;
+  explanation: string;
+  verified: boolean;
+  kind: string;
+  sourceType: string;
+  credibility: string;
+  /** Set when market-blind mode zero-weighted this source (kept for the audit trail). */
+  excluded: string | null;
+}
+
+export interface CaseRound {
+  round: number;
+  ts: string;
+  priorProb: number;
+  postProb: number;
+  netPp: number;
+  upPp: number | null;
+  downPp: number | null;
+  dominantTitle: string | null;
+  dominantUrl: string | null;
+  newSourceCount: number;
+  confidence: string;
+  reasoning: string;
+  searchQueries: string[];
+  sources: CaseSource[];
+  /** True when this round was picked for being the first/last rather than a big mover. */
+  anchor: "first" | "last" | null;
+}
+
+export interface CaseTimelineEvent {
+  ts: string;
+  kind: string;
+  label: string;
+  detail: string | null;
+  agentProb: number | null;
+  marketPrice: number | null;
+  netEdgePp: number | null;
+}
+
+export interface PaperCase {
+  rank: number;
+  bucket: "winner" | "loser";
+  positionId: string;
+  slug: string;
+  question: string;
+  side: string;
+  status: "open" | "closed";
+  openedUtc: string;
+  closedUtc: string | null;
+  pnlUsd: number | null;
+  entryAlphaUsd: number | null;
+  exitAlphaUsd: number | null;
+  entryPrice: number;
+  exitPrice: number | null;
+  benchmarkPrice: number | null;
+  benchmarkSource: string;
+  shares: number;
+  entryEdgePp: number | null;
+  exitReason: string | null;
+  /** Engine dossier context; null when the dossier is missing on this host. */
+  dossier: {
+    forecastId: string;
+    normalizedQuestion: string | null;
+    resolutionCriteria: string | null;
+    rounds: number;
+    evidenceCount: number;
+    status: string;
+    saturatedAt: string | null;
+    marketBlind: { enabled: boolean; blockedCount: number; priorSuspect: boolean } | null;
+    provider: string | null;
+    verdict: string | null;
+    whySentence: string | null;
+    keyFactorsYes: string[];
+    keyFactorsNo: string[];
+    mainUncertainties: string | null;
+    /** P(YES) after every round — the belief curve behind the position. */
+    beliefCurve: Array<{ round: number; ts: string; prob: number }>;
+    keyRounds: CaseRound[];
+  } | null;
+  /** What the harness did, in order: screen → fills → reviews → exit. */
+  timeline: CaseTimelineEvent[];
+  /** Market bid for the held outcome at each review — the price side of the chart. */
+  marketCurve: Array<{ ts: string; price: number; agentProb: number | null }>;
+}
+
+const trim = (s: unknown, max: number): string => {
+  const text = typeof s === "string" ? s.trim() : "";
+  return text.length > max ? `${text.slice(0, max).trimEnd()}…` : text;
+};
+
+const num = (v: unknown): number | null => (typeof v === "number" && Number.isFinite(v) ? v : null);
+const round4 = (n: number): number => Math.round(n * 10000) / 10000;
+
+interface DossierState {
+  eventId?: string;
+  framing?: { normalizedQuestion?: string; resolutionCriteria?: string };
+  round?: number;
+  status?: string;
+  provider?: string;
+  saturatedAt?: string | null;
+  marketBlind?: { enabled?: boolean; blockedCount?: number; priorSuspect?: boolean };
+  evidenceLedger?: unknown[];
+  roundHistory?: Array<Record<string, unknown>>;
+  summary?: Record<string, unknown> | null;
+}
+
+function readDossier(root: string, forecastId: string): DossierState | null {
+  const file = path.join(root, "engine", "forecasts", forecastId, "state.json");
+  if (!existsSync(file)) return null;
+  try {
+    return JSON.parse(readFileSync(file, "utf8")) as DossierState;
+  } catch {
+    return null;
+  }
+}
+
+function toSources(raw: unknown): CaseSource[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((s) => {
+      const r = s as Record<string, unknown>;
+      return {
+        url: String(r.url ?? ""),
+        title: trim(r.title, 160),
+        deltaPp: num(r.deltaPp) ?? 0,
+        explanation: trim(r.explanation, MAX_EXPLANATION_CHARS),
+        verified: r.verified === true,
+        kind: String(r.kind ?? "evidence"),
+        sourceType: String(r.sourceType ?? ""),
+        credibility: String(r.credibility ?? ""),
+        excluded: typeof r.excluded === "string" ? r.excluded : null
+      };
+    })
+    .filter((s) => s.url.length > 0)
+    .sort((a, b) => Math.abs(b.deltaPp) - Math.abs(a.deltaPp))
+    .slice(0, MAX_SOURCES_PER_ROUND);
+}
+
+function toRound(raw: Record<string, unknown>, anchor: CaseRound["anchor"]): CaseRound {
+  const why = (raw.whyChanged ?? null) as Record<string, unknown> | null;
+  const prior = num(raw.priorProb) ?? 0;
+  const post = num(raw.postProb) ?? 0;
+  return {
+    round: num(raw.round) ?? 0,
+    ts: String(raw.ts ?? ""),
+    priorProb: round4(prior),
+    postProb: round4(post),
+    netPp: num(why?.netPp) ?? Math.round((post - prior) * 10000) / 100,
+    upPp: num(why?.upPp),
+    downPp: num(why?.downPp),
+    dominantTitle: why?.dominantTitle ? trim(why.dominantTitle, 160) : null,
+    dominantUrl: typeof why?.dominantUrl === "string" ? why.dominantUrl : null,
+    newSourceCount: num(raw.newSourceCount) ?? 0,
+    confidence: String(raw.confidence ?? ""),
+    reasoning: trim(raw.reasoning, MAX_REASONING_CHARS),
+    searchQueries: Array.isArray(raw.searchQueries)
+      ? raw.searchQueries.filter((q): q is string => typeof q === "string").slice(0, 12)
+      : [],
+    sources: toSources(raw.perSourceUpdates),
+    anchor
+  };
+}
+
+/**
+ * Rounds worth showing: the opening round, the closing round, and the biggest
+ * movers in between. A 145-round dossier is mostly no-ops (the engine re-reads
+ * a quiet market three times a day); the moves are where the decision was made.
+ */
+function selectRounds(history: Array<Record<string, unknown>>): CaseRound[] {
+  if (history.length === 0) return [];
+  const first = history[0];
+  const last = history[history.length - 1];
+  const anchors = new Set<number>();
+  if (first) anchors.add(num(first.round) ?? 0);
+  if (last) anchors.add(num(last.round) ?? 0);
+  const movers = [...history]
+    .filter((r) => !anchors.has(num(r.round) ?? -1))
+    .sort((a, b) => {
+      const moveOf = (x: Record<string, unknown>): number => {
+        const why = (x.whyChanged ?? null) as Record<string, unknown> | null;
+        const net = num(why?.netPp);
+        if (net !== null) return Math.abs(net);
+        return Math.abs((num(x.postProb) ?? 0) - (num(x.priorProb) ?? 0)) * 100;
+      };
+      return moveOf(b) - moveOf(a);
+    })
+    .slice(0, Math.max(0, MAX_KEY_ROUNDS - anchors.size));
+  const picked = [
+    ...(first ? [toRound(first, "first")] : []),
+    ...movers.map((r) => toRound(r, null)),
+    ...(last && last !== first ? [toRound(last, "last")] : [])
+  ];
+  return picked.sort((a, b) => a.round - b.round);
+}
+
+function buildTimeline(events: readonly PaperLedgerEvent[], positionId: string, slug: string): CaseTimelineEvent[] {
+  const out: CaseTimelineEvent[] = [];
+  for (const e of events) {
+    const ts = String(e.ts ?? "");
+    if (!ts) continue;
+    const matchesPosition = e.positionId === positionId;
+    const matchesSlug = e.slug === slug;
+    if (e.type === "watchlist_eval" && matchesSlug) {
+      out.push({
+        ts,
+        kind: e.enter === true ? "screen_enter" : "screen_pass",
+        label: e.enter === true ? "选中建仓" : "扫描后放弃",
+        detail: trim(e.detail, 200) || null,
+        agentProb: num(e.probYes),
+        marketPrice: num(e.marketProbYes),
+        netEdgePp: num(e.edgePp)
+      });
+      continue;
+    }
+    if (!matchesPosition) continue;
+    if (e.type === "trade") {
+      const side = e.side === "buy" ? "买入" : "卖出";
+      const style = e.style === "limit" ? "限价" : "市价";
+      out.push({
+        ts,
+        kind: e.side === "buy" ? "buy" : "sell",
+        label: `${style}${side} ${(num(e.shares) ?? 0).toFixed(1)} 股 @ ${(num(e.avgPrice) ?? 0).toFixed(3)}`,
+        detail: e.reason ? String(e.reason) : null,
+        agentProb: null,
+        marketPrice: num(e.avgPrice),
+        netEdgePp: num(e.edgePp)
+      });
+      continue;
+    }
+    if (e.type === "evaluation") {
+      out.push({
+        ts,
+        kind: e.action === "sell" ? "review_sell" : "review_hold",
+        label: e.action === "sell" ? "复审：卖出" : "复审：继续持有",
+        detail: trim(e.detail, 200) || null,
+        agentProb: num(e.agentProbOutcome),
+        marketPrice: num(e.bestBid),
+        netEdgePp: num(e.netEdgePp)
+      });
+      continue;
+    }
+    if (e.type === "stop_loss_tick" || e.type === "stop_loss_pre_eval") {
+      out.push({
+        ts,
+        kind: "stop_loss",
+        label: "触发止损",
+        detail: `最优买价 ${String(e.bestBid ?? "—")}`,
+        agentProb: null,
+        marketPrice: num(e.bestBid),
+        netEdgePp: null
+      });
+      continue;
+    }
+    if (e.type === "resolution") {
+      out.push({
+        ts,
+        kind: "resolution",
+        label: `市场结算：${e.kind === "won" ? "我方获胜" : e.kind === "lost" ? "我方判负" : "作废退款"}`,
+        detail: null,
+        agentProb: null,
+        marketPrice: e.kind === "won" ? 1 : e.kind === "lost" ? 0 : 0.5,
+        netEdgePp: null
+      });
+      continue;
+    }
+    if (e.type === "evaluation_error") {
+      out.push({
+        ts,
+        kind: "error",
+        label: "评估失败（安全默认持有）",
+        detail: trim(e.error, 160) || null,
+        agentProb: null,
+        marketPrice: null,
+        netEdgePp: null
+      });
+    }
+  }
+  const sorted = out.sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0));
+  // Keep both ends when a long-held position has more reviews than the cap:
+  // the opening decisions and the exit are what a reader came for.
+  if (sorted.length <= MAX_TIMELINE_EVENTS) return sorted;
+  const head = sorted.slice(0, Math.floor(MAX_TIMELINE_EVENTS / 2));
+  const tail = sorted.slice(-Math.ceil(MAX_TIMELINE_EVENTS / 2));
+  return [...head, ...tail];
+}
+
+function buildCase(
+  episode: DecisionEpisode,
+  bucket: PaperCase["bucket"],
+  rank: number,
+  events: readonly PaperLedgerEvent[],
+  rootDir: string
+): PaperCase {
+  // The forecastId is recorded on the position's own evaluations — no need to
+  // re-derive the engine's question hash (and no risk of drifting from it).
+  const forecastId =
+    events.find((e) => e.positionId === episode.positionId && typeof e.forecastId === "string")?.forecastId ??
+    events.find((e) => e.slug === episode.slug && typeof e.forecastId === "string")?.forecastId ??
+    null;
+  const state = forecastId ? readDossier(rootDir, forecastId) : null;
+  const summary = (state?.summary ?? null) as Record<string, unknown> | null;
+  const history = Array.isArray(state?.roundHistory) ? state.roundHistory : [];
+  const beliefAll = history.flatMap((r) => {
+    const prob = num(r.postProb);
+    return prob === null ? [] : [{ round: num(r.round) ?? 0, ts: String(r.ts ?? ""), prob: round4(prob) }];
+  });
+  // Long dossiers get evenly thinned rather than truncated, so the curve keeps
+  // its shape (and its endpoints) instead of stopping halfway.
+  const stride = Math.ceil(beliefAll.length / MAX_BELIEF_POINTS);
+  const beliefCurve =
+    stride > 1
+      ? beliefAll.filter((_, i) => i % stride === 0 || i === beliefAll.length - 1)
+      : beliefAll;
+
+  const timeline = buildTimeline(events, episode.positionId, episode.slug);
+  const marketCurve = events.flatMap((e) => {
+    if (e.type !== "evaluation" || e.positionId !== episode.positionId) return [];
+    const price = num(e.bestBid);
+    return price === null ? [] : [{ ts: String(e.ts ?? ""), price, agentProb: num(e.agentProbOutcome) }];
+  });
+
+  return {
+    rank,
+    bucket,
+    positionId: episode.positionId,
+    slug: episode.slug,
+    question: episode.question,
+    side: episode.side,
+    status: episode.status,
+    openedUtc: episode.openedUtc,
+    closedUtc: episode.closedUtc,
+    pnlUsd: episode.pnlUsd,
+    entryAlphaUsd: episode.entryAlphaUsd,
+    exitAlphaUsd: episode.exitAlphaUsd,
+    entryPrice: episode.entryPrice,
+    exitPrice: episode.exitPrice,
+    benchmarkPrice: episode.benchmarkPrice,
+    benchmarkSource: episode.benchmarkSource,
+    shares: episode.shares,
+    entryEdgePp: episode.entryEdgePp,
+    exitReason: episode.exitReason,
+    dossier:
+      state && forecastId
+        ? {
+            forecastId,
+            normalizedQuestion: state.framing?.normalizedQuestion
+              ? trim(state.framing.normalizedQuestion, 400)
+              : null,
+            resolutionCriteria: state.framing?.resolutionCriteria
+              ? trim(state.framing.resolutionCriteria, 700)
+              : null,
+            rounds: num(state.round) ?? history.length,
+            evidenceCount: Array.isArray(state.evidenceLedger) ? state.evidenceLedger.length : 0,
+            status: String(state.status ?? ""),
+            saturatedAt: typeof state.saturatedAt === "string" ? state.saturatedAt : null,
+            marketBlind: state.marketBlind
+              ? {
+                  enabled: state.marketBlind.enabled === true,
+                  blockedCount: num(state.marketBlind.blockedCount) ?? 0,
+                  priorSuspect: state.marketBlind.priorSuspect === true
+                }
+              : null,
+            provider: typeof state.provider === "string" ? state.provider : null,
+            verdict: summary ? trim(summary.verdict, MAX_VERDICT_CHARS) || null : null,
+            whySentence: summary ? trim(summary.whySentence, 300) || null : null,
+            keyFactorsYes: Array.isArray(summary?.keyFactorsYes)
+              ? summary.keyFactorsYes.filter((x): x is string => typeof x === "string").slice(0, 6)
+              : [],
+            keyFactorsNo: Array.isArray(summary?.keyFactorsNo)
+              ? summary.keyFactorsNo.filter((x): x is string => typeof x === "string").slice(0, 6)
+              : [],
+            mainUncertainties: summary ? trim(summary.mainUncertainties, 600) || null : null,
+            beliefCurve,
+            keyRounds: selectRounds(history)
+          }
+        : null,
+    timeline,
+    marketCurve
+  };
+}
+
+export interface PaperCasesPayload {
+  generatedAtUtc: string;
+  /** How many of each bucket were requested. */
+  perBucket: number;
+  winners: PaperCase[];
+  losers: PaperCase[];
+}
+
+/**
+ * Pick the extremes by realised+unrealised PnL. Open positions are eligible —
+ * the book's best call is currently an open one, and excluding it would repeat
+ * exactly the survivorship problem the calibration section warns about.
+ */
+export function buildPaperCases(
+  episodes: readonly DecisionEpisode[],
+  events: readonly PaperLedgerEvent[],
+  rootDir: string,
+  perBucket = 2,
+  nowIso: string = new Date().toISOString()
+): PaperCasesPayload {
+  const ranked = episodes
+    .filter((e) => e.pnlUsd !== null)
+    .sort((a, b) => (b.pnlUsd ?? 0) - (a.pnlUsd ?? 0));
+  const winners = ranked.slice(0, perBucket).map((e, i) => buildCase(e, "winner", i + 1, events, rootDir));
+  const losers = ranked
+    .slice(-perBucket)
+    .reverse()
+    .map((e, i) => buildCase(e, "loser", i + 1, events, rootDir));
+  return { generatedAtUtc: nowIso, perBucket, winners, losers };
+}

--- a/services/forecast-api/src/paper-decisions.test.ts
+++ b/services/forecast-api/src/paper-decisions.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import { buildDecisionQuality, collectEntryContext, replayEpisodes } from "./paper-decisions";
+import type { PaperLedgerEvent } from "./paper-ledger";
+
+const noInputs = {
+  livePrices: new Map<string, number>(),
+  markPrices: new Map<string, number>(),
+  questions: new Map<string, string>(),
+  benchmarkAsOfUtc: "2026-08-20T12:00:00.000Z"
+};
+
+const buy = (over: Partial<PaperLedgerEvent> = {}): PaperLedgerEvent => ({
+  ts: "2026-07-01T00:00:00.000Z",
+  type: "trade",
+  side: "buy",
+  style: "market",
+  positionId: "mkt:1",
+  slug: "mkt",
+  outcome: "No",
+  shares: 1000,
+  avgPrice: 0.4,
+  feeUsd: 0,
+  reason: "watchlist_entry",
+  ...over
+});
+
+const sell = (over: Partial<PaperLedgerEvent> = {}): PaperLedgerEvent => ({
+  ts: "2026-07-05T00:00:00.000Z",
+  type: "trade",
+  side: "sell",
+  style: "market",
+  positionId: "mkt:1",
+  slug: "mkt",
+  shares: 1000,
+  avgPrice: 0.5,
+  feeUsd: 0,
+  reason: "negative_edge",
+  ...over
+});
+
+describe("replayEpisodes", () => {
+  it("closes an episode when the shares are fully sold", () => {
+    const { closed, openTail } = replayEpisodes([buy(), sell()]);
+    expect(openTail.size).toBe(0);
+    expect(closed).toHaveLength(1);
+    expect(closed[0]?.entryPrice).toBeCloseTo(0.4);
+    expect(closed[0]?.exitPrice).toBeCloseTo(0.5);
+    expect(closed[0]?.proceedsUsd).toBeCloseTo(500);
+  });
+
+  it("settles the remainder on a resolution event", () => {
+    const { closed } = replayEpisodes([
+      buy(),
+      { ts: "2026-07-09T00:00:00.000Z", type: "resolution", positionId: "mkt:1", slug: "mkt", kind: "won" }
+    ]);
+    expect(closed[0]?.settledPerShare).toBe(1);
+    expect(closed[0]?.exitReason).toBe("settled_won");
+    expect(closed[0]?.proceedsUsd).toBeCloseTo(1000);
+  });
+
+  it("re-entry under the same position id yields two separate episodes", () => {
+    const { closed } = replayEpisodes([
+      buy(),
+      sell({ reason: "stop_loss", avgPrice: 0.26 }),
+      buy({ ts: "2026-07-06T00:00:00.000Z", avgPrice: 0.3 }),
+      sell({ ts: "2026-07-20T00:00:00.000Z", avgPrice: 0.55 })
+    ]);
+    expect(closed).toHaveLength(2);
+    expect(closed[0]?.exitReason).toBe("stop_loss");
+    expect(closed[1]?.entryPrice).toBeCloseTo(0.3);
+  });
+
+  it("keeps a partially sold position open with a pro-rated cost basis", () => {
+    const { closed, openTail } = replayEpisodes([buy({ feeUsd: 10 }), sell({ shares: 400 })]);
+    expect(closed).toHaveLength(0);
+    const rest = openTail.get("mkt:1");
+    expect(rest?.shares).toBeCloseTo(600);
+    // 60% of (400 notional + 10 fee)
+    expect(rest?.costUsd).toBeCloseTo(246);
+  });
+});
+
+describe("buildDecisionQuality", () => {
+  it("splits pnl into entry + exit against one benchmark, exactly", () => {
+    const events = [buy(), sell({ avgPrice: 0.5, feeUsd: 5 })];
+    const dq = buildDecisionQuality(
+      events,
+      { ...noInputs, livePrices: new Map([["mkt:1", 0.9]]) },
+      495 - 400
+    );
+    const ep = dq.episodes[0];
+    expect(ep?.benchmarkPrice).toBe(0.9);
+    // buy-and-hold to 0.90 would have made 1000*0.9 - 400 = +500
+    expect(ep?.entryAlphaUsd).toBeCloseTo(500);
+    // selling at 0.50 instead gave up 495 - 900 = -405
+    expect(ep?.exitAlphaUsd).toBeCloseTo(-405);
+    expect(ep?.pnlUsd).toBeCloseTo(95);
+    expect((ep?.entryAlphaUsd ?? 0) + (ep?.exitAlphaUsd ?? 0)).toBeCloseTo(ep?.pnlUsd ?? 0);
+    expect(dq.reconciliation.deltaUsd).toBeCloseTo(0);
+  });
+
+  it("attributes an open position entirely to the entry decision", () => {
+    const dq = buildDecisionQuality(
+      [buy({ feeUsd: 20 })],
+      { ...noInputs, markPrices: new Map([["mkt:1", 0.65]]) },
+      0
+    );
+    const ep = dq.episodes[0];
+    expect(ep?.status).toBe("open");
+    expect(ep?.exitAlphaUsd).toBe(0);
+    // 1000 * 0.65 - (400 + 20)
+    expect(ep?.entryAlphaUsd).toBeCloseTo(230);
+    expect(dq.entry.openUsd).toBeCloseTo(230);
+    expect(dq.entry.closedUsd).toBe(0);
+  });
+
+  it("prefers a settlement over any observed price as the benchmark", () => {
+    const dq = buildDecisionQuality(
+      [
+        buy(),
+        sell({ avgPrice: 0.26, reason: "stop_loss" }),
+        buy({ ts: "2026-07-06T00:00:00.000Z" }),
+        { ts: "2026-07-09T00:00:00.000Z", type: "resolution", positionId: "mkt:1", slug: "mkt", kind: "lost" }
+      ],
+      { ...noInputs, livePrices: new Map([["mkt:1", 0.9]]) },
+      -140
+    );
+    const settled = dq.episodes.find((e) => e.exitReason === "settled_lost");
+    expect(settled?.benchmarkSource).toBe("settled");
+    expect(settled?.benchmarkPrice).toBe(0);
+    // The stop-loss episode still marks against the live price it was sold into.
+    const stopped = dq.episodes.find((e) => e.exitReason === "stop_loss");
+    expect(stopped?.benchmarkPrice).toBe(0.9);
+  });
+
+  it("flags an episode as unscored for exit quality when no benchmark exists", () => {
+    const dq = buildDecisionQuality([buy(), sell({ avgPrice: 0.5 })], noInputs, 100);
+    expect(dq.episodes[0]?.benchmarkSource).toBe("exit");
+    expect(dq.episodes[0]?.exitAlphaUsd).toBeCloseTo(0);
+    expect(dq.exit.unscored).toBe(1);
+  });
+
+  it("surfaces a replay mismatch instead of hiding it", () => {
+    const dq = buildDecisionQuality([buy(), sell({ avgPrice: 0.5 })], noInputs, 999);
+    expect(dq.reconciliation.deltaUsd).toBeCloseTo(100 - 999);
+  });
+});
+
+describe("collectEntryContext", () => {
+  it("attributes the preceding watchlist screen and the first review to the buy", () => {
+    const ctx = collectEntryContext([
+      {
+        ts: "2026-06-30T00:00:00.000Z",
+        type: "watchlist_eval",
+        slug: "mkt",
+        probYes: 0.12,
+        marketProbYes: 0.35,
+        edgePp: 23,
+        enter: true
+      },
+      buy(),
+      {
+        ts: "2026-07-02T00:00:00.000Z",
+        type: "evaluation",
+        positionId: "mkt:1",
+        engineRounds: 4,
+        evidenceCount: 17
+      },
+      {
+        ts: "2026-07-03T00:00:00.000Z",
+        type: "evaluation",
+        positionId: "mkt:1",
+        engineRounds: 9,
+        evidenceCount: 30
+      }
+    ]);
+    const entry = ctx.get("mkt:1");
+    // The position is NO, so both probabilities are reported for the held side.
+    expect(entry?.agentProb).toBeCloseTo(0.88);
+    expect(entry?.marketProb).toBeCloseTo(0.65);
+    expect(entry?.roundsAtEntry).toBe(4);
+    expect(entry?.evidenceAtEntry).toBe(17);
+    expect(entry?.reviewCount).toBe(2);
+  });
+});

--- a/services/forecast-api/src/paper-decisions.ts
+++ b/services/forecast-api/src/paper-decisions.ts
@@ -1,0 +1,417 @@
+// Decision-quality decomposition for the paper book.
+//
+// The agent makes exactly two decisions per position: ENTER (which side, at
+// what price) and EXIT (whether to sell before the market resolves). This
+// module splits every episode's realised/unrealised PnL into those two
+// contributions against one shared counterfactual — "what the position is
+// worth right now / at settlement":
+//
+//   benchmark      = settlement value (1 / 0 / 0.5) once resolved, else the
+//                    latest observed price for the held outcome
+//   entryAlphaUsd  = shares × benchmark − costUsd          (the buy-and-hold result)
+//   exitAlphaUsd   = proceedsUsd − shares × benchmark      (what selling early added)
+//   pnlUsd         = entryAlphaUsd + exitAlphaUsd          (exact identity)
+//
+// Open positions have no exit yet, so their exit contribution is 0 and their
+// entry contribution is the current unrealised PnL. This is why the split is
+// fairer than the old exit-only α: a book whose winners are still open shows
+// its entry skill instead of only its (negative) early-selling record.
+//
+// Everything is derived from the ledger + portfolio so the two halves always
+// reconcile to the book's own PnL; the reflection report is consulted only for
+// live prices of positions that were sold before their market resolved.
+
+import type { PaperLedgerEvent } from "./paper-ledger";
+import { outcomeIndexOf } from "./paper-ledger";
+
+export type BenchmarkSource = "settled" | "live" | "mark" | "exit";
+
+export interface DecisionEpisode {
+  positionId: string;
+  slug: string;
+  question: string;
+  side: string;
+  status: "open" | "closed";
+  openedUtc: string;
+  closedUtc: string | null;
+  holdDays: number | null;
+  shares: number;
+  entryPrice: number;
+  /** Notional + entry fees — the true cost basis the two alphas are measured against. */
+  costUsd: number;
+  exitPrice: number | null;
+  proceedsUsd: number | null;
+  benchmarkPrice: number | null;
+  benchmarkSource: BenchmarkSource;
+  entryAlphaUsd: number | null;
+  exitAlphaUsd: number | null;
+  pnlUsd: number | null;
+  exitReason: string | null;
+  exitStyle: string | null;
+  /** Entry-time context from the watchlist evaluation that opened the position. */
+  entryEdgePp: number | null;
+  agentProbAtEntry: number | null;
+  marketProbAtEntry: number | null;
+  /** Review depth: engine rounds / sources behind the first review after entry. */
+  roundsAtEntry: number | null;
+  evidenceAtEntry: number | null;
+  reviewCount: number;
+}
+
+export interface DecisionQuality {
+  /** Benchmark prices are as of this timestamp (latest reflection / last review). */
+  benchmarkAsOfUtc: string | null;
+  entry: { totalUsd: number; openUsd: number; closedUsd: number; scored: number; unscored: number };
+  exit: { totalUsd: number; scored: number; unscored: number };
+  /**
+   * Closed episodes must sum to the book's own realised PnL. Both sides are
+   * computed independently (replay here, running total in the portfolio), so a
+   * non-zero delta means the episode replay is wrong — surface it, never hide it.
+   */
+  reconciliation: { closedPnlUsd: number; realizedPnlUsd: number; deltaUsd: number };
+  episodes: DecisionEpisode[];
+}
+
+const round2 = (n: number): number => Math.round(n * 100) / 100;
+
+const SETTLEMENT_PER_SHARE: Record<string, number> = { won: 1, lost: 0, voided: 0.5 };
+
+/** Raw episode as replayed from the ledger, before benchmarks are applied. */
+export interface RawEpisode {
+  positionId: string;
+  slug: string;
+  question: string;
+  side: string;
+  openedUtc: string;
+  closedUtc: string | null;
+  shares: number;
+  entryPrice: number;
+  costUsd: number;
+  exitPrice: number | null;
+  proceedsUsd: number | null;
+  settledPerShare: number | null;
+  exitReason: string | null;
+  exitStyle: string | null;
+}
+
+/**
+ * Replay buys/sells/resolutions per positionId into complete episodes. A
+ * position can round-trip more than once under the same id (re-entry after a
+ * stop-loss), so episodes are emitted in close order and the still-open tail
+ * is returned separately by the caller via `openTail`.
+ */
+export function replayEpisodes(events: readonly PaperLedgerEvent[]): {
+  closed: RawEpisode[];
+  openTail: Map<string, RawEpisode>;
+} {
+  interface Acc {
+    slug: string;
+    question: string;
+    side: string;
+    openedUtc: string;
+    shares: number;
+    notionalUsd: number;
+    buyFeesUsd: number;
+    proceedsUsd: number;
+    soldShares: number;
+    lastSellUtc: string;
+    lastReason: string;
+    styles: Set<string>;
+  }
+  const open = new Map<string, Acc>();
+  const closed: RawEpisode[] = [];
+
+  const emit = (id: string, acc: Acc, closedUtc: string, settledPerShare: number | null, reason: string): void => {
+    const soldShares = acc.soldShares + (settledPerShare === null ? 0 : acc.shares);
+    const proceeds = acc.proceedsUsd + (settledPerShare === null ? 0 : acc.shares * settledPerShare);
+    if (!(soldShares > 0)) return;
+    closed.push({
+      positionId: id,
+      slug: acc.slug,
+      question: acc.question,
+      side: acc.side,
+      openedUtc: acc.openedUtc,
+      closedUtc,
+      shares: round2(soldShares),
+      entryPrice: acc.notionalUsd / soldShares,
+      costUsd: round2(acc.notionalUsd + acc.buyFeesUsd),
+      exitPrice: proceeds / soldShares,
+      proceedsUsd: round2(proceeds),
+      settledPerShare,
+      exitReason: reason,
+      exitStyle: [...acc.styles].sort().join("+") || null
+    });
+  };
+
+  for (const e of events) {
+    const id = String(e.positionId ?? "");
+    if (!id) continue;
+    if (e.type === "resolution") {
+      const acc = open.get(id);
+      const perShare = SETTLEMENT_PER_SHARE[String(e.kind ?? "")];
+      if (!acc || perShare === undefined || acc.shares <= 0.01) {
+        open.delete(id);
+        continue;
+      }
+      emit(id, acc, String(e.ts ?? ""), perShare, `settled_${String(e.kind)}`);
+      open.delete(id);
+      continue;
+    }
+    if (e.type !== "trade") continue;
+    const shares = Number(e.shares ?? 0);
+    const price = Number(e.avgPrice ?? 0);
+    if (!(shares > 0)) continue;
+    if (e.side === "buy") {
+      const acc = open.get(id) ?? {
+        slug: String(e.slug ?? ""),
+        question: "",
+        side: String(e.outcome ?? ""),
+        openedUtc: String(e.ts ?? ""),
+        shares: 0,
+        notionalUsd: 0,
+        buyFeesUsd: 0,
+        proceedsUsd: 0,
+        soldShares: 0,
+        lastSellUtc: "",
+        lastReason: "",
+        styles: new Set<string>()
+      };
+      open.set(id, {
+        ...acc,
+        shares: acc.shares + shares,
+        notionalUsd: acc.notionalUsd + shares * price,
+        buyFeesUsd: acc.buyFeesUsd + Number(e.feeUsd ?? 0)
+      });
+      continue;
+    }
+    const acc = open.get(id);
+    if (!acc) continue;
+    const styles = new Set(acc.styles);
+    styles.add(String(e.style ?? "market"));
+    const next: Acc = {
+      ...acc,
+      shares: acc.shares - shares,
+      proceedsUsd: acc.proceedsUsd + shares * price - Number(e.feeUsd ?? 0),
+      soldShares: acc.soldShares + shares,
+      lastSellUtc: String(e.ts ?? ""),
+      lastReason: String(e.reason ?? "").split(":")[0] ?? "",
+      styles
+    };
+    if (next.shares <= 0.01) {
+      emit(id, next, next.lastSellUtc, null, next.lastReason);
+      open.delete(id);
+    } else {
+      open.set(id, next);
+    }
+  }
+
+  const openTail = new Map<string, RawEpisode>();
+  for (const [id, acc] of open) {
+    if (!(acc.shares > 0.01)) continue;
+    const heldShares = acc.shares;
+    openTail.set(id, {
+      positionId: id,
+      slug: acc.slug,
+      question: acc.question,
+      side: acc.side,
+      openedUtc: acc.openedUtc,
+      closedUtc: null,
+      shares: round2(heldShares),
+      // Cost basis of the REMAINING shares only: a partially-sold position
+      // carries its already-realised leg in the closed episodes, not here.
+      entryPrice: acc.notionalUsd / (heldShares + acc.soldShares),
+      costUsd: round2(
+        (acc.notionalUsd + acc.buyFeesUsd) * (heldShares / (heldShares + acc.soldShares))
+      ),
+      exitPrice: null,
+      proceedsUsd: null,
+      settledPerShare: null,
+      exitReason: null,
+      exitStyle: null
+    });
+  }
+  return { closed, openTail };
+}
+
+export interface EntryContext {
+  edgePp: number | null;
+  agentProb: number | null;
+  marketProb: number | null;
+  roundsAtEntry: number | null;
+  evidenceAtEntry: number | null;
+  reviewCount: number;
+}
+
+/**
+ * Entry-time context per position: the watchlist evaluation immediately before
+ * the buy (the decision that opened it) plus the depth of the first review
+ * after it. Keyed by positionId; re-entries reuse the latest matching pair.
+ */
+export function collectEntryContext(events: readonly PaperLedgerEvent[]): Map<string, EntryContext> {
+  const out = new Map<string, EntryContext>();
+  // Last watchlist eval seen per slug — the buy that follows it is its result.
+  const lastWatchlist = new Map<string, PaperLedgerEvent>();
+  const reviewCounts = new Map<string, number>();
+  const firstReviewAfterBuy = new Map<string, PaperLedgerEvent>();
+  const awaitingReview = new Set<string>();
+
+  for (const e of events) {
+    if (e.type === "watchlist_eval" && typeof e.slug === "string") {
+      lastWatchlist.set(e.slug, e);
+      continue;
+    }
+    if (e.type === "trade" && e.side === "buy" && typeof e.positionId === "string") {
+      const slug = String(e.slug ?? "");
+      const wl = lastWatchlist.get(slug);
+      const idx = outcomeIndexOf(e.positionId);
+      const probYes = typeof wl?.probYes === "number" ? wl.probYes : null;
+      const marketYes = typeof wl?.marketProbYes === "number" ? wl.marketProbYes : null;
+      out.set(e.positionId, {
+        edgePp: typeof e.edgePp === "number" ? e.edgePp : typeof wl?.edgePp === "number" ? wl.edgePp : null,
+        // Probabilities are reported for the HELD outcome, matching the way
+        // the position's own reviews report agentProbOutcome.
+        agentProb: probYes === null ? null : idx === 1 ? 1 - probYes : probYes,
+        marketProb: marketYes === null ? null : idx === 1 ? 1 - marketYes : marketYes,
+        roundsAtEntry: null,
+        evidenceAtEntry: null,
+        reviewCount: 0
+      });
+      awaitingReview.add(e.positionId);
+      continue;
+    }
+    if (e.type === "evaluation" && typeof e.positionId === "string") {
+      reviewCounts.set(e.positionId, (reviewCounts.get(e.positionId) ?? 0) + 1);
+      if (awaitingReview.has(e.positionId)) {
+        firstReviewAfterBuy.set(e.positionId, e);
+        awaitingReview.delete(e.positionId);
+      }
+    }
+  }
+
+  for (const [id, ctx] of out) {
+    const first = firstReviewAfterBuy.get(id);
+    out.set(id, {
+      ...ctx,
+      roundsAtEntry: typeof first?.engineRounds === "number" ? first.engineRounds : null,
+      evidenceAtEntry: typeof first?.evidenceCount === "number" ? first.evidenceCount : null,
+      reviewCount: reviewCounts.get(id) ?? 0
+    });
+  }
+  return out;
+}
+
+export interface BenchmarkInputs {
+  /** positionId → last live price for the held outcome (reflection exit rows). */
+  livePrices: Map<string, number>;
+  /** positionId → current bid mark from the portfolio's last review. */
+  markPrices: Map<string, number>;
+  /** slug/positionId → display question text. */
+  questions: Map<string, string>;
+  benchmarkAsOfUtc: string | null;
+}
+
+function benchmarkFor(
+  ep: RawEpisode,
+  inputs: BenchmarkInputs
+): { price: number | null; source: BenchmarkSource } {
+  if (ep.settledPerShare !== null) return { price: ep.settledPerShare, source: "settled" };
+  const mark = inputs.markPrices.get(ep.positionId);
+  if (mark !== undefined) return { price: mark, source: "mark" };
+  const live = inputs.livePrices.get(ep.positionId);
+  if (live !== undefined) return { price: live, source: "live" };
+  // No observable price: fall back to the exit price so the episode still
+  // reconciles (exit α = 0, all of the PnL attributed to the entry) and flag
+  // the substitution so the UI can mark the row as unscored for exit quality.
+  return ep.exitPrice === null ? { price: null, source: "exit" } : { price: ep.exitPrice, source: "exit" };
+}
+
+export function buildDecisionQuality(
+  events: readonly PaperLedgerEvent[],
+  inputs: BenchmarkInputs,
+  realizedPnlUsd: number
+): DecisionQuality {
+  const { closed, openTail } = replayEpisodes(events);
+  const entryCtx = collectEntryContext(events);
+  const raw: RawEpisode[] = [...closed, ...openTail.values()];
+
+  const episodes: DecisionEpisode[] = raw.map((ep) => {
+    const { price, source } = benchmarkFor(ep, inputs);
+    const ctx = entryCtx.get(ep.positionId);
+    const isOpen = ep.closedUtc === null;
+    const entryAlpha = price === null ? null : round2(ep.shares * price - ep.costUsd);
+    const exitAlpha =
+      isOpen || price === null || ep.proceedsUsd === null ? (isOpen ? 0 : null) : round2(ep.proceedsUsd - ep.shares * price);
+    const pnl =
+      isOpen
+        ? entryAlpha
+        : ep.proceedsUsd === null
+          ? null
+          : round2(ep.proceedsUsd - ep.costUsd);
+    const closedMs = ep.closedUtc ? Date.parse(ep.closedUtc) : Date.parse(inputs.benchmarkAsOfUtc ?? "");
+    const openedMs = Date.parse(ep.openedUtc);
+    return {
+      positionId: ep.positionId,
+      slug: ep.slug,
+      question: inputs.questions.get(ep.positionId) ?? inputs.questions.get(ep.slug) ?? (ep.question || ep.slug),
+      side: ep.side,
+      status: isOpen ? "open" : "closed",
+      openedUtc: ep.openedUtc,
+      closedUtc: ep.closedUtc,
+      holdDays:
+        Number.isFinite(closedMs) && Number.isFinite(openedMs)
+          ? Math.round(((closedMs - openedMs) / 86_400_000) * 10) / 10
+          : null,
+      shares: ep.shares,
+      entryPrice: Math.round(ep.entryPrice * 10000) / 10000,
+      costUsd: ep.costUsd,
+      exitPrice: ep.exitPrice === null ? null : Math.round(ep.exitPrice * 10000) / 10000,
+      proceedsUsd: ep.proceedsUsd,
+      benchmarkPrice: price === null ? null : Math.round(price * 10000) / 10000,
+      benchmarkSource: source,
+      entryAlphaUsd: entryAlpha,
+      exitAlphaUsd: exitAlpha,
+      pnlUsd: pnl,
+      exitReason: ep.exitReason,
+      exitStyle: ep.exitStyle,
+      entryEdgePp: ctx?.edgePp ?? null,
+      agentProbAtEntry: ctx?.agentProb ?? null,
+      marketProbAtEntry: ctx?.marketProb ?? null,
+      roundsAtEntry: ctx?.roundsAtEntry ?? null,
+      evidenceAtEntry: ctx?.evidenceAtEntry ?? null,
+      reviewCount: ctx?.reviewCount ?? 0
+    };
+  });
+
+  episodes.sort((a, b) => (a.openedUtc < b.openedUtc ? 1 : a.openedUtc > b.openedUtc ? -1 : 0));
+
+  const sum = (xs: Array<number | null>): number => round2(xs.reduce<number>((s, x) => s + (x ?? 0), 0));
+  const entryVals = episodes.map((e) => e.entryAlphaUsd);
+  const openEntry = episodes.filter((e) => e.status === "open").map((e) => e.entryAlphaUsd);
+  const closedEntry = episodes.filter((e) => e.status === "closed").map((e) => e.entryAlphaUsd);
+  const exitVals = episodes.filter((e) => e.status === "closed").map((e) => e.exitAlphaUsd);
+  const entryTotal = sum(entryVals);
+  const exitTotal = sum(exitVals);
+  const closedPnl = sum(episodes.filter((e) => e.status === "closed").map((e) => e.pnlUsd));
+
+  return {
+    benchmarkAsOfUtc: inputs.benchmarkAsOfUtc,
+    entry: {
+      totalUsd: entryTotal,
+      openUsd: sum(openEntry),
+      closedUsd: sum(closedEntry),
+      scored: entryVals.filter((v) => v !== null).length,
+      unscored: entryVals.filter((v) => v === null).length
+    },
+    exit: {
+      totalUsd: exitTotal,
+      scored: episodes.filter((e) => e.status === "closed" && e.benchmarkSource !== "exit").length,
+      unscored: episodes.filter((e) => e.status === "closed" && e.benchmarkSource === "exit").length
+    },
+    reconciliation: {
+      closedPnlUsd: closedPnl,
+      realizedPnlUsd: round2(realizedPnlUsd),
+      deltaUsd: round2(closedPnl - realizedPnlUsd)
+    },
+    episodes
+  };
+}

--- a/services/forecast-api/src/paper-ledger.ts
+++ b/services/forecast-api/src/paper-ledger.ts
@@ -1,0 +1,65 @@
+// Shared reading + typing of the paper-agent's append-only ledger. The agent
+// writes one JSON object per line (services/paper-agent/src/store.ts); every
+// consumer here treats unknown event types as inert, so a new event kind on
+// the agent side can never break the review endpoints.
+
+import { existsSync, readFileSync } from "node:fs";
+
+export interface PaperLedgerEvent {
+  ts?: string;
+  type?: string;
+  positionId?: string;
+  slug?: string;
+  outcome?: string;
+  outcomeIndex?: number;
+  side?: "buy" | "sell" | string;
+  style?: string;
+  shares?: number;
+  avgPrice?: number;
+  feeUsd?: number;
+  reason?: string;
+  detail?: string;
+  action?: string;
+  kind?: string;
+  edgePp?: number;
+  netEdgePp?: number;
+  probYes?: number;
+  marketProbYes?: number;
+  agentProbOutcome?: number;
+  bestBid?: number;
+  forecastId?: string;
+  engineRounds?: number;
+  evidenceCount?: number;
+  saturatedAt?: "floor" | "ceil" | null;
+  contaminated?: boolean;
+  saturatedHold?: boolean;
+  enter?: boolean;
+  error?: string;
+  [key: string]: unknown;
+}
+
+export function readLedger(file: string): PaperLedgerEvent[] {
+  if (!existsSync(file)) return [];
+  return readFileSync(file, "utf8")
+    .split("\n")
+    .filter((l) => l.trim().length > 0)
+    .flatMap((l) => {
+      try {
+        return [JSON.parse(l) as PaperLedgerEvent];
+      } catch {
+        return [];
+      }
+    });
+}
+
+/** Position ids are "<slug>:<outcomeIndex>" — 0 = YES, 1 = NO. */
+export function outcomeIndexOf(positionId: string): number | null {
+  const suffix = positionId.split(":").pop();
+  const idx = Number(suffix);
+  return suffix !== undefined && Number.isInteger(idx) && idx >= 0 ? idx : null;
+}
+
+export function slugOfPositionId(positionId: string): string {
+  const parts = positionId.split(":");
+  return parts.slice(0, -1).join(":") || positionId;
+}

--- a/services/forecast-api/src/paper-snapshot.ts
+++ b/services/forecast-api/src/paper-snapshot.ts
@@ -11,6 +11,9 @@
 
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
+import { buildPaperCases, type PaperCasesPayload } from "./paper-cases";
+import { buildDecisionQuality, type DecisionQuality } from "./paper-decisions";
+import { readLedger, type PaperLedgerEvent } from "./paper-ledger";
 import { repoRoot } from "./repo";
 
 // The 2026-07-03 book-lock race dropped this buy fill from the portfolio
@@ -96,8 +99,48 @@ export interface PaperSnapshotPayload {
     agentScore: number | null;
     marketScore: number | null;
     skillScore: number | null;
-    rows: Array<{ question: string; agentProb: number; marketProb: number; happened: boolean; resolvedUtc: string }>;
+    rows: Array<{
+      question: string;
+      agentProb: number;
+      marketProb: number;
+      happened: boolean;
+      resolvedUtc: string;
+      horizonDays: number | null;
+    }>;
+    /**
+     * Fairness views written by the daily reflection (services/paper-agent).
+     * Null on books whose latest report predates them.
+     */
+    horizon: {
+      atEntry: BrierBlockView | null;
+      atLast: BrierBlockView | null;
+      buckets: Array<BrierBlockView & { label: string; minDays: number; maxDays: number | null }>;
+      weighted: { exponent: number; skill: number | null; n: number } | null;
+    } | null;
+    clusters: {
+      effectiveN: number;
+      rows: Array<{ eventSlug: string; label: string; n: number; skill: number | null }>;
+    } | null;
+    pending: Array<{
+      question: string;
+      slug: string;
+      side: string | null;
+      agentProb: number;
+      marketProb: number;
+      horizonDays: number | null;
+      unrealizedUsd: number | null;
+    }>;
   };
+  /** Entry-vs-exit contribution split; null when the ledger has no episodes. */
+  decisionQuality: DecisionQuality | null;
+}
+
+export interface BrierBlockView {
+  n: number;
+  brierAgent: number | null;
+  brierMarket: number | null;
+  skill: number | null;
+  medianHorizonDays: number | null;
 }
 
 const round2 = (n: number): number => Math.round(n * 100) / 100;
@@ -186,20 +229,6 @@ function readJson(file: string): Record<string, unknown> | null {
   } catch {
     return null;
   }
-}
-
-function readLedger(file: string): Array<Record<string, unknown>> {
-  if (!existsSync(file)) return [];
-  return readFileSync(file, "utf8")
-    .split("\n")
-    .filter((l) => l.trim().length > 0)
-    .flatMap((l) => {
-      try {
-        return [JSON.parse(l) as Record<string, unknown>];
-      } catch {
-        return [];
-      }
-    });
 }
 
 function isDroppedFill(e: Record<string, unknown>): boolean {
@@ -333,6 +362,7 @@ interface ReflectionLite {
   generatedAtUtc?: string;
   exitAlphaTotalUsd?: number | null;
   exits?: Array<Record<string, unknown>>;
+  positions?: Array<Record<string, unknown>>;
   calibration?: Record<string, unknown>;
   hybrid?: Record<string, unknown>;
 }
@@ -397,6 +427,64 @@ export function buildPaperSnapshot(rootDir: string = paperRoot()): PaperSnapshot
   const calRows = Array.isArray(calibration.rows) ? (calibration.rows as Array<Record<string, unknown>>) : [];
   const exits = Array.isArray(reflection?.exits) ? (reflection?.exits as Array<Record<string, unknown>>) : [];
 
+  // Decision-quality split. Benchmarks come from the same two places the rest
+  // of the page uses: the portfolio's live marks for open positions and the
+  // reflection's hold-counterfactual prices for positions already sold.
+  const markPrices = new Map<string, number>();
+  for (const p of positions) {
+    const lastEval = (p.lastEval ?? null) as Record<string, unknown> | null;
+    const id = String(p.id ?? "");
+    if (id && typeof lastEval?.mark === "number") markPrices.set(id, lastEval.mark);
+  }
+  const livePrices = new Map<string, number>();
+  for (const e of exits) {
+    const id = String(e.positionId ?? "");
+    if (id && typeof e.priceNow === "number") livePrices.set(id, e.priceNow);
+  }
+  const questions = new Map<string, string>();
+  for (const p of positions) {
+    const id = String(p.id ?? "");
+    const q = String(p.question ?? "");
+    if (id && q) questions.set(id, q);
+    if (p.slug && q) questions.set(String(p.slug), q);
+  }
+  for (const e of exits) {
+    const id = String(e.positionId ?? "");
+    const q = String(e.question ?? "");
+    if (id && q && !questions.has(id)) questions.set(id, q);
+  }
+  // Positions that settled without ever being sold have no exit episode, so
+  // their question text comes from the reflection's own position snapshot (and
+  // from its pending-calibration rows, which carry slug + question together).
+  for (const p of reflection?.positions ?? []) {
+    const id = String(p.positionId ?? "");
+    const q = String(p.question ?? "");
+    if (id && q && !questions.has(id)) questions.set(id, q);
+  }
+  const pendingRows = Array.isArray(calibration.pending) ? (calibration.pending as Array<Record<string, unknown>>) : [];
+  for (const r of pendingRows) {
+    const slug = String(r.slug ?? "");
+    const q = String(r.label ?? "");
+    if (slug && q && !questions.has(slug)) questions.set(slug, q);
+  }
+  const decisionQuality = buildDecisionQuality(
+    // The FULL ledger (minus the dropped fill), not just fills: entry context
+    // comes from the watchlist_eval that opened each position and the first
+    // review after it.
+    ledger.filter((e) => !isDroppedFill(e)),
+    {
+      livePrices,
+      markPrices,
+      questions,
+      benchmarkAsOfUtc: reflection?.generatedAtUtc ?? null
+    },
+    // Reconcile the CLOSED half against the book's own realized PnL — the one
+    // number both paths compute independently, so a replay bug shows up as a
+    // non-zero delta. (The open half cannot be reconciled the same way: the
+    // book's unrealized figure excludes entry fees, the decomposition doesn't.)
+    Number(portfolio.realizedPnlUsd ?? 0)
+  );
+
   return {
     generatedAtUtc: new Date().toISOString(),
     config: readPaperConfigView(),
@@ -457,10 +545,99 @@ export function buildPaperSnapshot(rootDir: string = paperRoot()): PaperSnapshot
         agentProb: Number(r.agentProb ?? 0),
         marketProb: Number(r.marketProb ?? 0),
         happened: r.outcome === 1,
-        resolvedUtc: typeof r.ts === "string" ? r.ts.slice(0, 10) : ""
-      }))
-    }
+        resolvedUtc: typeof r.ts === "string" ? r.ts.slice(0, 10) : "",
+        horizonDays: typeof r.horizonDays === "number" ? r.horizonDays : null
+      })),
+      horizon: readHorizonViews(calibration.horizon),
+      clusters: readClusters(calibration.clusters),
+      pending: readPending(calibration.pending)
+    },
+    decisionQuality: decisionQuality.episodes.length > 0 ? decisionQuality : null
   };
+}
+
+const numOrNull = (v: unknown): number | null => (typeof v === "number" && Number.isFinite(v) ? v : null);
+
+function readBrierBlock(raw: unknown): BrierBlockView | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const r = raw as Record<string, unknown>;
+  const n = numOrNull(r.n);
+  if (n === null) return null;
+  return {
+    n,
+    brierAgent: numOrNull(r.brierAgent),
+    brierMarket: numOrNull(r.brierMarket),
+    skill: numOrNull(r.skill),
+    medianHorizonDays: numOrNull(r.medianHorizonDays)
+  };
+}
+
+function readHorizonViews(raw: unknown): PaperSnapshotPayload["brier"]["horizon"] {
+  if (typeof raw !== "object" || raw === null) return null;
+  const r = raw as Record<string, unknown>;
+  const bucketsRaw = Array.isArray(r.buckets) ? r.buckets : [];
+  const weightedRaw = (typeof r.weighted === "object" && r.weighted !== null ? r.weighted : null) as Record<
+    string,
+    unknown
+  > | null;
+  return {
+    atEntry: readBrierBlock(r.atEntry),
+    atLast: readBrierBlock(r.atLast),
+    buckets: bucketsRaw.flatMap((b) => {
+      const block = readBrierBlock(b);
+      if (!block) return [];
+      const rec = b as Record<string, unknown>;
+      return [
+        {
+          ...block,
+          label: String(rec.label ?? ""),
+          minDays: numOrNull(rec.minDays) ?? 0,
+          maxDays: numOrNull(rec.maxDays)
+        }
+      ];
+    }),
+    weighted: weightedRaw
+      ? {
+          exponent: numOrNull(weightedRaw.exponent) ?? 1.5,
+          skill: numOrNull(weightedRaw.skill),
+          n: numOrNull(weightedRaw.n) ?? 0
+        }
+      : null
+  };
+}
+
+function readClusters(raw: unknown): PaperSnapshotPayload["brier"]["clusters"] {
+  if (typeof raw !== "object" || raw === null) return null;
+  const r = raw as Record<string, unknown>;
+  const rows = Array.isArray(r.rows) ? r.rows : [];
+  return {
+    effectiveN: numOrNull(r.effectiveN) ?? rows.length,
+    rows: rows.map((x) => {
+      const rec = x as Record<string, unknown>;
+      return {
+        eventSlug: String(rec.eventSlug ?? ""),
+        label: String(rec.label ?? ""),
+        n: numOrNull(rec.n) ?? 0,
+        skill: numOrNull(rec.skill)
+      };
+    })
+  };
+}
+
+function readPending(raw: unknown): PaperSnapshotPayload["brier"]["pending"] {
+  if (!Array.isArray(raw)) return [];
+  return raw.map((x) => {
+    const rec = x as Record<string, unknown>;
+    return {
+      question: String(rec.label ?? ""),
+      slug: String(rec.slug ?? ""),
+      side: typeof rec.direction === "string" ? rec.direction : null,
+      agentProb: numOrNull(rec.agentProb) ?? 0,
+      marketProb: numOrNull(rec.marketProb) ?? 0,
+      horizonDays: numOrNull(rec.horizonDays),
+      unrealizedUsd: numOrNull(rec.unrealizedUsd)
+    };
+  });
 }
 
 let cached: { at: number; payload: PaperSnapshotPayload } | null = null;
@@ -474,4 +651,28 @@ export function getPaperSnapshot(nowMs: number = Date.now()): PaperSnapshotPaylo
 
 export function resetPaperSnapshotCache(): void {
   cached = null;
+  cachedCases = null;
+}
+
+// ---------------------------------------------------------------------------
+// Case walk-throughs (biggest winners / losers, with their research trail).
+// Kept behind its own cache: reading dossiers is far heavier than the snapshot
+// and only the case endpoint needs it.
+// ---------------------------------------------------------------------------
+
+export function buildPaperCasesPayload(rootDir: string = paperRoot(), perBucket = 2): PaperCasesPayload {
+  const snapshot = buildPaperSnapshot(rootDir);
+  const ledger = readLedger(path.join(rootDir, "ledger.jsonl")).filter((e) => !isDroppedFill(e));
+  return buildPaperCases(snapshot.decisionQuality?.episodes ?? [], ledger, rootDir, perBucket);
+}
+
+let cachedCases: { at: number; perBucket: number; payload: PaperCasesPayload } | null = null;
+
+export function getPaperCases(perBucket = 2, nowMs: number = Date.now()): PaperCasesPayload {
+  if (cachedCases && cachedCases.perBucket === perBucket && nowMs - cachedCases.at < CACHE_TTL_MS) {
+    return cachedCases.payload;
+  }
+  const payload = buildPaperCasesPayload(paperRoot(), perBucket);
+  cachedCases = { at: nowMs, perBucket, payload };
+  return payload;
 }

--- a/services/forecast-api/src/server.ts
+++ b/services/forecast-api/src/server.ts
@@ -9,6 +9,7 @@
 //   GET  /v1/forecasts/:id/pdf         answer as a PDF dossier
 //   POST /mcp                          MCP streamable-HTTP endpoint (stateless)
 //   GET  /paper/snapshot               paper-agent book snapshot (token OR invite code)
+//   GET  /paper/cases                  biggest winners/losers + research trail (same auth)
 //
 // Every /v1 + /mcp route is token-gated (Authorization: Bearer, x-api-key, or ?token=).
 
@@ -20,7 +21,7 @@ import type { ServiceConfig } from "./config";
 import { authorizeInviteUse, describeInviteState, inviteState } from "./invites";
 import { log } from "./log";
 import { handleMcpRequest } from "./mcp";
-import { getPaperSnapshot } from "./paper-snapshot";
+import { getPaperCases, getPaperSnapshot } from "./paper-snapshot";
 import { ensurePdf } from "./pdf";
 import { QuotaExceededError } from "./quota";
 import { renderHtml } from "./render-html";
@@ -275,6 +276,25 @@ async function route(req: IncomingMessage, res: ServerResponse, config: ServiceC
       return;
     }
     sendJson(res, 200, snapshot);
+    return;
+  }
+
+  // Case walk-throughs for the same review page: biggest winners/losers with
+  // their engine dossier and decision timeline. Same credential rules as the
+  // snapshot (simulation data only), same 503 when the book is missing.
+  if (url.pathname === "/paper/cases" && method === "GET") {
+    if (!isAuthorized(req, url, config.token) && !isAuthorized(req, url, config.inviteCode)) {
+      sendJson(res, 401, { error: "unauthorized — provide the access token or invite code (Authorization: Bearer, x-api-key, or ?token=)" });
+      return;
+    }
+    const requested = Number(url.searchParams.get("perBucket") ?? "2");
+    const perBucket = Number.isInteger(requested) && requested >= 1 && requested <= 5 ? requested : 2;
+    const cases = getPaperCases(perBucket);
+    if (cases.winners.length === 0 && cases.losers.length === 0) {
+      sendJson(res, 503, { error: "paper book not found on this host — check ARTIFACT_STORAGE_ROOT / volume mounts" });
+      return;
+    }
+    sendJson(res, 200, cases);
     return;
   }
 

--- a/services/paper-agent/src/reflect.ts
+++ b/services/paper-agent/src/reflect.ts
@@ -81,6 +81,49 @@ export interface CalibrationRow {
   marketProb: number;
   outcome: 0 | 1;
   ts: string;
+  // Horizon context (added 2026-08-21): how far ahead of resolution this call
+  // was made, and which Gamma event the market belongs to. Both are needed to
+  // read the headline number fairly — scoring only the LAST pre-resolution
+  // eval measures near-zero-horizon calls, and sibling markets of one event
+  // are not independent samples.
+  horizonDays?: number | null;
+  eventSlug?: string | null;
+}
+
+/** A pooled agent-vs-market Brier over some subset of scored calls. */
+export interface BrierBlock {
+  n: number;
+  brierAgent: number | null;
+  brierMarket: number | null;
+  skill: number | null;
+  medianHorizonDays: number | null;
+}
+
+export interface HorizonBucket extends BrierBlock {
+  label: string;
+  minDays: number;
+  maxDays: number | null;
+}
+
+/** One Gamma event = one underlying uncertainty; its markets are correlated. */
+export interface CalibrationCluster {
+  eventSlug: string;
+  label: string;
+  n: number;
+  skill: number | null;
+  brierAgent: number | null;
+  brierMarket: number | null;
+}
+
+/** An evaluated market that has NOT resolved yet — excluded from every Brier. */
+export interface PendingCalibrationRow {
+  label: string;
+  slug: string;
+  direction: string | null;
+  agentProb: number;
+  marketProb: number;
+  horizonDays: number | null;
+  unrealizedUsd: number | null;
 }
 
 export interface Reflection {
@@ -103,6 +146,26 @@ export interface Reflection {
     skill: number | null; // 1 − brierAgent/brierMarket, >0 = beat the market
     note: string;
     rows: CalibrationRow[];
+    // Fairness views (2026-08-21). The headline number above scores the LAST
+    // eval before each resolution — the easiest call the agent ever makes, on
+    // whichever markets happened to settle. These break that out so the
+    // number can be read for what it is:
+    //   atEntry   the FIRST call on each market (real foresight, long horizon)
+    //   buckets   the same pooled score split by how far out the call was
+    //   weighted  horizon^exponent-weighted pooling, so a 60-day call counts
+    //             for more than a same-day one
+    //   clusters  per Gamma event — sibling expiries of one story are one bet,
+    //             so effectiveN (distinct events) is the honest sample size
+    //   pending   evaluated markets still open: never scored here, which is
+    //             why an unresolved winning book does not show up in Brier
+    horizon: {
+      atEntry: BrierBlock | null;
+      atLast: BrierBlock | null;
+      buckets: HorizonBucket[];
+      weighted: { exponent: number; skill: number | null; n: number } | null;
+    };
+    clusters: { effectiveN: number; rows: CalibrationCluster[] };
+    pending: PendingCalibrationRow[];
   };
   fees: { takerUsd: number; makerUsd: number; totalUsd: number };
   hybrid: {
@@ -232,15 +295,205 @@ async function resolveUnit(
   return { winner: market.resolvedOutcomeIndex, ts: null };
 }
 
-async function buildCalibration(ledger: LedgerEvent[], getMarket: MarketGetter): Promise<Reflection["calibration"]> {
+// ---- Fairness views over the same scored calls ----------------------------
+//
+// Longer-horizon calls are harder, so weighting them equally with a call made
+// hours before settlement understates a forecaster who takes long positions.
+// The market baseline absorbs most of that (it faces the same horizon), which
+// is why the pooled skill score stays the headline; the exponent below only
+// re-weights WHICH calls dominate the pool, it never rescales an individual
+// Brier. 1.5 is the owner's chosen prior on how difficulty grows with days.
+const HORIZON_EXPONENT = 1.5;
+// Sub-day calls would otherwise get ~zero weight and drop out entirely.
+const MIN_HORIZON_DAYS = 0.25;
+
+const HORIZON_BUCKETS: Array<{ label: string; minDays: number; maxDays: number | null }> = [
+  { label: "≤1 天", minDays: 0, maxDays: 1 },
+  { label: "1–7 天", minDays: 1, maxDays: 7 },
+  { label: "7–30 天", minDays: 7, maxDays: 30 },
+  { label: "30 天以上", minDays: 30, maxDays: null }
+];
+
+interface ScoredCall {
+  agentProb: number;
+  marketProb: number;
+  ts: string;
+  horizonDays: number | null;
+}
+
+interface ScoredUnit {
+  key: string;
+  slug: string;
+  eventSlug: string;
+  label: string;
+  outcome: 0 | 1;
+  calls: ScoredCall[]; // chronological, all strictly before resolution
+}
+
+interface BrierSample {
+  agentProb: number;
+  marketProb: number;
+  outcome: 0 | 1;
+  horizonDays: number | null;
+  weight: number;
+}
+
+function median(xs: number[]): number | null {
+  if (xs.length === 0) return null;
+  const sorted = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  const lo = sorted[mid - 1];
+  const hi = sorted[mid];
+  if (hi === undefined) return null;
+  return sorted.length % 2 === 0 && lo !== undefined ? (lo + hi) / 2 : hi;
+}
+
+/**
+ * Pooled paired Brier: weighted mean of the agent's squared error over the
+ * weighted mean of the market's. Pooling the SUMS (rather than averaging
+ * per-sample skill scores) is what keeps the number finite — a market that
+ * was nearly exact drives its own Brier toward 0 and would blow up any
+ * per-sample ratio.
+ */
+function poolBrier(samples: BrierSample[]): BrierBlock {
+  const totalWeight = samples.reduce((s, x) => s + x.weight, 0);
+  if (samples.length === 0 || totalWeight <= 0) {
+    return { n: samples.length, brierAgent: null, brierMarket: null, skill: null, medianHorizonDays: null };
+  }
+  const agent = samples.reduce((s, x) => s + x.weight * (x.agentProb - x.outcome) ** 2, 0) / totalWeight;
+  const market = samples.reduce((s, x) => s + x.weight * (x.marketProb - x.outcome) ** 2, 0) / totalWeight;
+  const horizons = samples.flatMap((x) => (x.horizonDays === null ? [] : [x.horizonDays]));
+  return {
+    n: samples.length,
+    brierAgent: agent,
+    brierMarket: market,
+    skill: market > 0 ? 1 - agent / market : null,
+    medianHorizonDays: median(horizons)
+  };
+}
+
+const sampleOf = (unit: ScoredUnit, call: ScoredCall, weight = 1): BrierSample => ({
+  agentProb: call.agentProb,
+  marketProb: call.marketProb,
+  outcome: unit.outcome,
+  horizonDays: call.horizonDays,
+  weight
+});
+
+function horizonViews(units: ScoredUnit[]): Reflection["calibration"]["horizon"] {
+  const firstCalls = units.flatMap((u) => {
+    const call = u.calls[0];
+    return call ? [{ unit: u, call }] : [];
+  });
+  const lastCalls = units.flatMap((u) => {
+    const call = u.calls[u.calls.length - 1];
+    return call ? [{ unit: u, call }] : [];
+  });
+
+  const buckets: HorizonBucket[] = HORIZON_BUCKETS.map((bucket) => {
+    // At most one call per unit per bucket: the LAST call still inside the
+    // band, so a market reviewed 40 times cannot dominate the bucket.
+    const samples = units.flatMap((u) => {
+      const inBucket = u.calls.filter(
+        (c) =>
+          c.horizonDays !== null &&
+          c.horizonDays >= bucket.minDays &&
+          (bucket.maxDays === null || c.horizonDays < bucket.maxDays)
+      );
+      const call = inBucket[inBucket.length - 1];
+      return call ? [sampleOf(u, call)] : [];
+    });
+    return { ...bucket, ...poolBrier(samples) };
+  });
+
+  const weightedSamples = firstCalls.map(({ unit, call }) =>
+    sampleOf(unit, call, Math.max(call.horizonDays ?? MIN_HORIZON_DAYS, MIN_HORIZON_DAYS) ** HORIZON_EXPONENT)
+  );
+  const weighted = poolBrier(weightedSamples);
+
+  return {
+    atEntry: firstCalls.length ? poolBrier(firstCalls.map(({ unit, call }) => sampleOf(unit, call))) : null,
+    atLast: lastCalls.length ? poolBrier(lastCalls.map(({ unit, call }) => sampleOf(unit, call))) : null,
+    buckets: buckets.filter((b) => b.n > 0),
+    weighted: weightedSamples.length ? { exponent: HORIZON_EXPONENT, skill: weighted.skill, n: weighted.n } : null
+  };
+}
+
+function clusterViews(units: ScoredUnit[]): Reflection["calibration"]["clusters"] {
+  const groups = new Map<string, ScoredUnit[]>();
+  for (const unit of units) {
+    groups.set(unit.eventSlug, [...(groups.get(unit.eventSlug) ?? []), unit]);
+  }
+  const rows: CalibrationCluster[] = [...groups.entries()].map(([eventSlug, members]) => {
+    const samples = members.flatMap((u) => {
+      const call = u.calls[u.calls.length - 1];
+      return call ? [sampleOf(u, call)] : [];
+    });
+    const pooled = poolBrier(samples);
+    return {
+      eventSlug,
+      label: members[0]?.label ?? eventSlug,
+      n: members.length,
+      skill: pooled.skill,
+      brierAgent: pooled.brierAgent,
+      brierMarket: pooled.brierMarket
+    };
+  });
+  return {
+    effectiveN: rows.length,
+    rows: rows.sort((a, b) => b.n - a.n)
+  };
+}
+
+async function buildPending(
+  units: ScoringUnit[],
+  scoredKeys: Set<string>,
+  getMarket: MarketGetter,
+  portfolio: Portfolio,
+  nowMs: number
+): Promise<PendingCalibrationRow[]> {
+  const rows: PendingCalibrationRow[] = [];
+  for (const unit of units) {
+    if (scoredKeys.has(unit.key)) continue;
+    const last = unit.evals[unit.evals.length - 1];
+    if (!last) continue;
+    const market = await getMarket(unit.slug);
+    if (market && market.resolution !== "open") continue;
+    const position = portfolio.positions.find((p) => p.id === unit.key);
+    const endMs = market?.endDateIso ? Date.parse(market.endDateIso) : NaN;
+    rows.push({
+      label: market?.question ?? unit.slug,
+      slug: unit.slug,
+      direction: position?.outcomeLabel.toUpperCase() ?? null,
+      agentProb: last.agentProb,
+      marketProb: last.marketProb,
+      horizonDays: Number.isFinite(endMs) ? Math.round(((endMs - nowMs) / 86_400_000) * 10) / 10 : null,
+      unrealizedUsd:
+        position && position.lastEval?.mark !== undefined && position.lastEval.mark !== null
+          ? position.shares * (position.lastEval.mark - position.avgEntryPrice)
+          : null
+    });
+  }
+  return rows.sort((a, b) => (b.unrealizedUsd ?? -Infinity) - (a.unrealizedUsd ?? -Infinity));
+}
+
+async function buildCalibration(
+  ledger: LedgerEvent[],
+  getMarket: MarketGetter,
+  portfolio: Portfolio,
+  nowMs: number = Date.now()
+): Promise<Reflection["calibration"]> {
   const units = collectScoringUnits(ledger);
   const settled = ledgerResolutions(ledger);
   const rows: CalibrationRow[] = [];
+  const scored: ScoredUnit[] = [];
+  const scoredKeys = new Set<string>();
   let sumAgent = 0;
   let sumMarket = 0;
   for (const unit of units) {
     const resolved = await resolveUnit(unit.slug, settled, getMarket);
     if (!resolved) continue;
+    const market = await getMarket(unit.slug);
     // Last eval strictly before the ledgered resolution time; fetched
     // resolutions carry no timestamp, but evals stop once a market closes,
     // so the last eval IS the pre-resolution one.
@@ -251,13 +504,44 @@ async function buildCalibration(ledger: LedgerEvent[], getMarket: MarketGetter):
     const outcome: 0 | 1 = resolved.winner === unit.scoredIndex ? 1 : 0;
     sumAgent += (last.agentProb - outcome) ** 2;
     sumMarket += (last.marketProb - outcome) ** 2;
-    const market = await getMarket(unit.slug);
+    // Resolution instant for horizon maths: the ledgered settlement if we held
+    // it, else the market's own end date. Without either, horizon is unknown
+    // and the call still counts in the headline but not in the horizon views.
+    const endMs = resolvedTs
+      ? Date.parse(resolvedTs)
+      : market?.endDateIso
+        ? Date.parse(market.endDateIso)
+        : NaN;
+    const horizonOf = (ts: string): number | null => {
+      const callMs = Date.parse(ts);
+      if (!Number.isFinite(endMs) || !Number.isFinite(callMs)) return null;
+      return Math.max(0, Math.round(((endMs - callMs) / 86_400_000) * 100) / 100);
+    };
+    const label = market?.question ?? unit.slug;
+    scoredKeys.add(unit.key);
+    scored.push({
+      key: unit.key,
+      slug: unit.slug,
+      // Sibling expiries of one story share a Gamma event; without one, the
+      // market stands alone as its own cluster.
+      eventSlug: market?.eventSlug || unit.slug,
+      label,
+      outcome,
+      calls: usable.map((e) => ({
+        agentProb: e.agentProb,
+        marketProb: e.marketProb,
+        ts: e.ts,
+        horizonDays: horizonOf(e.ts)
+      }))
+    });
     rows.push({
-      label: market?.question ?? unit.slug,
+      label,
       agentProb: last.agentProb,
       marketProb: last.marketProb,
       outcome,
-      ts: last.ts
+      ts: last.ts,
+      horizonDays: horizonOf(last.ts),
+      eventSlug: market?.eventSlug ?? null
     });
   }
   const n = rows.length;
@@ -272,7 +556,10 @@ async function buildCalibration(ledger: LedgerEvent[], getMarket: MarketGetter):
     note: n
       ? "paired Brier over every resolved eval unit: last pre-resolution agent prob vs market price (bestBid); skill = 1 - agent/market, >0 beats the market"
       : "尚无已结算市场，Brier 暂不可计",
-    rows: [...rows].sort((a, b) => (a.ts < b.ts ? 1 : a.ts > b.ts ? -1 : 0)).slice(0, 30)
+    rows: [...rows].sort((a, b) => (a.ts < b.ts ? 1 : a.ts > b.ts ? -1 : 0)).slice(0, 30),
+    horizon: horizonViews(scored),
+    clusters: clusterViews(scored),
+    pending: await buildPending(units, scoredKeys, getMarket, portfolio, nowMs)
   };
 }
 
@@ -467,7 +754,7 @@ export async function buildReflection(): Promise<Reflection> {
   const portfolio = loadPortfolio();
   const getMarket = memoizedMarketGetter();
 
-  const calibration = await buildCalibration(ledger, getMarket);
+  const calibration = await buildCalibration(ledger, getMarket, portfolio);
   const { episodes, totalAlphaUsd } = await buildExits(ledger, getMarket);
   const hybrid = buildHybrid(ledger);
   const engineFlags = buildEngineFlags(ledger);


### PR DESCRIPTION
把 `/live-predict-raven` 复盘页从「一次人工复盘的留档」改成「每次评估周期自动重算的复盘」，并按用户 8/21 的四点要求重做分析口径。

## 1. 决策质量：建仓 vs 退出（新）

agent 只有两个决定：买什么/什么价买，和什么时候卖。所以把每个仓位周期的盈亏按同一个基准拆成两半：

```
基准价      = 已结算用结算值（$1/$0/$0.50），否则用最近观察到的价
建仓贡献 α  = shares × 基准价 − 成本（含入场费）      ← 买了一直拿着会是多少
退出贡献 α  = 卖出所得 − shares × 基准价              ← 提前卖多赚/少赚多少
盈亏        = 建仓 α + 退出 α                          （逐仓位恒等，非近似）
```

在持仓位没有退出，所以退出 α = 0、建仓 α = 当前浮盈——这也顺带修掉了「未结算的盈利仓位在页面上没有任何位置」的问题。

实测（8/20 账本）：建仓 **+$988**、退出 **−$455**。已平仓 30 个 episode 合计 −$1,091.66 vs 账本已实现 −$1,091.67，差 $0.01（取整），reconciliation 直接显示在页面上而不是藏起来。

## 2. 四个案例的决策 walk-through（新）

新端点 `GET /paper/cases`：按盈亏取最赚的两笔和最亏的两笔，把两条记录拼起来——

- **引擎档案**（`engine/forecasts/<id>/state.json`）：信念曲线、按影响挑出的关键轮次，每轮含检索 query、找到的每条源（标题 + 原始链接 + 来源类型 + 可信度 + 是否在检索链路中验真 + 该源把概率推了多少 pp + 它给的理由）、以及那一轮的判断原文；末尾是引擎自己的整体结论。
- **决策记录**（ledger）：扫描 → 建仓 → 每次复审的 hold/sell 与净 edge → 止损 → 结算。

页面上配一张「引擎概率 vs 市场报价」的时间轴图（统一按持仓方向表达，NO 仓自动镜像），买入/卖出/止损/结算打点在同一时间轴上。136 轮的档案会挑轮次 + 等距抽稀，不截断。

## 3. Brier 的三个结构性不公平（用户提出）

原来的技巧分 −0.75 是「对已结算市场、在结算前最后一次判断」打的分。页面现在把三点摊开：

1. **只算已结算的**：24 个已评估未结算市场不在样本里，其中在持部分浮盈 +$1,670；这部分表现归到建仓贡献。
2. **打分打在最容易的那一刻**：换成每个市场的**第一次**判断（中位提前 5.6 天）技巧分 **−0.37**，最后一次（中位 3.0 天）是 −0.75。按提前量分桶后：≤1 天 −5.72、1–7 天 −0.77、**7–30 天 +0.23（跑赢市场）**、30 天以上 −1.07。≤1 天那桶市场 Brier 只有 0.043——市场已经基本确定，而引擎被 1%/99% 钳位，差距被机制放大，不全是判断错。
3. **n=20 不是 20 个独立样本**：按 Gamma 事件归并后只有 **11** 个独立事件。

另外按用户提的「难度随天数增长」实现了 horizon^1.5 加权口径（对 Brier **和**加权，不是把单条分数除以天数——后者会让长周期预测几乎不受惩罚）：加权后技巧分 **−0.20**。这一项作为附加口径展示，主指标仍是相对市场基准的技巧分。

## 4. 结论与建议改为自动推导

`findings.ts` 用规则从当前快照重算，不再是写死的 2026-08-05 文字（那段文字描述的是 −20% 的账本，而账本已经 +5.3%）。每条结论带触发它的数字。风控类建议一律标成「待你拍板」，agent 不自行改参数。

现在触发的：题材集中（伊朗/中东占在持成本 61%、10 仓方向全 NO）、止损后重进同一市场（4 个市场 −$367）、低价合约止损被打脸（2 笔，退出贡献 −$3,636）、引擎饱和率 65%。

## 兼容性

新字段全部可选、逐字段宽松解析：VM 跑旧镜像时新板块直接不渲染，不会整页回退到 baked 快照。`paper/cases` 拿不到就省掉整节（不做 baked 兜底——过期的 walk-through 会歪曲已被修正的判断）。

## 验证

- `npx vitest run`：114 文件 / 994 测试全绿（新增 17 条：决策拆分恒等式、re-entry/低价止损规则、entry context 归属）
- `pnpm --filter @autopoly/web build` 通过
- 本地起 forecast-api 指向 VM 真实账本副本 + next dev，桌面 1280 / 移动 390 两个视口截图自评：0 console error、0 pageerror、无横向溢出（`scripts/lpr-shots.mjs`，解 cookie 门后展开所有 details 再截）

⚠️ **合并后还需要部署 VM**（`services/forecast-api` + `services/paper-agent` 重建 raven-suite 镜像、`up -d --no-deps` 只起这两个），否则线上页面只会显示旧板块。paper-agent 的改动仅在 reflect.ts（日报分析），不涉及交易/风控逻辑。
