### PR TITLE
feat(delta-pm): daily reflection — 24h signal follow-ups + calibration report

### DIFF
--- a/packages/delta-pm-contracts/src/index.ts
+++ b/packages/delta-pm-contracts/src/index.ts
@@ -318,6 +318,7 @@ export const LEDGER_EVENT_TYPES = [
   "hard_floor_stop",
   "halt",
   "resume",
+  "reflection_written",
   "error"
 ] as const;
 

--- a/services/delta-pm/src/index.ts
+++ b/services/delta-pm/src/index.ts
@@ -10,7 +10,9 @@ import { config } from "./config.js";
 import { backfillFromSitemap, pollFeed } from "./feed.js";
 import { marketState, sweepCandles, sweepCtxs } from "./market.js";
 import { acquireBookLock, appendLedger, pmRoot, releaseBookLock, repoRoot } from "./store.js";
-import { processNews, scheduleDailyReview, scheduleFastTick } from "./run-cycle.js";
+import { currentMarks, enqueueWriter, loadPortfolio, processNews, scheduleDailyReview, scheduleFastTick } from "./run-cycle.js";
+import { equityOf } from "./policy.js";
+import { runReflection } from "./reflect.js";
 import { startStatusServer } from "./status-server.js";
 
 function loadUniverse(): UniverseEntry[] {
@@ -104,6 +106,14 @@ async function main(): Promise<void> {
       lastReviewDay = day;
       console.log("[INFO] daily position review starting");
       scheduleDailyReview({ universe });
+      // Reflection runs after the review in the same slow lane: 24h signal
+      // follow-ups (incl. the archived/"wrongly killed" column) + the daily
+      // calibration report — the actual product of Phase 0.
+      enqueueWriter(false, async () => {
+        const portfolio = loadPortfolio();
+        const report = await runReflection(equityOf(portfolio, currentMarks(universe)), portfolio);
+        console.log(`[OK] daily reflection written: ${report}`);
+      });
     }
   }, 60_000);
 

--- a/services/delta-pm/src/reflect.test.ts
+++ b/services/delta-pm/src/reflect.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import type { Portfolio } from "@autopoly/delta-pm-contracts";
+import { buildReflection, renderReflectionMd, type StoredSignal } from "./reflect.js";
+
+function signal(over: Partial<StoredSignal> = {}): StoredSignal {
+  return {
+    id: `sig-${Math.random().toString(36).slice(2, 8)}`,
+    newsId: "n1",
+    fingerprint: "fp",
+    firstSeenUtc: "2026-08-20T14:00:00.000Z",
+    firstSeenBasis: "test",
+    expectedDirection: "bullish",
+    coarseImpactBand: "medium",
+    consensusBaselineAsOf: null,
+    materiality: {
+      tradeable: true,
+      score: 70,
+      eventType: "order_contract",
+      factLevel: "fact",
+      tickers: ["NVDA"],
+      surpriseNote: "s",
+      reason: "r"
+    },
+    pricedIn: {
+      status: "none",
+      tEvalUtc: "2026-08-20T14:10:00.000Z",
+      deltaTMinutes: 10,
+      realizedExcessPct: 0.2,
+      volumeZ: null,
+      dataBasis: "hl_perp",
+      sessionBucket: "rth",
+      benchmarkUsed: "XYZ100",
+      betaUsed: 1,
+      confidence: "high",
+      note: "n"
+    },
+    createdAtUtc: "2026-08-20T14:10:00.000Z",
+    ...over
+  };
+}
+
+const portfolio: Portfolio = {
+  mode: "shadow",
+  initialCapitalUsd: 10_000,
+  realizedPnlUsd: -50,
+  positions: [],
+  halted: false,
+  haltedReason: null,
+  lastStopOutUtc: {},
+  updatedAtUtc: "2026-08-21T00:00:00.000Z"
+};
+
+describe("buildReflection", () => {
+  const signals: StoredSignal[] = [
+    // forwarded, tracked, hit
+    signal({ followUp24h: { realizedExcessPct: 2.5, directionHit: true, computedAtUtc: "x" } }),
+    // forwarded, tracked, miss
+    signal({ followUp24h: { realizedExcessPct: -1.2, directionHit: false, computedAtUtc: "x" } }),
+    // archived as full, then kept moving with the news ≥1% — a "wrong kill"
+    signal({
+      pricedIn: { ...signal().pricedIn!, status: "full" },
+      followUp24h: { realizedExcessPct: 3.1, directionHit: true, computedAtUtc: "x" }
+    }),
+    // archived: no ticker
+    signal({ materiality: { ...signal().materiality, tickers: [], tradeable: false }, pricedIn: null })
+  ];
+  const ledger = [
+    { type: "news_seen" },
+    { type: "news_seen" },
+    { type: "thesis_created", contamination: "hard", engine: "claude-cli" },
+    { type: "thesis_created", contamination: "none", engine: "claude-cli" },
+    { type: "decision", decision: { action: "open", reason: "ok" } },
+    { type: "decision", decision: { action: "no_trade", reason: "cooldown: stopped out" } },
+    { type: "decision", decision: { action: "no_trade", reason: "cooldown: stopped out again" } },
+    { type: "signal_archived", why: "stale: duplicate" }
+  ];
+
+  const r = buildReflection({ signals, ledger, portfolio, equityUsd: 9950 }, "2026-08-22T13:00:00.000Z");
+
+  it("computes the funnel and priced-in distribution", () => {
+    expect(r.funnel.newsSeen).toBe(2);
+    expect(r.funnel.signals).toBe(4);
+    expect(r.funnel.archivedNoTicker).toBe(1);
+    expect(r.funnel.archivedStale).toBe(1);
+    expect(r.funnel.decisionsOpen).toBe(1);
+    expect(r.funnel.decisionsNoTrade).toBe(2);
+    expect(r.pricedInDistribution.none).toBe(2);
+    expect(r.pricedInDistribution.full).toBe(1);
+    expect(r.pricedInDistribution.not_evaluated).toBe(1);
+  });
+
+  it("M1 calibration: forwarded hit rate and wrongly-killed column", () => {
+    expect(r.m1Calibration.forwarded.n).toBe(2);
+    expect(r.m1Calibration.forwarded.hits).toBe(1);
+    expect(r.m1Calibration.forwarded.hitRate).toBeCloseTo(0.5);
+    expect(r.m1Calibration.archivedFullReverse).toEqual({ n: 1, movedWithNews: 1 });
+  });
+
+  it("contamination rate and no-trade reason grouping", () => {
+    expect(r.contamination).toMatchObject({ theses: 2, hard: 1, soft: 0, rate: 0.5 });
+    expect(r.noTradeReasons[0]).toEqual({ reason: "cooldown", count: 2 });
+  });
+
+  it("renders markdown with the headline numbers", () => {
+    const md = renderReflectionMd(r);
+    expect(md).toContain("新闻 2 → 信号 4");
+    expect(md).toContain("命中率 50%");
+    expect(md).toContain("错杀检查");
+    expect(md).toContain("1/1");
+    expect(md).toContain("污染率 50%");
+  });
+});

--- a/services/delta-pm/src/reflect.ts
+++ b/services/delta-pm/src/reflect.ts
@@ -1,0 +1,246 @@
+// Phase 0 daily reflection — the calibration dataset IS the product of the
+// shadow phase (PRD §13). Two jobs:
+//   1. trackSignals(): for every signal ≥24h old without a follow-up, compute
+//      the realized 24h excess move after t0 — INCLUDING archived signals,
+//      which is the confusion matrix's "wrongly killed" column.
+//   2. buildReflection(): aggregate signals/theses/ledger/book into
+//      reports/<date>-reflection.{json,md} — M1 direction hit rates by
+//      priced-in status, Δt stats, contamination rate, engine usage,
+//      decision funnel, book digest.
+// Aggregation cores are pure so tests inject synthetic records.
+
+import path from "node:path";
+import { readdirSync } from "node:fs";
+import type { NewsSignal, Portfolio } from "@autopoly/delta-pm-contracts";
+import { candlesInterval, computeExcessMove } from "./m0.js";
+import { appendLedger, paths, readJson, readLedger, writeJsonAtomic } from "./store.js";
+
+export interface StoredSignal extends NewsSignal {
+  title?: string;
+  followUp24h?: {
+    realizedExcessPct: number | null;
+    directionHit: boolean | null; // null when expectedDirection is mixed or data missing
+    computedAtUtc: string;
+  };
+}
+
+export function listSignalFiles(): string[] {
+  try {
+    return readdirSync(paths.signalsDir())
+      .filter((f) => f.endsWith(".json"))
+      .map((f) => path.join(paths.signalsDir(), f));
+  } catch {
+    return [];
+  }
+}
+
+// --- follow-up tracking ----------------------------------------------------
+
+export async function trackSignals(nowMs = Date.now()): Promise<number> {
+  let updated = 0;
+  for (const file of listSignalFiles()) {
+    const signal = readJson<StoredSignal>(file);
+    if (!signal || signal.followUp24h) continue;
+    const t0Ms = Date.parse(signal.firstSeenUtc ?? signal.createdAtUtc);
+    if (!Number.isFinite(t0Ms) || nowMs - t0Ms < 24 * 3600_000) continue;
+    const ticker = signal.materiality.tickers[0];
+    // Signals with no universe ticker can't be tracked — mark them so the
+    // tracker doesn't rescan forever.
+    if (!ticker) {
+      signal.followUp24h = { realizedExcessPct: null, directionHit: null, computedAtUtc: new Date(nowMs).toISOString() };
+      writeJsonAtomic(file, signal);
+      updated++;
+      continue;
+    }
+    try {
+      // 15m candles reach ~52 days back — enough granularity for a 24h window.
+      const coin = `xyz:${ticker}`;
+      const [asset, bench] = await Promise.all([
+        candlesInterval(coin, "15m", t0Ms - 3600_000, t0Ms + 25 * 3600_000),
+        candlesInterval("xyz:XYZ100", "15m", t0Ms - 3600_000, t0Ms + 25 * 3600_000)
+      ]);
+      const beta = signal.pricedIn?.betaUsed ?? 1;
+      const excess = asset.length
+        ? computeExcessMove(asset, signal.pricedIn?.benchmarkUsed === "none" ? null : bench, beta, t0Ms, t0Ms + 24 * 3600_000)
+        : null;
+      const dirSign = signal.expectedDirection === "bearish" ? -1 : signal.expectedDirection === "bullish" ? 1 : 0;
+      signal.followUp24h = {
+        realizedExcessPct: excess === null ? null : excess * 100,
+        directionHit: excess === null || dirSign === 0 ? null : excess * dirSign > 0,
+        computedAtUtc: new Date(nowMs).toISOString()
+      };
+      writeJsonAtomic(file, signal);
+      updated++;
+    } catch {
+      // transient market-data failure — retry on the next tracking pass
+    }
+  }
+  return updated;
+}
+
+// --- aggregation (pure) ----------------------------------------------------
+
+export interface ReflectionInput {
+  signals: StoredSignal[];
+  ledger: Array<Record<string, unknown>>;
+  portfolio: Portfolio;
+  equityUsd: number;
+}
+
+export interface Reflection {
+  date: string;
+  generatedAtUtc: string;
+  funnel: {
+    newsSeen: number;
+    signals: number;
+    archivedNoTicker: number;
+    archivedNotMaterial: number;
+    archivedStale: number;
+    archivedPricedIn: number;
+    theses: number;
+    decisionsOpen: number;
+    decisionsNoTrade: number;
+  };
+  pricedInDistribution: Record<string, number>;
+  deltaT: { n: number; medianMinutes: number | null };
+  m1Calibration: {
+    // 24h direction hit rate for signals M1 sent forward (none/partial/leaked)
+    forwarded: { n: number; hits: number; hitRate: number | null };
+    // "wrongly killed" column: archived-as-full/reverse that then moved ≥1% with the news
+    archivedFullReverse: { n: number; movedWithNews: number };
+  };
+  contamination: { theses: number; hard: number; soft: number; rate: number | null };
+  engines: Record<string, number>;
+  noTradeReasons: Array<{ reason: string; count: number }>;
+  book: { equityUsd: number; realizedPnlUsd: number; positions: number; halted: boolean };
+}
+
+export function buildReflection(input: ReflectionInput, nowUtc = new Date().toISOString()): Reflection {
+  const { signals, ledger } = input;
+  const count = (type: string) => ledger.filter((e) => e.type === type).length;
+
+  const archived = signals.filter((s) => !s.materiality.tradeable || !s.materiality.tickers.length || (s.pricedIn && !["none", "partial", "leaked"].includes(s.pricedIn.status)));
+  const forwarded = signals.filter((s) => s.materiality.tradeable && s.materiality.tickers.length && s.pricedIn && ["none", "partial", "leaked"].includes(s.pricedIn.status));
+
+  const pricedInDistribution: Record<string, number> = {};
+  for (const s of signals) {
+    const k = s.pricedIn?.status ?? "not_evaluated";
+    pricedInDistribution[k] = (pricedInDistribution[k] ?? 0) + 1;
+  }
+
+  const deltas = signals.map((s) => s.pricedIn?.deltaTMinutes).filter((d): d is number => typeof d === "number").sort((a, b) => a - b);
+  const median = deltas.length ? deltas[Math.floor(deltas.length / 2)] : null;
+
+  const fwdTracked = forwarded.filter((s) => s.followUp24h?.directionHit !== null && s.followUp24h?.directionHit !== undefined);
+  const fwdHits = fwdTracked.filter((s) => s.followUp24h!.directionHit).length;
+
+  const killedFullReverse = signals.filter((s) => s.pricedIn && ["full", "reverse"].includes(s.pricedIn.status) && s.followUp24h?.realizedExcessPct !== null && s.followUp24h?.realizedExcessPct !== undefined);
+  const movedWithNews = killedFullReverse.filter((s) => {
+    const dirSign = s.expectedDirection === "bearish" ? -1 : 1;
+    return (s.followUp24h!.realizedExcessPct as number) * dirSign >= 1;
+  }).length;
+
+  const thesisEvents = ledger.filter((e) => e.type === "thesis_created");
+  const hard = thesisEvents.filter((e) => e.contamination === "hard").length;
+  const soft = thesisEvents.filter((e) => e.contamination === "soft").length;
+
+  const engines: Record<string, number> = {};
+  for (const e of ledger) {
+    if (typeof e.engine === "string") engines[e.engine] = (engines[e.engine] ?? 0) + 1;
+  }
+
+  const noTradeCounts = new Map<string, number>();
+  for (const e of ledger) {
+    if (e.type !== "decision") continue;
+    const d = e.decision as { action?: string; reason?: string } | undefined;
+    if (d?.action === "no_trade" && d.reason) {
+      const key = d.reason.split(":")[0].slice(0, 60);
+      noTradeCounts.set(key, (noTradeCounts.get(key) ?? 0) + 1);
+    }
+  }
+
+  const decisions = ledger.filter((e) => e.type === "decision" && (e.decision as { action?: string } | undefined)?.action);
+  const opens = decisions.filter((e) => (e.decision as { action: string }).action === "open").length;
+
+  return {
+    date: nowUtc.slice(0, 10),
+    generatedAtUtc: nowUtc,
+    funnel: {
+      newsSeen: count("news_seen"),
+      signals: signals.length,
+      archivedNoTicker: signals.filter((s) => !s.materiality.tickers.length).length,
+      archivedNotMaterial: signals.filter((s) => s.materiality.tickers.length > 0 && !s.materiality.tradeable).length,
+      archivedStale: ledger.filter((e) => e.type === "signal_archived" && String(e.why ?? "").startsWith("stale")).length,
+      archivedPricedIn: signals.filter((s) => s.pricedIn && ["full", "reverse", "awaiting_market"].includes(s.pricedIn.status)).length,
+      theses: thesisEvents.length,
+      decisionsOpen: opens,
+      decisionsNoTrade: decisions.length - opens
+    },
+    pricedInDistribution,
+    deltaT: { n: deltas.length, medianMinutes: median },
+    m1Calibration: {
+      forwarded: { n: fwdTracked.length, hits: fwdHits, hitRate: fwdTracked.length ? fwdHits / fwdTracked.length : null },
+      archivedFullReverse: { n: killedFullReverse.length, movedWithNews }
+    },
+    contamination: { theses: thesisEvents.length, hard, soft, rate: thesisEvents.length ? (hard + soft) / thesisEvents.length : null },
+    engines,
+    noTradeReasons: [...noTradeCounts.entries()].map(([reason, c]) => ({ reason, count: c })).sort((a, b) => b.count - a.count),
+    book: { equityUsd: input.equityUsd, realizedPnlUsd: input.portfolio.realizedPnlUsd, positions: input.portfolio.positions.length, halted: input.portfolio.halted }
+  };
+}
+
+export function renderReflectionMd(r: Reflection): string {
+  const pct = (x: number | null) => (x === null ? "—" : `${(x * 100).toFixed(0)}%`);
+  return `# Delta PM 每日反思 — ${r.date}
+
+> 影子模式 · 生成于 ${r.generatedAtUtc} · 本报告是 Phase 0 校准数据集的日切片
+
+## 漏斗
+
+新闻 ${r.funnel.newsSeen} → 信号 ${r.funnel.signals}(无池内标的 ${r.funnel.archivedNoTicker} / 不重要 ${r.funnel.archivedNotMaterial} / 旧闻重复 ${r.funnel.archivedStale} / 已定价类归档 ${r.funnel.archivedPricedIn})→ thesis ${r.funnel.theses} → 开仓 ${r.funnel.decisionsOpen} / 不开 ${r.funnel.decisionsNoTrade}
+
+## 已定价分布
+
+${Object.entries(r.pricedInDistribution).map(([k, v]) => `- ${k}: ${v}`).join("\n")}
+
+Δt(t_eval − t0):n=${r.deltaT.n},中位 ${r.deltaT.medianMinutes === null ? "—" : r.deltaT.medianMinutes.toFixed(0) + " 分钟"}
+
+## M1 校准(24h 超额方向)
+
+- 放行信号(none/partial/leaked):n=${r.m1Calibration.forwarded.n},方向命中 ${r.m1Calibration.forwarded.hits},命中率 ${pct(r.m1Calibration.forwarded.hitRate)}(样本不足时勿下结论)
+- 错杀检查(判 full/reverse 后 24h 仍顺新闻方向走 ≥1%):${r.m1Calibration.archivedFullReverse.movedWithNews}/${r.m1Calibration.archivedFullReverse.n}
+
+## M2 盲测污染率
+
+thesis ${r.contamination.theses} 份:hard ${r.contamination.hard} / soft ${r.contamination.soft} / 污染率 ${pct(r.contamination.rate)}
+
+## 引擎使用
+
+${Object.entries(r.engines).map(([k, v]) => `- ${k}: ${v}`).join("\n") || "- (无记录)"}
+
+## 不开仓原因 Top
+
+${r.noTradeReasons.slice(0, 6).map((x) => `- ${x.count}× ${x.reason}`).join("\n") || "- (无)"}
+
+## 账本
+
+equity $${r.book.equityUsd.toFixed(2)} · 已实现 $${r.book.realizedPnlUsd.toFixed(2)} · 在持 ${r.book.positions} · ${r.book.halted ? "⛔ 已停机" : "运行中"}
+`;
+}
+
+// --- entry point (called by the scheduler after the daily review) ----------
+
+export async function runReflection(equityUsd: number, portfolio: Portfolio): Promise<string> {
+  const tracked = await trackSignals();
+  const signals = listSignalFiles()
+    .map((f) => readJson<StoredSignal>(f))
+    .filter((s): s is StoredSignal => Boolean(s));
+  const reflection = buildReflection({ signals, ledger: readLedger(), portfolio, equityUsd });
+  const base = path.join(paths.reportsDir(), `${reflection.date}-reflection`);
+  writeJsonAtomic(`${base}.json`, reflection);
+  const { writeFileSync, mkdirSync } = await import("node:fs");
+  mkdirSync(paths.reportsDir(), { recursive: true });
+  writeFileSync(`${base}.md`, renderReflectionMd(reflection), "utf8");
+  appendLedger({ type: "reflection_written", tracked, report: `${base}.md` });
+  return `${base}.md`;
+}


### PR DESCRIPTION
重开 #105(原分支与 squash 后的 main 历史冲突)。改动相同:

- `trackSignals()`:距 t0 ≥24h 的信号(含归档的『错杀』列)用 15m K 线算实际 24h 超额并写回。
- `buildReflection()`:纯函数聚合出 `reports/<date>-reflection.{json,md}`(漏斗 / 已定价分布 / Δt / M1 命中率与错杀 / M2 污染率 / 引擎用量 / 不开仓原因 / 账本)。挂每日复审后慢 lane。
- 实弹验证:对 23 条真实 soak 信号生成了报告(错杀检查 0/1——判 reverse 的信号 24h 后确实没顺新闻走)。56 单测绿。

纯新增,不触及现有交易路径。