### PR TITLE
feat(delta-pm): full audit chain — IC-memo decisions, /delta-pm/audit API, /live-delta-pm page

### DIFF
--- a/apps/web/app/api/live-delta-pm/unlock/route.ts
+++ b/apps/web/app/api/live-delta-pm/unlock/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import {
+  ACCESS_COOKIE_MAX_AGE_SECONDS,
+  ACCESS_COOKIE_NAME,
+  expectedAccessToken,
+  isValidCode
+} from "../../../../lib/live-delta-pm/access";
+import { resolveRequestOrigin } from "../../../../lib/auth";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  let code: unknown;
+  try {
+    const form = await request.formData();
+    code = form.get("code");
+  } catch {
+    code = null;
+  }
+
+  const target = new URL("/live-delta-pm", resolveRequestOrigin(request));
+  if (!isValidCode(code)) {
+    target.searchParams.set("error", "1");
+    return NextResponse.redirect(target, { status: 303 });
+  }
+
+  const response = NextResponse.redirect(target, { status: 303 });
+  response.cookies.set({
+    name: ACCESS_COOKIE_NAME,
+    value: expectedAccessToken(),
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: ACCESS_COOKIE_MAX_AGE_SECONDS
+  });
+  return response;
+}

--- a/apps/web/app/live-delta-pm/page.tsx
+++ b/apps/web/app/live-delta-pm/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from "next";
+import { cookies } from "next/headers";
+import { ACCESS_COOKIE_NAME, isValidAccessToken } from "../../lib/live-delta-pm/access";
+import { bakedAuditPayload, fetchLiveAudit } from "../../lib/live-delta-pm/live";
+import { DeltaPmReport } from "./report";
+import { UnlockGate } from "./unlock-gate";
+
+export const metadata: Metadata = {
+  title: "Delta PM 决策链审计 — Predict Raven",
+  description: "US-stock shadow-trading decision-chain audit (invite-code gated).",
+  robots: { index: false, follow: false }
+};
+
+// Reads the access cookie on every request — never prerender a cached variant.
+export const dynamic = "force-dynamic";
+
+export default async function LiveDeltaPmPage({
+  searchParams
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(ACCESS_COOKIE_NAME)?.value;
+  if (!isValidAccessToken(token)) {
+    const params = await searchParams;
+    return <UnlockGate showError={params?.error === "1"} />;
+  }
+  // Live decision chain from the Tokyo VM; the baked fixture (real run data,
+  // checked in) is the labeled fallback when the VM is down or when
+  // LIVE_DELTA_PM_MOCK=1 forces deterministic local rendering.
+  const live = await fetchLiveAudit();
+  return <DeltaPmReport payload={live ?? bakedAuditPayload()} dataSource={live ? "live" : "baked"} />;
+}

--- a/apps/web/app/live-delta-pm/report.module.css
+++ b/apps/web/app/live-delta-pm/report.module.css
@@ -1,0 +1,760 @@
+.page {
+  max-width: 1060px;
+  margin: 0 auto;
+  padding: 40px 20px 72px;
+  font-size: 16.5px;
+  line-height: 1.6;
+}
+
+.header {
+  margin-bottom: 10px;
+}
+
+.kicker {
+  display: inline-block;
+  font-size: 13px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-line);
+  border-radius: 999px;
+  padding: 5px 14px;
+  margin-bottom: 14px;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: clamp(30px, 5vw, 44px);
+  line-height: 1.15;
+  margin: 0 0 10px;
+}
+
+.meta {
+  color: var(--muted);
+  font-size: 15px;
+  margin: 4px 0;
+}
+
+.bannerRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 14px 0 4px;
+}
+
+.banner {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13.5px;
+  border-radius: 999px;
+  padding: 4px 14px;
+  border: 1px solid var(--line-strong);
+  font-weight: 600;
+}
+
+.bannerLive {
+  color: var(--positive);
+  border-color: var(--positive);
+  background: rgba(36, 104, 68, 0.08);
+}
+
+.bannerBaked {
+  color: #8a5a18;
+  border-color: rgba(138, 90, 24, 0.55);
+  background: rgba(196, 138, 42, 0.12);
+}
+
+.bannerShadow {
+  color: var(--muted);
+  background: var(--panel-strong);
+}
+
+.haltBar {
+  margin: 12px 0 0;
+  border: 1px solid var(--negative);
+  background: rgba(165, 60, 45, 0.1);
+  color: var(--negative);
+  border-radius: 12px;
+  padding: 10px 16px;
+  font-weight: 650;
+}
+
+.tiles {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin: 14px 0 0;
+}
+
+.tile {
+  background: var(--panel-strong);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 13px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  box-shadow: var(--shadow-soft);
+}
+
+.tileLabel {
+  font-size: 13.5px;
+  color: var(--muted);
+}
+
+.tileValue {
+  font-size: 23px;
+  font-weight: 650;
+  line-height: 1.2;
+  font-variant-numeric: tabular-nums;
+}
+
+.tileSub {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.pos {
+  color: var(--positive);
+}
+
+.neg {
+  color: var(--negative);
+}
+
+.section {
+  margin-top: 40px;
+}
+
+.sectionTitle {
+  font-family: var(--font-display);
+  font-size: clamp(22px, 3.2vw, 28px);
+  margin: 0 0 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--line-strong);
+}
+
+.sectionNote {
+  color: var(--muted);
+  font-size: 14.5px;
+  margin: 6px 0 12px;
+}
+
+.mono {
+  font-family: var(--font-mono), monospace;
+  font-size: 0.82em;
+  color: var(--muted);
+  overflow-wrap: anywhere;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+/* ---- Case cards ---------------------------------------------------------- */
+
+.caseCard {
+  background: var(--panel);
+  border: 1px solid var(--line-strong);
+  border-radius: 16px;
+  margin-top: 16px;
+  overflow: hidden;
+}
+
+.caseSummary {
+  cursor: pointer;
+  list-style: none;
+  padding: 14px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.caseSummary::-webkit-details-marker {
+  display: none;
+}
+
+.caseSummary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.caseCard[open] > .caseSummary {
+  border-bottom: 1px solid var(--line);
+  background: var(--panel-strong);
+}
+
+.sumTop {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.sumTitle {
+  font-family: var(--font-display);
+  font-size: 18.5px;
+  line-height: 1.3;
+  font-weight: 600;
+}
+
+.sumMeta {
+  color: var(--muted);
+  font-size: 13.5px;
+  font-variant-numeric: tabular-nums;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 14px;
+}
+
+.sumChevron {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.caseBody {
+  padding: 8px 18px 20px;
+}
+
+/* Outcome / generic chips */
+
+.chip {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 2px 6px;
+  font-size: 13px;
+  border-radius: 12px;
+  border: 1px solid var(--line-strong);
+  padding: 2px 10px;
+  background: var(--panel-strong);
+  max-width: 100%;
+}
+
+.chipStrong {
+  font-weight: 650;
+}
+
+.chipRaw {
+  font-family: var(--font-mono), monospace;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.outGreen {
+  color: var(--positive);
+  border-color: var(--positive);
+  background: rgba(36, 104, 68, 0.08);
+}
+
+.outRed {
+  color: var(--negative);
+  border-color: var(--negative);
+  background: rgba(165, 60, 45, 0.1);
+}
+
+.outGrey {
+  color: var(--muted);
+}
+
+.outAmber {
+  color: #8a5a18;
+  border-color: rgba(138, 90, 24, 0.55);
+  background: rgba(196, 138, 42, 0.12);
+}
+
+.outBlue {
+  color: #275e7a;
+  border-color: rgba(39, 94, 122, 0.5);
+  background: rgba(39, 94, 122, 0.08);
+}
+
+/* Priced-in six-state chips */
+
+.pinNone {
+  color: var(--positive);
+  border-color: var(--positive);
+  background: rgba(36, 104, 68, 0.08);
+}
+
+.pinPartial {
+  color: #8a5a18;
+  border-color: rgba(138, 90, 24, 0.55);
+  background: rgba(196, 138, 42, 0.12);
+}
+
+.pinFull {
+  color: var(--muted);
+  border-color: var(--line-strong);
+  background: var(--panel-strong);
+}
+
+.pinLeaked {
+  color: #7a2775;
+  border-color: rgba(122, 39, 117, 0.5);
+  background: rgba(122, 39, 117, 0.08);
+}
+
+.pinReverse {
+  color: var(--negative);
+  border-color: var(--negative);
+  background: rgba(165, 60, 45, 0.1);
+}
+
+.pinAwait {
+  color: #275e7a;
+  border-color: rgba(39, 94, 122, 0.5);
+  background: rgba(39, 94, 122, 0.08);
+}
+
+.pinOther {
+  color: var(--muted);
+}
+
+/* ---- Station chain ------------------------------------------------------- */
+
+.chain {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+}
+
+.station {
+  display: grid;
+  grid-template-columns: 34px 1fr;
+  gap: 0 14px;
+  position: relative;
+  padding-bottom: 18px;
+}
+
+.station:last-child {
+  padding-bottom: 0;
+}
+
+.station::before {
+  content: "";
+  position: absolute;
+  left: 16px;
+  top: 34px;
+  bottom: 0;
+  width: 2px;
+  background: var(--line-strong);
+}
+
+.station:last-child::before {
+  display: none;
+}
+
+.stationNo {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 650;
+  font-size: 15px;
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-line);
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+}
+
+.stationNoSkipped {
+  background: var(--panel-strong);
+  border-color: var(--line-strong);
+  color: var(--muted);
+}
+
+.stationBody {
+  min-width: 0;
+  padding-top: 3px;
+}
+
+.stationHead {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px 12px;
+  margin-bottom: 6px;
+}
+
+.stationTitle {
+  font-size: 17px;
+  font-weight: 650;
+  margin: 0;
+}
+
+.stationTag {
+  font-family: var(--font-mono), monospace;
+  font-size: 12px;
+  color: var(--muted);
+  background: var(--panel-strong);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 1px 8px;
+}
+
+.skipNote {
+  color: var(--muted);
+  font-size: 14.5px;
+  margin: 2px 0 0;
+}
+
+.chipRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 6px 0;
+}
+
+/* Key-value grids */
+
+.kvGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px 16px;
+  margin: 8px 0;
+}
+
+.kv {
+  min-width: 0;
+}
+
+.kvLabel {
+  display: block;
+  font-size: 12.5px;
+  color: var(--muted);
+}
+
+.kvValue {
+  font-size: 15px;
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+
+/* Verbatim quotes (原文) */
+
+.quote {
+  margin: 8px 0;
+  padding: 10px 14px;
+  background: var(--panel-strong);
+  border-left: 3px solid var(--accent-line);
+  border-radius: 8px;
+  font-size: 14.5px;
+}
+
+.quoteLabel {
+  display: block;
+  font-family: var(--font-mono), monospace;
+  font-size: 11.5px;
+  color: var(--muted);
+  margin-bottom: 3px;
+}
+
+/* Tables */
+
+.tableWrap {
+  overflow-x: auto;
+  background: var(--panel-strong);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  margin: 8px 0;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14.5px;
+  min-width: 520px;
+}
+
+.table th,
+.table td {
+  text-align: left;
+  vertical-align: top;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--line);
+}
+
+.table thead th {
+  font-size: 12.5px;
+  color: var(--muted);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.hlRow td {
+  background: var(--accent-soft);
+  font-weight: 650;
+}
+
+.formulaCell {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.tagClipped {
+  display: inline-block;
+  font-size: 11.5px;
+  font-weight: 650;
+  color: var(--negative);
+  border: 1px solid var(--negative);
+  border-radius: 6px;
+  padding: 0 6px;
+  margin-left: 6px;
+}
+
+.tagBinding {
+  display: inline-block;
+  font-size: 11.5px;
+  font-weight: 650;
+  color: var(--accent);
+  border: 1px solid var(--accent-line);
+  background: var(--accent-soft);
+  border-radius: 6px;
+  padding: 0 6px;
+  margin-left: 6px;
+}
+
+/* fairImpact three big numbers */
+
+.bigNums {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 8px 0;
+}
+
+.bigNum {
+  flex: 1 1 120px;
+  background: var(--panel-strong);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 10px 14px;
+  text-align: center;
+}
+
+.bigNumMain {
+  border-color: var(--accent-line);
+  background: var(--accent-soft);
+}
+
+.bigNumLabel {
+  display: block;
+  font-size: 12.5px;
+  color: var(--muted);
+}
+
+.bigNumValue {
+  font-size: 24px;
+  font-weight: 650;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Sizing equation */
+
+.eqLine {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 8px 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.eqPart {
+  background: var(--panel-strong);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 6px 12px;
+  text-align: center;
+}
+
+.eqPartHl {
+  border-color: var(--accent-line);
+  background: var(--accent-soft);
+  font-weight: 650;
+}
+
+.eqValue {
+  display: block;
+  font-size: 17px;
+  font-weight: 650;
+}
+
+.eqLabel {
+  display: block;
+  font-size: 11.5px;
+  color: var(--muted);
+}
+
+.eqOp {
+  font-size: 18px;
+  color: var(--muted);
+}
+
+/* Verdict line (residual vs threshold) */
+
+.verdictLine {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 8px 0;
+  font-size: 15px;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Lists (evidence / falsifiers / limitations) */
+
+.plainList {
+  margin: 6px 0 10px;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 14.5px;
+}
+
+.srcMeta {
+  display: block;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.subHead {
+  font-size: 14px;
+  font-weight: 650;
+  margin: 12px 0 2px;
+}
+
+/* Timeline (post events) */
+
+.timeline {
+  list-style: none;
+  margin: 6px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.timelineItem {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px 12px;
+  background: var(--panel-strong);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 8px 12px;
+  font-size: 14.5px;
+}
+
+/* Reflection funnel */
+
+.funnelLine {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin: 10px 0;
+  font-size: 14.5px;
+  font-variant-numeric: tabular-nums;
+}
+
+.funnelStep {
+  background: var(--panel-strong);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 5px 12px;
+  max-width: 100%;
+}
+
+.funnelArrow {
+  color: var(--muted);
+}
+
+.footer {
+  margin-top: 48px;
+  padding-top: 18px;
+  border-top: 1px solid var(--line-strong);
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.srcLink {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+/* ---- Responsive ---------------------------------------------------------- */
+
+@media (max-width: 860px) {
+  .tiles {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .kvGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 480px) {
+  .page {
+    padding: 28px 12px 56px;
+    font-size: 15.5px;
+  }
+
+  .tiles {
+    grid-template-columns: 1fr;
+  }
+
+  .kvGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .station {
+    grid-template-columns: 26px 1fr;
+    gap: 0 10px;
+  }
+
+  .stationNo {
+    width: 26px;
+    height: 26px;
+    font-size: 13px;
+  }
+
+  .station::before {
+    left: 12px;
+    top: 26px;
+  }
+
+  .caseSummary,
+  .caseBody {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+
+  .tileValue {
+    font-size: 21px;
+  }
+
+  .bigNumValue {
+    font-size: 21px;
+  }
+}

--- a/apps/web/app/live-delta-pm/report.tsx
+++ b/apps/web/app/live-delta-pm/report.tsx
@@ -1,0 +1,1081 @@
+// /live-delta-pm — the shadow-trading decision chain rendered as a human
+// hedge-fund desk flow: per news item, six desk stations (情报台 → 重要性 →
+// 已定价 → 研究 memo → PM 台 → 执行/风控), every number itemized, nothing
+// abstracted. Server-rendered; the only interactivity is native <details>.
+
+import type {
+  AuditPayload,
+  CaseView,
+  DecisionView,
+  PositionNowView,
+  ReflectionView,
+  SignalView,
+  ThesisView
+} from "../../lib/live-delta-pm/decode";
+import {
+  fmtBeta,
+  fmtFracPct,
+  fmtHours,
+  fmtInt,
+  fmtMinutes,
+  fmtPct,
+  fmtPx,
+  fmtQty,
+  fmtSignedUsd,
+  fmtUsd,
+  fmtUtc,
+  fmtX,
+  minutesBetween,
+  pricedInTone,
+  zhAction,
+  zhBenchmark,
+  zhConfidence,
+  zhContamination,
+  zhCredibility,
+  zhEventType,
+  zhFactLevel,
+  zhGuard,
+  zhImpactBand,
+  zhKind,
+  zhNewsDirection,
+  zhPostEvent,
+  zhPrefix,
+  zhPricedIn,
+  zhProvider,
+  zhSession,
+  zhTradeDirection
+} from "../../lib/live-delta-pm/labels";
+import styles from "./report.module.css";
+
+// ---------------------------------------------------------------------------
+// Small building blocks
+
+function Chip({ zh, raw, tone, strong }: { zh: string; raw?: string; tone?: string; strong?: boolean }) {
+  const toneClass = tone ? styles[tone] ?? "" : "";
+  return (
+    <span className={`${styles.chip} ${toneClass} ${strong ? styles.chipStrong : ""}`}>
+      {zh}
+      {raw && raw !== zh ? <span className={styles.chipRaw}>{raw}</span> : null}
+    </span>
+  );
+}
+
+function KV({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className={styles.kv}>
+      <span className={styles.kvLabel}>{label}</span>
+      <span className={styles.kvValue}>{children}</span>
+    </div>
+  );
+}
+
+function Quote({ label, text }: { label: string; text: string }) {
+  if (!text) return null;
+  return (
+    <blockquote className={styles.quote}>
+      <span className={styles.quoteLabel}>{label}</span>
+      {text}
+    </blockquote>
+  );
+}
+
+function Station({
+  no,
+  title,
+  tag,
+  skipReason,
+  children
+}: {
+  no: number;
+  title: string;
+  tag: string;
+  /** When set, the station renders greyed as 未到达 with this reason. */
+  skipReason?: string | null;
+  children?: React.ReactNode;
+}) {
+  const skipped = typeof skipReason === "string";
+  return (
+    <li className={styles.station}>
+      <span className={`${styles.stationNo} ${skipped ? styles.stationNoSkipped : ""}`}>{no}</span>
+      <div className={styles.stationBody}>
+        <div className={styles.stationHead}>
+          <h4 className={styles.stationTitle}>{title}</h4>
+          <span className={styles.stationTag}>{tag}</span>
+        </div>
+        {skipped ? <p className={styles.skipNote}>未到达 — {skipReason}</p> : children}
+      </div>
+    </li>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Chain outcome / progress helpers
+
+interface Outcome {
+  label: string;
+  raw?: string;
+  tone: string;
+}
+
+const ARCHIVE_STATUSES = new Set(["full", "leaked", "reverse"]);
+
+function caseOutcome(c: CaseView): Outcome {
+  const d = c.decision;
+  if (d?.audit?.vetoedBy) return { label: "PM 否决", raw: `veto:${d.audit.vetoedBy}`, tone: "outRed" };
+  if (d) {
+    if (d.action === "open" || d.action === "add" || d.action === "flip") {
+      const dir = d.direction ? ` · ${zhTradeDirection(d.direction)}` : "";
+      return { label: `${zhAction(d.action)}${dir}`, raw: d.action, tone: "outGreen" };
+    }
+    if (d.action === "close" || d.action === "trim") return { label: zhAction(d.action), raw: d.action, tone: "outBlue" };
+    return { label: zhAction(d.action), raw: d.action, tone: "outGrey" };
+  }
+  if (c.thesis) return { label: "研究完成 · 无决策记录", tone: "outGrey" };
+  const pin = c.signal?.pricedIn;
+  if (pin && ARCHIVE_STATUSES.has(pin.status)) {
+    return { label: `闸门2入档（${zhPricedIn(pin.status)}）`, raw: pin.status, tone: "outAmber" };
+  }
+  const mat = c.signal?.materiality;
+  if (mat && mat.tradeable === false) return { label: "闸门1入档（不可交易）", tone: "outGrey" };
+  if (c.signal && !mat) return { label: "无 M1 判定", tone: "outGrey" };
+  if (!c.signal) return { label: "未生成信号", tone: "outGrey" };
+  return { label: "闸门2未运行", tone: "outGrey" };
+}
+
+function stationsReached(c: CaseView): number {
+  let n = 1;
+  if (c.signal?.materiality) n += 1;
+  if (c.signal?.pricedIn) n += 1;
+  if (c.thesis) n += 1;
+  if (c.decision) n += 1;
+  if (c.execution || c.positionNow || c.postEvents.length > 0) n += 1;
+  return n;
+}
+
+// ---------------------------------------------------------------------------
+// Station 1 — 情报台
+
+function NewsStation({ c }: { c: CaseView }) {
+  const { news, signal } = c;
+  const lagMin = minutesBetween(news.publishedUtc, news.seenAtUtc);
+  return (
+    <Station no={1} title="情报台" tag="ingest">
+      <div className={styles.chipRow}>
+        <Chip zh={zhKind(news.kind)} raw={news.kind} />
+        <Chip zh={zhPrefix(news.prefix)} raw={news.prefix} tone={news.prefix === "reportedly" ? "outAmber" : undefined} />
+        {news.url ? (
+          <a className={styles.srcLink} href={news.url} target="_blank" rel="noopener noreferrer">
+            原文链接 ↗
+          </a>
+        ) : null}
+      </div>
+      <div className={styles.kvGrid}>
+        <KV label="发布时间 publishedUtc">{fmtUtc(news.publishedUtc)}</KV>
+        <KV label="系统见到 seenAtUtc">{fmtUtc(news.seenAtUtc)}</KV>
+        <KV label="发布 → 见到 Δ">{fmtMinutes(lagMin)}</KV>
+        <KV label="首次公开 firstSeenUtc">{signal ? fmtUtc(signal.firstSeenUtc) : "—"}</KV>
+        <KV label="信号指纹 fingerprint">
+          <span className={styles.mono}>{signal?.fingerprint || "—"}</span>
+        </KV>
+        <KV label="新闻 id">
+          <span className={styles.mono}>{news.newsId || "—"}</span>
+        </KV>
+      </div>
+      {signal?.firstSeenBasis ? <Quote label="firstSeenBasis 原文（t0 依据）" text={signal.firstSeenBasis} /> : null}
+    </Station>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Station 2 — 重要性判定 (M1 · 闸门1)
+
+function MaterialityStation({ signal, skipReason }: { signal: SignalView | null; skipReason: string | null }) {
+  const mat = signal?.materiality ?? null;
+  if (!signal || !mat) {
+    return <Station no={2} title="重要性判定" tag="M1 · 闸门1" skipReason={skipReason ?? "上游未记录 M1 判定"} />;
+  }
+  return (
+    <Station no={2} title="重要性判定" tag="M1 · 闸门1">
+      <div className={styles.chipRow}>
+        {mat.tradeable === null ? (
+          <Chip zh="tradeable 未记录" tone="outGrey" />
+        ) : (
+          <Chip
+            zh={mat.tradeable ? "可交易" : "不可交易"}
+            raw={`tradeable:${mat.tradeable}`}
+            tone={mat.tradeable ? "outGreen" : "outGrey"}
+            strong
+          />
+        )}
+        <Chip zh={`评分 ${mat.score === null ? "—" : mat.score}/100`} raw="score" strong />
+        <Chip zh={zhEventType(mat.eventType)} raw={mat.eventType} />
+        <Chip zh={zhFactLevel(mat.factLevel)} raw={mat.factLevel} />
+        <Chip zh={zhNewsDirection(signal.expectedDirection)} raw={signal.expectedDirection} />
+        <Chip zh={`预估幅度：${zhImpactBand(signal.coarseImpactBand)}`} raw={signal.coarseImpactBand} />
+        {mat.tickers.length > 0 ? (
+          mat.tickers.map((t) => <Chip key={t} zh={t} tone="outBlue" strong />)
+        ) : (
+          <Chip zh="无标的命中" tone="outGrey" />
+        )}
+      </div>
+      <Quote label="surpriseNote 原文（超出共识基线的部分）" text={mat.surpriseNote} />
+      <Quote label="reason 原文" text={mat.reason} />
+    </Station>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Station 3 — 交易台 · 已定价检查 (M1 · 闸门2)
+
+function PricedInStation({ signal, skipReason }: { signal: SignalView | null; skipReason: string | null }) {
+  const pin = signal?.pricedIn ?? null;
+  if (!pin) {
+    return <Station no={3} title="交易台 · 已定价检查" tag="M1 · 闸门2" skipReason={skipReason ?? "上游未记录已定价检查"} />;
+  }
+  return (
+    <Station no={3} title="交易台 · 已定价检查" tag="M1 · 闸门2">
+      <div className={styles.chipRow}>
+        <Chip zh={zhPricedIn(pin.status)} raw={pin.status} tone={pricedInTone(pin.status)} strong />
+        <Chip zh={`判定信心：${zhConfidence(pin.confidence)}`} raw={pin.confidence} />
+        <Chip zh={zhSession(pin.sessionBucket)} raw={pin.sessionBucket} />
+        <Chip zh={`行情源：${pin.dataBasis || "—"}`} raw={pin.dataBasis} />
+      </div>
+      <div className={styles.kvGrid}>
+        <KV label="已实现超额涨跌 realizedExcessPct">{fmtPct(pin.realizedExcessPct, { signed: true })}</KV>
+        <KV label="β（基准）">
+          {fmtBeta(pin.betaUsed)}（{zhBenchmark(pin.benchmarkUsed) || "—"}）
+        </KV>
+        <KV label="成交量 Z 分位 volumeZ">{pin.volumeZ === null ? "—" : pin.volumeZ.toFixed(2)}</KV>
+        <KV label="评估时刻 tEvalUtc">{fmtUtc(pin.tEvalUtc)}</KV>
+        <KV label="距 t0 时长 deltaTMinutes">{fmtMinutes(pin.deltaTMinutes)}</KV>
+      </div>
+      <Quote label="note 原文（内含反应完成度算式）" text={pin.note} />
+    </Station>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Station 4 — 研究 memo (M2)
+
+function ThesisStation({ thesis, skipReason }: { thesis: ThesisView | null; skipReason: string | null }) {
+  if (!thesis) {
+    return <Station no={4} title="研究 memo" tag="M2 · analysis" skipReason={skipReason ?? "上游未记录研究 memo"} />;
+  }
+  const fair = thesis.fairImpactPct;
+  const contaminationTone =
+    thesis.contamination === "hard" ? "outRed" : thesis.contamination === "soft" ? "outAmber" : "outGreen";
+  return (
+    <Station no={4} title="研究 memo" tag="M2 · analysis">
+      <div className={styles.chipRow}>
+        <Chip zh={thesis.ticker || "—"} tone="outBlue" strong />
+        <Chip
+          zh={zhTradeDirection(thesis.direction)}
+          raw={thesis.direction}
+          tone={thesis.direction === "long" ? "outGreen" : thesis.direction === "short" ? "outRed" : undefined}
+          strong
+        />
+        <Chip zh={`信心：${zhConfidence(thesis.confidence)}`} raw={thesis.confidence} />
+        <Chip zh={zhContamination(thesis.contamination)} raw={thesis.contamination} tone={contaminationTone} />
+        <Chip zh={`分析引擎：${zhProvider(thesis.provider)}`} raw={thesis.provider} />
+        <Chip zh={`持有窗口 ${fmtHours(thesis.horizonHours)}`} raw="horizonHours" />
+      </div>
+      {fair ? (
+        <div className={styles.bigNums}>
+          <div className={styles.bigNum}>
+            <span className={styles.bigNumLabel}>公允冲击下限 min</span>
+            <span className={styles.bigNumValue}>{fmtPct(fair.min, { signed: true })}</span>
+          </div>
+          <div className={`${styles.bigNum} ${styles.bigNumMain}`}>
+            <span className={styles.bigNumLabel}>点估计 point</span>
+            <span className={styles.bigNumValue}>{fmtPct(fair.point, { signed: true })}</span>
+          </div>
+          <div className={styles.bigNum}>
+            <span className={styles.bigNumLabel}>公允冲击上限 max</span>
+            <span className={styles.bigNumValue}>{fmtPct(fair.max, { signed: true })}</span>
+          </div>
+        </div>
+      ) : (
+        <p className={styles.skipNote}>fairImpactPct 未记录</p>
+      )}
+      {thesis.impactPath.length > 0 ? (
+        <>
+          <p className={styles.subHead}>影响传导路径 impactPath（全文，不截断）</p>
+          <div className={styles.tableWrap}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th>step</th>
+                  <th>value</th>
+                </tr>
+              </thead>
+              <tbody>
+                {thesis.impactPath.map((s, i) => (
+                  <tr key={i}>
+                    <td>{s.step}</td>
+                    <td>{s.value}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      ) : null}
+      {thesis.evidence.length > 0 ? (
+        <>
+          <p className={styles.subHead}>证据 evidence</p>
+          <ul className={styles.plainList}>
+            {thesis.evidence.map((e, i) => (
+              <li key={i}>
+                {e.point}
+                <span className={styles.srcMeta}>
+                  {e.source ? `来源：${e.source} · ` : ""}
+                  {zhCredibility(e.credibility)}
+                  <span className={styles.mono}> {e.credibility}</span>
+                </span>
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : null}
+      {thesis.catalysts.length > 0 ? (
+        <>
+          <p className={styles.subHead}>催化剂 catalysts</p>
+          <ul className={styles.plainList}>
+            {thesis.catalysts.map((x, i) => (
+              <li key={i}>{x}</li>
+            ))}
+          </ul>
+        </>
+      ) : null}
+      {thesis.falsifiers.length > 0 ? (
+        <>
+          <p className={styles.subHead}>证伪条件 falsifiers</p>
+          <ul className={styles.plainList}>
+            {thesis.falsifiers.map((x, i) => (
+              <li key={i}>{x}</li>
+            ))}
+          </ul>
+        </>
+      ) : null}
+      {thesis.limitations.length > 0 ? (
+        <>
+          <p className={styles.subHead}>局限 limitations</p>
+          <ul className={styles.plainList}>
+            {thesis.limitations.map((x, i) => (
+              <li key={i}>{x}</li>
+            ))}
+          </ul>
+        </>
+      ) : null}
+    </Station>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Station 5 — PM 台 (M3 · decision)
+
+const ZH_VETO: Record<string, string> = {
+  halted: "账本熔断中",
+  cooldown: "止损冷却期",
+  earnings: "财报窗口",
+  earnings_window: "财报窗口"
+};
+
+function actionTone(action: string): string {
+  if (action === "open" || action === "add" || action === "flip") return "outGreen";
+  if (action === "close" || action === "trim") return "outBlue";
+  return "outGrey";
+}
+
+function DecisionStation({ decision, skipReason }: { decision: DecisionView | null; skipReason: string | null }) {
+  if (!decision) {
+    return <Station no={5} title="PM 台" tag="M3 · decision" skipReason={skipReason ?? "上游未记录 PM 决策"} />;
+  }
+  const audit = decision.audit;
+  const vetoed = audit?.vetoedBy ?? null;
+  const edge = audit?.edge ?? null;
+  const thr = audit?.threshold ?? null;
+  const stop = audit?.stopMenu ?? null;
+  const sizing = audit?.sizing ?? null;
+  const mkt = audit?.marketView ?? null;
+  const volBinds =
+    thr !== null && thr.thresholdPct !== null && thr.volFloorPct !== null && thr.thresholdPct === thr.volFloorPct;
+  const costBinds =
+    thr !== null && thr.thresholdPct !== null && thr.costFloorPct !== null && thr.thresholdPct === thr.costFloorPct;
+  const passed =
+    edge !== null && thr !== null && edge.residualPct !== null && thr.thresholdPct !== null
+      ? edge.residualPct >= thr.thresholdPct
+      : null;
+  return (
+    <Station no={5} title="PM 台" tag="M3 · decision">
+      <div className={styles.chipRow}>
+        <Chip
+          zh={vetoed ? `否决 · ${ZH_VETO[vetoed] ?? vetoed}` : zhAction(decision.action)}
+          raw={vetoed ? `vetoedBy:${vetoed}` : decision.action}
+          tone={vetoed ? "outRed" : actionTone(decision.action)}
+          strong
+        />
+        {decision.direction ? <Chip zh={zhTradeDirection(decision.direction)} raw={decision.direction} /> : null}
+        <Chip zh={decision.ticker || "—"} tone="outBlue" />
+        <Chip zh={`决策参考价 ${fmtPx(decision.refPx)}`} raw="refPx" />
+        <Chip zh={fmtUtc(decision.createdAtUtc)} raw="createdAtUtc" />
+      </div>
+
+      {audit ? (
+        <>
+          {edge ? (
+            <>
+              <p className={styles.subHead}>Edge 表（%，超额口径）</p>
+              <div className={styles.tableWrap}>
+                <table className={styles.table}>
+                  <thead>
+                    <tr>
+                      <th>
+                        保守口径 <span className={styles.mono}>conservativePct</span>
+                      </th>
+                      <th>
+                        点估计 <span className={styles.mono}>pointPct</span>
+                      </th>
+                      <th>
+                        已实现 <span className={styles.mono}>realizedPct</span>
+                      </th>
+                      <th>
+                        残余 edge <span className={styles.mono}>residualPct</span>
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td className={styles.num}>{fmtPct(edge.conservativePct, { signed: true })}</td>
+                      <td className={styles.num}>{fmtPct(edge.pointPct, { signed: true })}</td>
+                      <td className={styles.num}>{fmtPct(edge.realizedPct, { signed: true })}</td>
+                      <td className={styles.num}>
+                        <strong>{fmtPct(edge.residualPct, { signed: true })}</strong>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </>
+          ) : (
+            <p className={styles.skipNote}>Edge 算术未记录（决策在此之前终止）</p>
+          )}
+
+          {thr ? (
+            <>
+              <p className={styles.subHead}>门槛分解表</p>
+              <div className={styles.tableWrap}>
+                <table className={styles.table}>
+                  <thead>
+                    <tr>
+                      <th>成本项</th>
+                      <th>算式</th>
+                      <th className={styles.num}>数值</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>
+                        taker 手续费 <span className={styles.mono}>takerFeePct</span>
+                      </td>
+                      <td className={styles.formulaCell}>单边</td>
+                      <td className={styles.num}>{fmtPct(thr.takerFeePct)}</td>
+                    </tr>
+                    <tr>
+                      <td>
+                        滑点 <span className={styles.mono}>slippagePct</span>
+                      </td>
+                      <td className={styles.formulaCell}>单边估计</td>
+                      <td className={styles.num}>{fmtPct(thr.slippagePct)}</td>
+                    </tr>
+                    <tr>
+                      <td>
+                        资金费 <span className={styles.mono}>fundingPct</span>
+                      </td>
+                      <td className={styles.formulaCell}>持有期合计（下限 0）</td>
+                      <td className={styles.num}>{fmtPct(thr.fundingPct)}</td>
+                    </tr>
+                    <tr>
+                      <td>
+                        往返成本 <span className={styles.mono}>roundTripPct</span>
+                      </td>
+                      <td className={styles.formulaCell}>2×(手续费+滑点)+资金费</td>
+                      <td className={styles.num}>{fmtPct(thr.roundTripPct)}</td>
+                    </tr>
+                    <tr className={costBinds ? styles.hlRow : undefined}>
+                      <td>
+                        成本地板 <span className={styles.mono}>costFloorPct</span>
+                      </td>
+                      <td className={styles.formulaCell}>= 3 × 往返成本</td>
+                      <td className={styles.num}>{fmtPct(thr.costFloorPct)}</td>
+                    </tr>
+                    <tr className={volBinds ? styles.hlRow : undefined}>
+                      <td>
+                        波动地板 <span className={styles.mono}>volFloorPct</span>
+                      </td>
+                      <td className={styles.formulaCell}>= 0.5 × 日波动 × 持有折算</td>
+                      <td className={styles.num}>{fmtPct(thr.volFloorPct)}</td>
+                    </tr>
+                    <tr className={styles.hlRow}>
+                      <td>
+                        门槛 <span className={styles.mono}>thresholdPct</span>
+                      </td>
+                      <td className={styles.formulaCell}>
+                        = max(成本地板, 波动地板){volBinds ? " → 波动地板生效" : costBinds ? " → 成本地板生效" : ""}
+                      </td>
+                      <td className={styles.num}>{fmtPct(thr.thresholdPct)}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              {passed !== null && edge ? (
+                <p className={styles.verdictLine}>
+                  残余 edge {fmtPct(edge.residualPct, { signed: true })}{" "}
+                  {passed ? "≥" : "<"} 门槛 {fmtPct(thr.thresholdPct)} →{" "}
+                  <Chip zh={passed ? "通过门槛" : "不过门槛"} tone={passed ? "outGreen" : "outRed"} strong />
+                </p>
+              ) : null}
+            </>
+          ) : (
+            <p className={styles.skipNote}>门槛分解未记录（决策在此之前终止）</p>
+          )}
+
+          {stop ? (
+            <>
+              <p className={styles.subHead}>止损菜单 stopMenu</p>
+              <div className={styles.tableWrap}>
+                <table className={styles.table}>
+                  <thead>
+                    <tr>
+                      <th>候选</th>
+                      <th className={styles.num}>价格 / 数值</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>
+                        ATR(20 日) <span className={styles.mono}>atr20d</span>
+                      </td>
+                      <td className={styles.num}>{fmtPx(stop.atr20d)}</td>
+                    </tr>
+                    <tr>
+                      <td>
+                        ATR 止损价 <span className={styles.mono}>atrStopPx</span>
+                      </td>
+                      <td className={styles.num}>{fmtPx(stop.atrStopPx)}</td>
+                    </tr>
+                    <tr>
+                      <td>
+                        摆动位 <span className={styles.mono}>swingPx</span>
+                      </td>
+                      <td className={styles.num}>{fmtPx(stop.swingPx)}</td>
+                    </tr>
+                    <tr>
+                      <td>
+                        硬性红线价 <span className={styles.mono}>hardFloorPx</span>（−20% 用户红线）
+                      </td>
+                      <td className={styles.num}>{fmtPx(stop.hardFloorPx)}</td>
+                    </tr>
+                    <tr className={styles.hlRow}>
+                      <td>
+                        选用止损价 <span className={styles.mono}>chosenPx</span>
+                      </td>
+                      <td className={styles.num}>{fmtPx(stop.chosenPx)}</td>
+                    </tr>
+                    <tr>
+                      <td>
+                        止损距离 <span className={styles.mono}>stopDistPct</span>
+                      </td>
+                      <td className={styles.num}>{fmtFracPct(stop.stopDistPct)}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </>
+          ) : (
+            <p className={styles.skipNote}>止损菜单未记录（决策在此之前终止）</p>
+          )}
+
+          {sizing ? (
+            <>
+              <p className={styles.subHead}>Sizing 链</p>
+              <div className={styles.eqLine}>
+                <span className={styles.eqPart}>
+                  <span className={styles.eqValue}>{fmtUsd(sizing.equityUsd)}</span>
+                  <span className={styles.eqLabel}>权益 equityUsd</span>
+                </span>
+                <span className={styles.eqOp}>×</span>
+                <span className={styles.eqPart}>
+                  <span className={styles.eqValue}>{fmtFracPct(sizing.riskBudgetPct)}</span>
+                  <span className={styles.eqLabel}>风险预算 riskBudgetPct</span>
+                </span>
+                <span className={styles.eqOp}>÷</span>
+                <span className={styles.eqPart}>
+                  <span className={styles.eqValue}>{fmtFracPct(stop?.stopDistPct ?? null)}</span>
+                  <span className={styles.eqLabel}>止损距离 stopDistPct</span>
+                </span>
+                <span className={styles.eqOp}>=</span>
+                <span className={`${styles.eqPart} ${styles.eqPartHl}`}>
+                  <span className={styles.eqValue}>{fmtUsd(sizing.intendedNotionalUsd)}</span>
+                  <span className={styles.eqLabel}>意向名义 intendedNotionalUsd</span>
+                </span>
+              </div>
+              {sizing.guards.length > 0 ? (
+                <div className={styles.tableWrap}>
+                  <table className={styles.table}>
+                    <thead>
+                      <tr>
+                        <th>风控闸 guard</th>
+                        <th className={styles.num}>上限 capUsd</th>
+                        <th className={styles.num}>过闸后名义 notionalAfterUsd</th>
+                        <th>状态</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {sizing.guards.map((g, i) => {
+                        const binding = decision.bindingConstraint !== null && g.name === decision.bindingConstraint;
+                        return (
+                          <tr key={i} className={g.clipped ? styles.hlRow : undefined}>
+                            <td>
+                              {zhGuard(g.name)} <span className={styles.mono}>{g.name}</span>
+                            </td>
+                            <td className={styles.num}>{fmtUsd(g.capUsd)}</td>
+                            <td className={styles.num}>{fmtUsd(g.notionalAfterUsd)}</td>
+                            <td>
+                              {g.clipped ? <span className={styles.tagClipped}>裁剪</span> : "通过"}
+                              {binding ? <span className={styles.tagBinding}>binding</span> : null}
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              ) : null}
+              <div className={styles.kvGrid}>
+                <KV label="最终名义 finalNotionalUsd">
+                  <strong>{fmtUsd(sizing.finalNotionalUsd)}</strong>
+                </KV>
+                {sizing.leverage ? (
+                  <KV label="杠杆三帽 configCap / volCap / venueCap → chosen">
+                    {fmtX(sizing.leverage.configCap)} / {fmtX(sizing.leverage.volCap)} /{" "}
+                    {fmtX(sizing.leverage.venueCap)} → <strong>{fmtX(sizing.leverage.chosen)}</strong>
+                  </KV>
+                ) : (
+                  <KV label="杠杆三帽">—</KV>
+                )}
+              </div>
+            </>
+          ) : (
+            <p className={styles.skipNote}>Sizing 链未记录（决策在此之前终止）</p>
+          )}
+
+          {mkt ? (
+            <div className={styles.chipRow}>
+              <Chip zh={`mark ${fmtPx(mkt.markPx)}`} raw="markPx" />
+              <Chip zh={`日波动 ${fmtFracPct(mkt.dailyVolPct)}`} raw="dailyVolPct" />
+              <Chip zh={`最大日内波动 ${fmtFracPct(mkt.maxDailyMovePct)}`} raw="maxDailyMovePct" />
+              <Chip zh={`资金费率 ${fmtFracPct(mkt.fundingHourly)}/小时`} raw="fundingHourly" />
+              <Chip zh={`β ${fmtBeta(mkt.beta)}`} raw="beta" />
+            </div>
+          ) : null}
+        </>
+      ) : (
+        <p className={styles.skipNote}>此决策无逐项审计——审计字段自 2026-08-23 起记录，早于该时点的决策仅有 reason 原文。</p>
+      )}
+
+      {decision.action !== "no_trade" || decision.sizeUsd ? (
+        <div className={styles.kvGrid}>
+          <KV label="下单规模 sizeUsd">{fmtUsd(decision.sizeUsd)}</KV>
+          <KV label="杠杆 leverage">{fmtX(decision.leverage)}</KV>
+          <KV label="意向风险 intendedRiskPct">{fmtFracPct(decision.intendedRiskPct)}</KV>
+          <KV label="实际风险 realizedRiskPct">{fmtFracPct(decision.realizedRiskPct)}</KV>
+          <KV label="残余 edge residualEdgePct">{fmtPct(decision.residualEdgePct)}</KV>
+          <KV label="被裁剪于 bindingConstraint">
+            {decision.bindingConstraint ? (
+              <>
+                {zhGuard(decision.bindingConstraint)} <span className={styles.mono}>{decision.bindingConstraint}</span>
+              </>
+            ) : (
+              "—"
+            )}
+          </KV>
+          <KV label="持有期限 horizonUtc">{fmtUtc(decision.horizonUtc)}</KV>
+          <KV label="目标超额区间 targetPctExcess">
+            {decision.targetPctExcess
+              ? `${fmtPct(decision.targetPctExcess.lo)} ~ ${fmtPct(decision.targetPctExcess.hi)}`
+              : "—"}
+          </KV>
+          {decision.stop ? (
+            <KV label="止损 initialPx / hardFloorPx">
+              {fmtPx(decision.stop.initialPx)} / {fmtPx(decision.stop.hardFloorPx)}（−20% 用户红线）
+            </KV>
+          ) : null}
+        </div>
+      ) : null}
+      {decision.stop?.rule ? <Quote label="止损规则 stop.rule 原文" text={decision.stop.rule} /> : null}
+      <Quote label="decision.reason 原文" text={decision.reason} />
+      <p className={styles.mono}>decision id: {decision.id || "—"}</p>
+    </Station>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Station 6 — 执行 / 风控后续
+
+function PostStation({ c, skipReason }: { c: CaseView; skipReason: string | null }) {
+  const { execution, positionNow, postEvents, decision } = c;
+  if (!execution && !positionNow && postEvents.length === 0) {
+    return <Station no={6} title="执行 / 风控后续" tag="paper book" skipReason={skipReason ?? "无记录"} />;
+  }
+  const slippage =
+    execution !== null && execution.fillPx !== null && decision !== null && decision.refPx !== null && decision.refPx !== 0
+      ? (execution.fillPx - decision.refPx) / decision.refPx
+      : null;
+  return (
+    <Station no={6} title="执行 / 风控后续" tag="paper book">
+      {execution ? (
+        <>
+          <p className={styles.subHead}>模拟执行 execution</p>
+          <div className={styles.kvGrid}>
+            <KV label="类型 type">
+              {zhPostEvent(execution.type)} <span className={styles.mono}>{execution.type}</span>
+            </KV>
+            <KV label="成交时间 ts">{fmtUtc(execution.ts)}</KV>
+            <KV label="方向 / 数量">
+              {execution.direction ? zhTradeDirection(execution.direction) : "—"} · {fmtQty(execution.qty)}
+            </KV>
+            <KV label="成交价 fillPx">{fmtPx(execution.fillPx)}</KV>
+            <KV label="名义规模 sizeUsd">{fmtUsd(execution.sizeUsd)}</KV>
+            <KV label="滑点（fillPx vs 决策 refPx）">
+              {slippage === null ? (
+                "—"
+              ) : (
+                <>
+                  {fmtPx(execution.fillPx)} vs {fmtPx(decision?.refPx ?? null)} = {fmtFracPct(slippage, { signed: true })}
+                </>
+              )}
+            </KV>
+          </div>
+        </>
+      ) : null}
+      {positionNow ? <PositionBlock p={positionNow} /> : execution ? (
+        <p className={styles.skipNote}>当前账本无此仓位（可能已平仓，见下方事件；或账本已重置）。</p>
+      ) : null}
+      <p className={styles.subHead}>风控事件时间线 postEvents</p>
+      {postEvents.length === 0 ? (
+        <p className={styles.skipNote}>暂无 stop_loss / hard_floor_stop / paper_close 事件。</p>
+      ) : (
+        <ul className={styles.timeline}>
+          {postEvents.map((e, i) => (
+            <li key={i} className={styles.timelineItem}>
+              <Chip
+                zh={zhPostEvent(e.type)}
+                raw={e.type}
+                tone={e.type === "hard_floor_stop" ? "outRed" : e.type === "stop_loss" ? "outAmber" : "outBlue"}
+                strong
+              />
+              <span>{fmtUtc(e.ts)}</span>
+              {e.pnlUsd !== null ? (
+                <span className={e.pnlUsd >= 0 ? styles.pos : styles.neg}>盈亏 {fmtSignedUsd(e.pnlUsd)}</span>
+              ) : null}
+              {e.extras.map((x) => (
+                <span key={x.key} className={styles.mono}>
+                  {x.key}={x.value}
+                </span>
+              ))}
+            </li>
+          ))}
+        </ul>
+      )}
+    </Station>
+  );
+}
+
+function PositionBlock({ p }: { p: PositionNowView }) {
+  return (
+    <>
+      <p className={styles.subHead}>当前仓位 positionNow</p>
+      <div className={styles.kvGrid}>
+        <KV label="标的 / 方向">
+          {p.ticker} · {zhTradeDirection(p.direction)}
+        </KV>
+        <KV label="开仓价 entryPx / 数量 qty">
+          {fmtPx(p.entryPx)} · {fmtQty(p.qty)}
+        </KV>
+        <KV label="开仓名义 notionalUsdAtEntry">{fmtUsd(p.notionalUsdAtEntry)}</KV>
+        <KV label="杠杆 leverage">{fmtX(p.leverage)}</KV>
+        <KV label="当前 mark">{p.markPx === null ? "—（快照未含实时 mark）" : fmtPx(p.markPx)}</KV>
+        <KV label="浮动盈亏 unrealizedPnlUsd">
+          {p.unrealizedPnlUsd === null ? "—（快照未含实时 mark）" : fmtSignedUsd(p.unrealizedPnlUsd)}
+        </KV>
+        <KV label="止损价 stopPx">{fmtPx(p.stopPx)}</KV>
+        <KV label="硬性红线价 hardFloorPx（−20%）">{fmtPx(p.hardFloorPx)}</KV>
+        <KV label="持有期限 horizonUtc">{fmtUtc(p.horizonUtc)}</KV>
+        <KV label="t0 基准价 baselinePx">{fmtPx(p.baselinePx)}</KV>
+        <KV label="基准指数 t0 价 benchmarkBaselinePx">{fmtPx(p.benchmarkBaselinePx)}</KV>
+        <KV label="β / 追踪止损">
+          {fmtBeta(p.beta)} · {p.trailArmed === null ? "—" : p.trailArmed ? "追踪已启动" : "追踪未启动"}
+        </KV>
+        <KV label="目标超额区间 targetPctExcess">
+          {p.targetPctExcess ? `${fmtPct(p.targetPctExcess.lo)} ~ ${fmtPct(p.targetPctExcess.hi)}` : "—"}
+        </KV>
+        <KV label="最高收盘 highestClosePx">{fmtPx(p.highestClosePx)}</KV>
+        <KV label="开仓时间 entryUtc">{fmtUtc(p.entryUtc)}</KV>
+      </div>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Case card: summary line + six-station chain
+
+function skipReasons(c: CaseView): { st2: string | null; st3: string | null; st4: string | null; st5: string | null; st6: string | null } {
+  const mat = c.signal?.materiality ?? null;
+  const pin = c.signal?.pricedIn ?? null;
+  const notTradeable = mat !== null && mat.tradeable === false;
+  const pinArchived = pin !== null && ARCHIVE_STATUSES.has(pin.status);
+  const st2 = c.signal && mat ? null : c.signal ? "上游未记录 M1 判定" : "该新闻未生成信号记录";
+  const st3 = pin
+    ? null
+    : !c.signal
+      ? "闸门1未运行（无信号）"
+      : notTradeable
+        ? `闸门1判定不可交易（score ${mat?.score ?? "—"}），已入档，未进入已定价检查`
+        : "上游未记录已定价检查";
+  const st4 = c.thesis
+    ? null
+    : notTradeable
+      ? "闸门1入档，未进入研究"
+      : pinArchived && pin
+        ? `已定价检查判定「${zhPricedIn(pin.status)}」，已入档，未进入研究`
+        : c.signal
+          ? "上游未记录研究 memo"
+          : "无信号，未进入研究";
+  const st5 = c.decision ? null : c.thesis ? "上游未记录 PM 决策" : "无研究 memo，未进入 PM 台";
+  const st6 =
+    c.execution || c.positionNow || c.postEvents.length > 0
+      ? null
+      : c.decision
+        ? c.decision.action === "open" || c.decision.action === "add" || c.decision.action === "flip"
+          ? "上游未记录执行"
+          : `决策为「${zhAction(c.decision.action)}」，无执行`
+        : "无决策，未进入执行";
+  return { st2, st3, st4, st5, st6 };
+}
+
+function CaseCard({ c, defaultOpen }: { c: CaseView; defaultOpen: boolean }) {
+  const outcome = caseOutcome(c);
+  const reached = stationsReached(c);
+  const tickers = c.thesis?.ticker
+    ? [c.thesis.ticker]
+    : c.signal?.materiality?.tickers?.length
+      ? c.signal.materiality.tickers
+      : [];
+  const skip = skipReasons(c);
+  return (
+    <details className={styles.caseCard} open={defaultOpen}>
+      <summary className={styles.caseSummary}>
+        <div className={styles.sumTop}>
+          <Chip zh={outcome.label} raw={outcome.raw} tone={outcome.tone} strong />
+          <span className={styles.sumTitle}>{c.news.title}</span>
+        </div>
+        <div className={styles.sumMeta}>
+          <span>见到 {fmtUtc(c.news.seenAtUtc)}</span>
+          {tickers.length > 0 ? <span>{tickers.join(" · ")}</span> : null}
+          <span>到站 {reached}/6</span>
+          <span className={styles.sumChevron}>展开决策链 ▾</span>
+        </div>
+      </summary>
+      <div className={styles.caseBody}>
+        <ol className={styles.chain}>
+          <NewsStation c={c} />
+          <MaterialityStation signal={c.signal} skipReason={skip.st2} />
+          <PricedInStation signal={c.signal} skipReason={skip.st3} />
+          <ThesisStation thesis={c.thesis} skipReason={skip.st4} />
+          <DecisionStation decision={c.decision} skipReason={skip.st5} />
+          <PostStation c={c} skipReason={skip.st6} />
+        </ol>
+      </div>
+    </details>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Reflection footer
+
+function ReflectionFooter({ r }: { r: ReflectionView }) {
+  const f = r.funnel;
+  const cont = r.contamination;
+  const m1 = r.m1Calibration;
+  return (
+    <section className={styles.section} aria-labelledby="sec-reflection">
+      <h2 id="sec-reflection" className={styles.sectionTitle}>
+        当日反思关键数（{r.date || "—"}）
+      </h2>
+      {f ? (
+        <div className={styles.funnelLine}>
+          <span className={styles.funnelStep}>新闻 {fmtInt(f.newsSeen)}</span>
+          <span className={styles.funnelArrow}>→</span>
+          <span className={styles.funnelStep}>信号 {fmtInt(f.signals)}</span>
+          <span className={styles.funnelArrow}>→</span>
+          <span className={styles.funnelStep}>
+            入档：无标的 {fmtInt(f.archivedNoTicker)} · 不重要 {fmtInt(f.archivedNotMaterial)} · 过期{" "}
+            {fmtInt(f.archivedStale)} · 已定价 {fmtInt(f.archivedPricedIn)}
+          </span>
+          <span className={styles.funnelArrow}>→</span>
+          <span className={styles.funnelStep}>研究 memo {fmtInt(f.theses)}</span>
+          <span className={styles.funnelArrow}>→</span>
+          <span className={styles.funnelStep}>
+            开仓 {fmtInt(f.decisionsOpen)} · 不开仓 {fmtInt(f.decisionsNoTrade)}
+          </span>
+        </div>
+      ) : (
+        <p className={styles.sectionNote}>反思报告未含漏斗数据。</p>
+      )}
+      <div className={styles.chipRow}>
+        {cont ? (
+          <Chip
+            zh={`污染率 ${cont.rate === null ? "—" : `${(cont.rate * 100).toFixed(0)}%`}（研究 ${fmtInt(cont.theses)} 份：重度 ${fmtInt(cont.hard)} · 轻度 ${fmtInt(cont.soft)}）`}
+            raw="contamination"
+            tone={cont.rate !== null && cont.rate > 0 ? "outAmber" : "outGreen"}
+          />
+        ) : null}
+        {m1?.forwarded ? (
+          <Chip
+            zh={`放行样本方向命中 ${fmtInt(m1.forwarded.hits)}/${fmtInt(m1.forwarded.n)}${m1.forwarded.hitRate === null ? "（样本不足）" : ` = ${(m1.forwarded.hitRate * 100).toFixed(0)}%`}`}
+            raw="m1Calibration.forwarded"
+          />
+        ) : null}
+        {m1?.archivedFullReverse ? (
+          <Chip
+            zh={`错杀检查：入档「已定价/反向」${fmtInt(m1.archivedFullReverse.n)} 条，其中随新闻方向走 ${fmtInt(m1.archivedFullReverse.movedWithNews)} 条`}
+            raw="m1Calibration.archivedFullReverse"
+          />
+        ) : null}
+        {r.deltaT ? (
+          <Chip zh={`t0→评估延迟中位数 ${fmtMinutes(r.deltaT.medianMinutes)}（n=${fmtInt(r.deltaT.n)}）`} raw="deltaT" />
+        ) : null}
+        {r.engines.map((e) => (
+          <Chip key={e.name} zh={`${zhProvider(e.name)} ${e.count} 次`} raw={e.name} />
+        ))}
+      </div>
+      {r.pricedInDistribution.length > 0 ? (
+        <p className={styles.sectionNote}>
+          已定价检查分布：
+          {r.pricedInDistribution
+            .map((d) => `${d.status === "not_evaluated" ? "未评估" : zhPricedIn(d.status)} ${d.count}`)
+            .join(" · ")}
+        </p>
+      ) : null}
+      {r.noTradeReasons.length > 0 ? (
+        <p className={styles.sectionNote}>
+          不开仓原因：{r.noTradeReasons.map((x) => `「${x.reason}」× ${x.count}`).join("；")}
+        </p>
+      ) : null}
+      {r.book ? (
+        <p className={styles.sectionNote}>
+          反思时点账本：权益 {fmtUsd(r.book.equityUsd)} · 已实现 {fmtSignedUsd(r.book.realizedPnlUsd)} · 持仓{" "}
+          {fmtInt(r.book.positions)} · {r.book.halted ? "已熔断" : "未熔断"}
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page shell
+
+export function DeltaPmReport({ payload, dataSource }: { payload: AuditPayload; dataSource: "live" | "baked" }) {
+  const p = payload.portfolio;
+  const book = payload.latestReflection?.book ?? null;
+  const initial = p?.initialCapitalUsd ?? null;
+  const realized = p?.realizedPnlUsd ?? null;
+  const equity = book?.equityUsd ?? (initial !== null && realized !== null ? initial + realized : null);
+  const firstThesisIdx = payload.cases.findIndex((c) => c.thesis !== null);
+  return (
+    <main className={styles.page}>
+      <header className={styles.header}>
+        <span className={styles.kicker}>Tokyo VM · services/delta-pm · 内部审计页</span>
+        <h1 className={styles.title}>Delta PM 决策链审计</h1>
+        <p className={styles.meta}>
+          每条新闻一份 IC memo：情报台 → 重要性判定 → 已定价检查 → 研究 memo → PM 台 → 执行/风控。
+          每个数字逐项摊开，不做抽象汇总；中文标签旁保留原始枚举值，便于与账本核对。
+        </p>
+        <div className={styles.bannerRow}>
+          <span className={`${styles.banner} ${styles.bannerShadow}`}>Phase 0 影子模式 · 只记账，不下真实订单</span>
+          {dataSource === "live" ? (
+            <span className={`${styles.banner} ${styles.bannerLive}`}>实时数据 · VM /delta-pm/audit</span>
+          ) : (
+            <span className={`${styles.banner} ${styles.bannerBaked}`}>
+              烘焙快照回退 · 实时数据暂不可用，显示 {payload.generatedAtUtc.slice(0, 10) || "—"} 留档
+            </span>
+          )}
+        </div>
+        <p className={styles.meta}>
+          账本起始 {fmtUtc(payload.bookStartedUtc)} · 数据生成 {fmtUtc(payload.generatedAtUtc)}
+          {p ? <> · 组合更新 {fmtUtc(p.updatedAtUtc)}</> : null}
+        </p>
+        {p?.halted ? (
+          <div className={styles.haltBar}>账本已熔断 HALTED{p.haltedReason ? ` — ${p.haltedReason}` : ""}</div>
+        ) : null}
+        <div className={styles.tiles}>
+          <div className={styles.tile}>
+            <span className={styles.tileLabel}>总权益（反思时点）</span>
+            <strong className={styles.tileValue}>{fmtUsd(equity)}</strong>
+            <span className={styles.tileSub}>
+              {initial !== null && equity !== null
+                ? `${fmtPct(((equity - initial) / initial) * 100, { signed: true })} vs 初始`
+                : "—"}
+            </span>
+          </div>
+          <div className={styles.tile}>
+            <span className={styles.tileLabel}>初始本金</span>
+            <strong className={styles.tileValue}>{fmtUsd(initial)}</strong>
+            <span className={styles.tileSub}>mode: {p?.mode || "—"}</span>
+          </div>
+          <div className={styles.tile}>
+            <span className={styles.tileLabel}>已实现盈亏</span>
+            <strong className={`${styles.tileValue} ${realized !== null && realized < 0 ? styles.neg : styles.pos}`}>
+              {fmtSignedUsd(realized)}
+            </strong>
+            <span className={styles.tileSub}>影子账本累计</span>
+          </div>
+          <div className={styles.tile}>
+            <span className={styles.tileLabel}>当前持仓</span>
+            <strong className={styles.tileValue}>{p ? p.positions.length : "—"}</strong>
+            <span className={styles.tileSub}>
+              {p && p.positions.length > 0
+                ? p.positions.map((x) => `${x.ticker} ${zhTradeDirection(x.direction)}`).join(" · ")
+                : "空仓"}
+            </span>
+          </div>
+        </div>
+      </header>
+
+      <section className={styles.section} aria-labelledby="sec-cases">
+        <h2 id="sec-cases" className={styles.sectionTitle}>
+          决策链（{payload.cases.length} 条新闻，新 → 旧）
+        </h2>
+        <p className={styles.sectionNote}>
+          点击任意卡片展开六站决策链；灰色站点表示该新闻止步于此，卡片会写明入档原因。
+        </p>
+        {payload.cases.length === 0 ? (
+          <p className={styles.sectionNote}>暂无案例数据。</p>
+        ) : (
+          payload.cases.map((c, i) => (
+            <CaseCard key={`${c.news.newsId}-${i}`} c={c} defaultOpen={i === (firstThesisIdx === -1 ? 0 : firstThesisIdx)} />
+          ))
+        )}
+      </section>
+
+      {payload.latestReflection ? <ReflectionFooter r={payload.latestReflection} /> : null}
+
+      <footer className={styles.footer}>
+        数据来自 Tokyo VM <span className={styles.mono}>/delta-pm/audit</span>（每次页面请求服务端拉取，成功后缓存 60
+        秒；连续失败退避 30 秒）。上游不可达时退回烘焙快照，页首会标注数据源。本页为 Phase 0
+        影子模式审计——所有决策仅记账，不向任何交易所下真实订单。
+      </footer>
+    </main>
+  );
+}

--- a/apps/web/app/live-delta-pm/unlock-gate.tsx
+++ b/apps/web/app/live-delta-pm/unlock-gate.tsx
@@ -1,0 +1,28 @@
+// Invite-code gate shown before the Delta PM audit page. Mirrors the /invite
+// look (auth-* classes from globals.css); the code is checked server-side by
+// /api/live-delta-pm/unlock.
+export function UnlockGate({ showError }: { showError: boolean }) {
+  return (
+    <section className="auth-shell">
+      <div className="auth-panel">
+        <span className="auth-kicker">Private audit</span>
+        <h1>Delta PM 决策链审计</h1>
+        <p>这是美股影子交易系统的内部审计页。输入访问码解锁（与 /engine 门相同的口令）。</p>
+        <form action="/api/live-delta-pm/unlock" method="post" className="auth-form">
+          <label htmlFor="ldp-code">Access code</label>
+          <input
+            id="ldp-code"
+            name="code"
+            type="password"
+            autoComplete="one-time-code"
+            maxLength={128}
+            required
+            autoFocus
+          />
+          <button type="submit">解锁 Unlock</button>
+        </form>
+        {showError ? <p className="auth-error">访问码不对，再试一次。</p> : null}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/lib/live-delta-pm/access.test.ts
+++ b/apps/web/lib/live-delta-pm/access.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { expectedAccessToken as lprExpectedAccessToken } from "../live-predict-raven/access";
+import { expectedAccessToken, isValidAccessToken, isValidCode } from "./access";
+
+describe("live-delta-pm access gate", () => {
+  afterEach(() => {
+    delete process.env.LIVE_DELTA_PM_CODE;
+  });
+
+  it("accepts the default code, ignoring surrounding whitespace", () => {
+    expect(isValidCode("raven-labs")).toBe(true);
+    expect(isValidCode("  raven-labs  ")).toBe(true);
+  });
+
+  it("rejects wrong, empty, oversized, and non-string codes", () => {
+    expect(isValidCode("raven-lab")).toBe(false);
+    expect(isValidCode("")).toBe(false);
+    expect(isValidCode("x".repeat(200))).toBe(false);
+    expect(isValidCode(null)).toBe(false);
+    expect(isValidCode(42)).toBe(false);
+  });
+
+  it("honors LIVE_DELTA_PM_CODE overriding the default", () => {
+    process.env.LIVE_DELTA_PM_CODE = "other-code";
+    expect(isValidCode("raven-labs")).toBe(false);
+    expect(isValidCode("other-code")).toBe(true);
+  });
+
+  it("round-trips the cookie token and rejects malformed ones", () => {
+    expect(isValidAccessToken(expectedAccessToken())).toBe(true);
+    expect(isValidAccessToken("deadbeef")).toBe(false);
+    expect(isValidAccessToken(undefined)).toBe(false);
+    expect(isValidAccessToken("g".repeat(64))).toBe(false);
+  });
+
+  it("invalidates old cookies when the code changes", () => {
+    const oldToken = expectedAccessToken();
+    process.env.LIVE_DELTA_PM_CODE = "rotated";
+    expect(isValidAccessToken(oldToken)).toBe(false);
+  });
+
+  it("does not share cookie tokens with the live-predict-raven gate (different namespace)", () => {
+    // Same default code word, but the sha256 namespace differs — a cookie
+    // minted for one page must not unlock the other.
+    expect(expectedAccessToken()).not.toBe(lprExpectedAccessToken());
+    expect(isValidAccessToken(lprExpectedAccessToken())).toBe(false);
+  });
+});

--- a/apps/web/lib/live-delta-pm/access.ts
+++ b/apps/web/lib/live-delta-pm/access.ts
@@ -1,0 +1,49 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+
+// Invite-code gate for /live-delta-pm, mirroring /live-predict-raven's gate
+// (same default code word as the /engine gate). The code is an access hurdle
+// for a low-sensitivity internal review page, not a credential; override via
+// env without redeploying the default.
+const DEFAULT_CODE = "raven-labs";
+const TOKEN_NAMESPACE = "live-delta-pm:v1:";
+
+export const ACCESS_COOKIE_NAME = "ldp-access";
+export const ACCESS_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+
+function configuredCode(): string {
+  const fromEnv = process.env.LIVE_DELTA_PM_CODE?.trim();
+  return fromEnv && fromEnv.length > 0 ? fromEnv : DEFAULT_CODE;
+}
+
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function safeEqualHex(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, "hex");
+  const bufB = Buffer.from(b, "hex");
+  return bufA.length === bufB.length && timingSafeEqual(bufA, bufB);
+}
+
+/** Stateless cookie token derived from the configured code. */
+export function expectedAccessToken(): string {
+  return sha256Hex(TOKEN_NAMESPACE + configuredCode());
+}
+
+export function isValidCode(input: unknown): boolean {
+  if (typeof input !== "string") {
+    return false;
+  }
+  const trimmed = input.trim();
+  if (trimmed.length === 0 || trimmed.length > 128) {
+    return false;
+  }
+  return safeEqualHex(sha256Hex(TOKEN_NAMESPACE + trimmed), expectedAccessToken());
+}
+
+export function isValidAccessToken(token: unknown): boolean {
+  if (typeof token !== "string" || !/^[0-9a-f]{64}$/.test(token)) {
+    return false;
+  }
+  return safeEqualHex(token, expectedAccessToken());
+}

--- a/apps/web/lib/live-delta-pm/decode.test.ts
+++ b/apps/web/lib/live-delta-pm/decode.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import { parseAuditPayload } from "./decode";
+import fixture from "./fixture.json";
+
+describe("live-delta-pm lenient decoder", () => {
+  const payload = parseAuditPayload(fixture);
+
+  it("decodes the baked fixture (real run data)", () => {
+    expect(payload).not.toBeNull();
+    expect(payload!.cases).toHaveLength(30);
+    expect(payload!.generatedAtUtc).toBe("2026-08-23T08:57:06.731Z");
+    expect(payload!.bookStartedUtc).toBe("2026-08-21T18:53:20.930Z");
+  });
+
+  it("sorts cases newest-first by seenAtUtc", () => {
+    const times = payload!.cases.map((c) => Date.parse(c.news.seenAtUtc));
+    for (let i = 1; i < times.length; i += 1) {
+      expect(times[i - 1]).toBeGreaterThanOrEqual(times[i]);
+    }
+  });
+
+  it("decodes the full audit arithmetic of the SNDK open decision", () => {
+    const sndk = payload!.cases.find((c) => c.decision?.action === "open");
+    expect(sndk).toBeDefined();
+    const d = sndk!.decision!;
+    expect(d.ticker).toBe("SNDK");
+    expect(d.audit).not.toBeNull();
+    expect(d.audit!.vetoedBy).toBeNull();
+    expect(d.audit!.edge).toEqual({ conservativePct: 6, pointPct: 13, realizedPct: 0.1, residualPct: 5.9 });
+    expect(d.audit!.threshold!.thresholdPct).toBeCloseTo(5.642843237781729, 10);
+    expect(d.audit!.threshold!.costFloorPct).toBeCloseTo(0.579, 10);
+    expect(d.audit!.stopMenu!.chosenPx).toBe(1585);
+    expect(d.audit!.stopMenu!.hardFloorPx).toBe(1274.96);
+    const sizing = d.audit!.sizing!;
+    expect(sizing.equityUsd).toBe(10000);
+    expect(sizing.intendedNotionalUsd).toBe(18318);
+    expect(sizing.finalNotionalUsd).toBe(3000);
+    expect(sizing.guards).toHaveLength(6);
+    const tier1 = sizing.guards.find((g) => g.name === "tier1_cap");
+    expect(tier1).toEqual({ name: "tier1_cap", capUsd: 3000, notionalAfterUsd: 3000, clipped: true });
+    expect(sizing.leverage!.chosen).toBeCloseTo(1.4657, 6);
+    expect(d.bindingConstraint).toBe("tier1_cap");
+    // Downstream book state came through too.
+    expect(sndk!.execution!.fillPx).toBeCloseTo(1603.4013, 4);
+    expect(sndk!.positionNow!.stopPx).toBe(1580.4);
+    expect(sndk!.positionNow!.markPx).toBeNull(); // absent in feed — page shows "—"
+  });
+
+  it("keeps older decisions without an audit block (audit stays null)", () => {
+    const nvda = payload!.cases.find(
+      (c) => c.decision !== null && c.decision.action === "no_trade" && c.thesis?.provider === "rules"
+    );
+    expect(nvda).toBeDefined();
+    expect(nvda!.decision!.audit).toBeNull();
+    expect(nvda!.decision!.reason).toContain("residual edge");
+  });
+
+  it("keeps cases whose chain stopped early (null signal / null thesis)", () => {
+    const noSignal = payload!.cases.filter((c) => c.signal === null);
+    expect(noSignal.length).toBeGreaterThan(0);
+    const gatedOut = payload!.cases.find((c) => c.signal?.materiality?.tradeable === false);
+    expect(gatedOut).toBeDefined();
+    expect(gatedOut!.thesis).toBeNull();
+  });
+
+  it("decodes portfolio and reflection blocks", () => {
+    expect(payload!.portfolio!.initialCapitalUsd).toBe(10000);
+    expect(payload!.portfolio!.halted).toBe(false);
+    expect(payload!.portfolio!.positions).toHaveLength(1);
+    const r = payload!.latestReflection!;
+    expect(r.funnel!.newsSeen).toBe(30);
+    expect(r.funnel!.archivedNoTicker).toBe(21);
+    expect(r.contamination!.rate).toBe(0.5);
+    expect(r.engines).toEqual([
+      { name: "rules", count: 19 },
+      { name: "claude-cli", count: 12 }
+    ]);
+    expect(r.noTradeReasons).toHaveLength(1);
+    expect(r.book!.equityUsd).toBeCloseTo(9992.887681954606, 6);
+    expect(r.m1Calibration!.forwarded!.hitRate).toBeNull();
+  });
+
+  it("rejects only payloads without a cases array", () => {
+    expect(parseAuditPayload(null)).toBeNull();
+    expect(parseAuditPayload("nonsense")).toBeNull();
+    expect(parseAuditPayload({})).toBeNull();
+    expect(parseAuditPayload({ cases: "nope" })).toBeNull();
+    expect(parseAuditPayload({ cases: [] })).not.toBeNull();
+  });
+
+  it("is lenient on minimal and malformed cases", () => {
+    const decoded = parseAuditPayload({
+      cases: [
+        { news: { title: "bare headline" } }, // everything else missing
+        { news: {} }, // no title — dropped, unrenderable
+        "garbage", // not an object — dropped
+        {
+          news: { title: "drifted enums", kind: "podcast", prefix: "rumor", seenAtUtc: "2026-08-22T00:00:00Z" },
+          signal: { materiality: { score: "84", tradeable: "yes" } }, // wrong scalar types → null
+          decision: { action: "hedge", audit: { vetoedBy: "halted" } }
+        }
+      ]
+    });
+    expect(decoded).not.toBeNull();
+    expect(decoded!.cases).toHaveLength(2);
+    const bare = decoded!.cases.find((c) => c.news.title === "bare headline")!;
+    expect(bare.signal).toBeNull();
+    expect(bare.thesis).toBeNull();
+    expect(bare.postEvents).toEqual([]);
+    const drifted = decoded!.cases.find((c) => c.news.title === "drifted enums")!;
+    // Unknown enums survive verbatim; wrong scalar types decode to null.
+    expect(drifted.news.kind).toBe("podcast");
+    expect(drifted.signal!.materiality!.score).toBeNull();
+    expect(drifted.signal!.materiality!.tradeable).toBeNull();
+    expect(drifted.decision!.action).toBe("hedge");
+    expect(drifted.decision!.audit!.vetoedBy).toBe("halted");
+    expect(drifted.decision!.audit!.edge).toBeNull();
+  });
+
+  it("collects unknown post-event fields as verbatim extras", () => {
+    const decoded = parseAuditPayload({
+      cases: [
+        {
+          news: { title: "with events", seenAtUtc: "2026-08-22T00:00:00Z" },
+          postEvents: [
+            { ts: "2026-08-22T01:00:00Z", type: "stop_loss", pnlUsd: -42.5, fillPx: 99.1, note: "gap down" },
+            null
+          ]
+        }
+      ]
+    });
+    const events = decoded!.cases[0]!.postEvents;
+    expect(events).toHaveLength(1);
+    expect(events[0]!.pnlUsd).toBe(-42.5);
+    expect(events[0]!.extras).toEqual([
+      { key: "fillPx", value: "99.1" },
+      { key: "note", value: "gap down" }
+    ]);
+  });
+});

--- a/apps/web/lib/live-delta-pm/decode.test.ts
+++ b/apps/web/lib/live-delta-pm/decode.test.ts
@@ -15,7 +15,7 @@ describe("live-delta-pm lenient decoder", () => {
   it("sorts cases newest-first by seenAtUtc", () => {
     const times = payload!.cases.map((c) => Date.parse(c.news.seenAtUtc));
     for (let i = 1; i < times.length; i += 1) {
-      expect(times[i - 1]).toBeGreaterThanOrEqual(times[i]);
+      expect(times[i - 1]!).toBeGreaterThanOrEqual(times[i]!);
     }
   });
 

--- a/apps/web/lib/live-delta-pm/decode.ts
+++ b/apps/web/lib/live-delta-pm/decode.ts
@@ -1,0 +1,699 @@
+// Lenient decoder for the Delta PM shadow-book audit feed
+// (GET <upstream>/delta-pm/audit). The authoritative field vocabulary lives in
+// packages/delta-pm-contracts/src/index.ts (NewsSignal / TradeThesis /
+// PMDecision / decisionAuditSchema); it is mirrored HERE as plain view types
+// instead of imported, so the web build never depends on that package's build
+// order.
+//
+// Decoding policy: every field is optional. Older ledger rows may lack
+// `decision.audit` (recorded since 2026-08-23), enum values may drift — an
+// unknown enum is kept as its raw string and the label layer falls back to
+// showing it verbatim. Only a payload that is not an object or has no `cases`
+// array is rejected (returns null → caller falls back to the baked fixture).
+
+type Rec = Record<string, unknown>;
+
+const isRec = (v: unknown): v is Rec => typeof v === "object" && v !== null && !Array.isArray(v);
+const num = (v: unknown): number | null => (typeof v === "number" && Number.isFinite(v) ? v : null);
+const str = (v: unknown): string => (typeof v === "string" ? v : "");
+const strOrNull = (v: unknown): string | null => (typeof v === "string" && v.length > 0 ? v : null);
+const bool = (v: unknown): boolean | null => (typeof v === "boolean" ? v : null);
+const strArr = (v: unknown): string[] => (Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : []);
+
+// ---------------------------------------------------------------------------
+// View types (mirror of the delta-pm contracts, everything nullable)
+
+export interface NewsView {
+  newsId: string;
+  title: string;
+  publishedUtc: string;
+  kind: string; // article | briefing | manual (raw)
+  prefix: string; // exclusive | reportedly | none (raw)
+  seenAtUtc: string;
+  url: string | null;
+}
+
+export interface MaterialityView {
+  tradeable: boolean | null;
+  score: number | null;
+  eventType: string;
+  factLevel: string;
+  tickers: string[];
+  surpriseNote: string;
+  reason: string;
+}
+
+export interface PricedInView {
+  status: string; // none | partial | full | leaked | reverse | awaiting_market (raw)
+  tEvalUtc: string;
+  deltaTMinutes: number | null;
+  realizedExcessPct: number | null; // percent units (0.11 => 0.11%)
+  volumeZ: number | null;
+  dataBasis: string;
+  sessionBucket: string;
+  benchmarkUsed: string;
+  betaUsed: number | null;
+  confidence: string;
+  note: string;
+}
+
+export interface SignalView {
+  id: string;
+  fingerprint: string;
+  firstSeenUtc: string | null;
+  firstSeenBasis: string;
+  expectedDirection: string;
+  coarseImpactBand: string;
+  materiality: MaterialityView | null;
+  pricedIn: PricedInView | null;
+  createdAtUtc: string;
+}
+
+export interface ImpactStepView {
+  step: string;
+  value: string;
+}
+
+export interface EvidenceView {
+  point: string;
+  source: string | null;
+  url: string | null;
+  credibility: string;
+}
+
+export interface ThesisView {
+  id: string;
+  ticker: string;
+  direction: string; // long | short (raw)
+  fairImpactPct: { min: number; max: number; point: number } | null; // percent units
+  impactPath: ImpactStepView[];
+  evidence: EvidenceView[];
+  contamination: string; // none | soft | hard (raw)
+  horizonHours: number | null;
+  catalysts: string[];
+  falsifiers: string[];
+  limitations: string[];
+  confidence: string;
+  provider: string;
+  createdAtUtc: string;
+}
+
+export interface AuditEdgeView {
+  conservativePct: number | null;
+  pointPct: number | null;
+  realizedPct: number | null;
+  residualPct: number | null;
+}
+
+export interface AuditThresholdView {
+  takerFeePct: number | null;
+  slippagePct: number | null;
+  fundingPct: number | null;
+  roundTripPct: number | null;
+  costFloorPct: number | null;
+  volFloorPct: number | null;
+  thresholdPct: number | null;
+}
+
+export interface AuditStopMenuView {
+  atr20d: number | null;
+  atrStopPx: number | null;
+  swingPx: number | null;
+  hardFloorPx: number | null;
+  chosenPx: number | null;
+  stopDistPct: number | null; // fraction (0.0055 => 0.55%)
+}
+
+export interface GuardView {
+  name: string;
+  capUsd: number | null;
+  notionalAfterUsd: number | null;
+  clipped: boolean;
+}
+
+export interface AuditSizingView {
+  equityUsd: number | null;
+  riskBudgetPct: number | null; // fraction
+  intendedNotionalUsd: number | null;
+  guards: GuardView[];
+  finalNotionalUsd: number | null;
+  leverage: { configCap: number | null; volCap: number | null; venueCap: number | null; chosen: number | null } | null;
+}
+
+export interface AuditMarketView {
+  markPx: number | null;
+  dailyVolPct: number | null; // fraction
+  maxDailyMovePct: number | null; // fraction
+  fundingHourly: number | null; // fraction per hour
+  beta: number | null;
+}
+
+export interface DecisionAuditView {
+  vetoedBy: string | null;
+  edge: AuditEdgeView | null;
+  threshold: AuditThresholdView | null;
+  stopMenu: AuditStopMenuView | null;
+  sizing: AuditSizingView | null;
+  marketView: AuditMarketView | null;
+}
+
+export interface DecisionStopView {
+  initialPx: number | null;
+  hardFloorPx: number | null;
+  rule: string;
+  atr20d: number | null;
+  trailArmed: boolean | null;
+}
+
+export interface DecisionView {
+  id: string;
+  ticker: string;
+  action: string; // open | add | trim | close | flip | no_trade (raw)
+  direction: string | null;
+  refPx: number | null;
+  sizeUsd: number | null;
+  leverage: number | null;
+  stop: DecisionStopView | null;
+  targetPctExcess: { lo: number; hi: number } | null; // percent units
+  horizonUtc: string | null;
+  intendedRiskPct: number | null; // fraction
+  realizedRiskPct: number | null; // fraction
+  bindingConstraint: string | null;
+  residualEdgePct: number | null; // percent units
+  reason: string;
+  audit: DecisionAuditView | null;
+  createdAtUtc: string;
+}
+
+export interface ExecutionView {
+  ts: string;
+  type: string;
+  ticker: string;
+  direction: string | null;
+  qty: number | null;
+  fillPx: number | null;
+  sizeUsd: number | null;
+}
+
+export interface PositionNowView {
+  ticker: string;
+  direction: string;
+  qty: number | null;
+  entryPx: number | null;
+  entryUtc: string;
+  notionalUsdAtEntry: number | null;
+  leverage: number | null;
+  stopPx: number | null;
+  hardFloorPx: number | null;
+  targetPctExcess: { lo: number; hi: number } | null;
+  horizonUtc: string | null;
+  extendedOnce: boolean | null;
+  signalT0Utc: string | null;
+  baselinePx: number | null;
+  benchmarkBaselinePx: number | null;
+  beta: number | null;
+  trailArmed: boolean | null;
+  highestClosePx: number | null;
+  markPx: number | null; // not in every snapshot — display "—" when absent
+  unrealizedPnlUsd: number | null;
+}
+
+export interface PostEventView {
+  ts: string;
+  type: string;
+  pnlUsd: number | null;
+  /** Remaining primitive fields, verbatim, so nothing is hidden from audit. */
+  extras: Array<{ key: string; value: string }>;
+}
+
+export interface CaseView {
+  news: NewsView;
+  signal: SignalView | null;
+  thesis: ThesisView | null;
+  decision: DecisionView | null;
+  execution: ExecutionView | null;
+  positionNow: PositionNowView | null;
+  postEvents: PostEventView[];
+}
+
+export interface PortfolioView {
+  mode: string;
+  initialCapitalUsd: number | null;
+  realizedPnlUsd: number | null;
+  positions: PositionNowView[];
+  halted: boolean;
+  haltedReason: string | null;
+  updatedAtUtc: string;
+}
+
+export interface ReflectionFunnelView {
+  newsSeen: number | null;
+  signals: number | null;
+  archivedNoTicker: number | null;
+  archivedNotMaterial: number | null;
+  archivedStale: number | null;
+  archivedPricedIn: number | null;
+  theses: number | null;
+  decisionsOpen: number | null;
+  decisionsNoTrade: number | null;
+}
+
+export interface ReflectionView {
+  date: string;
+  generatedAtUtc: string;
+  funnel: ReflectionFunnelView | null;
+  pricedInDistribution: Array<{ status: string; count: number }>;
+  deltaT: { n: number | null; medianMinutes: number | null } | null;
+  m1Calibration: {
+    forwarded: { n: number | null; hits: number | null; hitRate: number | null } | null;
+    archivedFullReverse: { n: number | null; movedWithNews: number | null } | null;
+  } | null;
+  contamination: { theses: number | null; hard: number | null; soft: number | null; rate: number | null } | null;
+  engines: Array<{ name: string; count: number }>;
+  noTradeReasons: Array<{ reason: string; count: number }>;
+  book: {
+    equityUsd: number | null;
+    realizedPnlUsd: number | null;
+    positions: number | null;
+    halted: boolean | null;
+  } | null;
+}
+
+export interface AuditPayload {
+  generatedAtUtc: string;
+  bookStartedUtc: string | null;
+  portfolio: PortfolioView | null;
+  latestReflection: ReflectionView | null;
+  cases: CaseView[];
+}
+
+// ---------------------------------------------------------------------------
+// Parsers
+
+function parseRange(raw: unknown): { min: number; max: number; point: number } | null {
+  if (!isRec(raw)) return null;
+  const min = num(raw.min);
+  const max = num(raw.max);
+  const point = num(raw.point);
+  if (min === null || max === null || point === null) return null;
+  return { min, max, point };
+}
+
+function parseLoHi(raw: unknown): { lo: number; hi: number } | null {
+  if (!isRec(raw)) return null;
+  const lo = num(raw.lo);
+  const hi = num(raw.hi);
+  if (lo === null || hi === null) return null;
+  return { lo, hi };
+}
+
+function parseMateriality(raw: unknown): MaterialityView | null {
+  if (!isRec(raw)) return null;
+  return {
+    tradeable: bool(raw.tradeable),
+    score: num(raw.score),
+    eventType: str(raw.eventType),
+    factLevel: str(raw.factLevel),
+    tickers: strArr(raw.tickers),
+    surpriseNote: str(raw.surpriseNote),
+    reason: str(raw.reason)
+  };
+}
+
+function parsePricedIn(raw: unknown): PricedInView | null {
+  if (!isRec(raw)) return null;
+  return {
+    status: str(raw.status),
+    tEvalUtc: str(raw.tEvalUtc),
+    deltaTMinutes: num(raw.deltaTMinutes),
+    realizedExcessPct: num(raw.realizedExcessPct),
+    volumeZ: num(raw.volumeZ),
+    dataBasis: str(raw.dataBasis),
+    sessionBucket: str(raw.sessionBucket),
+    benchmarkUsed: str(raw.benchmarkUsed),
+    betaUsed: num(raw.betaUsed),
+    confidence: str(raw.confidence),
+    note: str(raw.note)
+  };
+}
+
+function parseSignal(raw: unknown): SignalView | null {
+  if (!isRec(raw)) return null;
+  return {
+    id: str(raw.id),
+    fingerprint: str(raw.fingerprint),
+    firstSeenUtc: strOrNull(raw.firstSeenUtc),
+    firstSeenBasis: str(raw.firstSeenBasis),
+    expectedDirection: str(raw.expectedDirection),
+    coarseImpactBand: str(raw.coarseImpactBand),
+    materiality: parseMateriality(raw.materiality),
+    pricedIn: parsePricedIn(raw.pricedIn),
+    createdAtUtc: str(raw.createdAtUtc)
+  };
+}
+
+function parseThesis(raw: unknown): ThesisView | null {
+  if (!isRec(raw)) return null;
+  const impactPath: ImpactStepView[] = Array.isArray(raw.impactPath)
+    ? raw.impactPath.flatMap((s) => (isRec(s) ? [{ step: str(s.step), value: str(s.value) }] : []))
+    : [];
+  const evidence: EvidenceView[] = Array.isArray(raw.evidence)
+    ? raw.evidence.flatMap((e) =>
+        isRec(e)
+          ? [
+              {
+                point: str(e.point),
+                source: strOrNull(e.source),
+                url: strOrNull(e.url),
+                credibility: str(e.credibility)
+              }
+            ]
+          : []
+      )
+    : [];
+  return {
+    id: str(raw.id),
+    ticker: str(raw.ticker),
+    direction: str(raw.direction),
+    fairImpactPct: parseRange(raw.fairImpactPct),
+    impactPath,
+    evidence,
+    contamination: str(raw.contamination),
+    horizonHours: num(raw.horizonHours),
+    catalysts: strArr(raw.catalysts),
+    falsifiers: strArr(raw.falsifiers),
+    limitations: strArr(raw.limitations),
+    confidence: str(raw.confidence),
+    provider: str(raw.provider),
+    createdAtUtc: str(raw.createdAtUtc)
+  };
+}
+
+function parseAudit(raw: unknown): DecisionAuditView | null {
+  if (!isRec(raw)) return null;
+  const edgeRec = isRec(raw.edge) ? raw.edge : null;
+  const thrRec = isRec(raw.threshold) ? raw.threshold : null;
+  const stopRec = isRec(raw.stopMenu) ? raw.stopMenu : null;
+  const sizingRec = isRec(raw.sizing) ? raw.sizing : null;
+  const mktRec = isRec(raw.marketView) ? raw.marketView : null;
+  const levRec = sizingRec && isRec(sizingRec.leverage) ? sizingRec.leverage : null;
+  return {
+    vetoedBy: strOrNull(raw.vetoedBy),
+    edge: edgeRec
+      ? {
+          conservativePct: num(edgeRec.conservativePct),
+          pointPct: num(edgeRec.pointPct),
+          realizedPct: num(edgeRec.realizedPct),
+          residualPct: num(edgeRec.residualPct)
+        }
+      : null,
+    threshold: thrRec
+      ? {
+          takerFeePct: num(thrRec.takerFeePct),
+          slippagePct: num(thrRec.slippagePct),
+          fundingPct: num(thrRec.fundingPct),
+          roundTripPct: num(thrRec.roundTripPct),
+          costFloorPct: num(thrRec.costFloorPct),
+          volFloorPct: num(thrRec.volFloorPct),
+          thresholdPct: num(thrRec.thresholdPct)
+        }
+      : null,
+    stopMenu: stopRec
+      ? {
+          atr20d: num(stopRec.atr20d),
+          atrStopPx: num(stopRec.atrStopPx),
+          swingPx: num(stopRec.swingPx),
+          hardFloorPx: num(stopRec.hardFloorPx),
+          chosenPx: num(stopRec.chosenPx),
+          stopDistPct: num(stopRec.stopDistPct)
+        }
+      : null,
+    sizing: sizingRec
+      ? {
+          equityUsd: num(sizingRec.equityUsd),
+          riskBudgetPct: num(sizingRec.riskBudgetPct),
+          intendedNotionalUsd: num(sizingRec.intendedNotionalUsd),
+          guards: Array.isArray(sizingRec.guards)
+            ? sizingRec.guards.flatMap((g) =>
+                isRec(g)
+                  ? [
+                      {
+                        name: str(g.name),
+                        capUsd: num(g.capUsd),
+                        notionalAfterUsd: num(g.notionalAfterUsd),
+                        clipped: g.clipped === true
+                      }
+                    ]
+                  : []
+              )
+            : [],
+          finalNotionalUsd: num(sizingRec.finalNotionalUsd),
+          leverage: levRec
+            ? {
+                configCap: num(levRec.configCap),
+                volCap: num(levRec.volCap),
+                venueCap: num(levRec.venueCap),
+                chosen: num(levRec.chosen)
+              }
+            : null
+        }
+      : null,
+    marketView: mktRec
+      ? {
+          markPx: num(mktRec.markPx),
+          dailyVolPct: num(mktRec.dailyVolPct),
+          maxDailyMovePct: num(mktRec.maxDailyMovePct),
+          fundingHourly: num(mktRec.fundingHourly),
+          beta: num(mktRec.beta)
+        }
+      : null
+  };
+}
+
+function parseDecision(raw: unknown): DecisionView | null {
+  if (!isRec(raw)) return null;
+  const stopRec = isRec(raw.stop) ? raw.stop : null;
+  return {
+    id: str(raw.id),
+    ticker: str(raw.ticker),
+    action: str(raw.action),
+    direction: strOrNull(raw.direction),
+    refPx: num(raw.refPx),
+    sizeUsd: num(raw.sizeUsd),
+    leverage: num(raw.leverage),
+    stop: stopRec
+      ? {
+          initialPx: num(stopRec.initialPx),
+          hardFloorPx: num(stopRec.hardFloorPx),
+          rule: str(stopRec.rule),
+          atr20d: num(stopRec.atr20d),
+          trailArmed: bool(stopRec.trailArmed)
+        }
+      : null,
+    targetPctExcess: parseLoHi(raw.targetPctExcess),
+    horizonUtc: strOrNull(raw.horizonUtc),
+    intendedRiskPct: num(raw.intendedRiskPct),
+    realizedRiskPct: num(raw.realizedRiskPct),
+    bindingConstraint: strOrNull(raw.bindingConstraint),
+    residualEdgePct: num(raw.residualEdgePct),
+    reason: str(raw.reason),
+    audit: parseAudit(raw.audit),
+    createdAtUtc: str(raw.createdAtUtc)
+  };
+}
+
+function parseExecution(raw: unknown): ExecutionView | null {
+  if (!isRec(raw)) return null;
+  return {
+    ts: str(raw.ts),
+    type: str(raw.type),
+    ticker: str(raw.ticker),
+    direction: strOrNull(raw.direction),
+    qty: num(raw.qty),
+    fillPx: num(raw.fillPx),
+    sizeUsd: num(raw.sizeUsd)
+  };
+}
+
+function parsePosition(raw: unknown): PositionNowView | null {
+  if (!isRec(raw)) return null;
+  return {
+    ticker: str(raw.ticker),
+    direction: str(raw.direction),
+    qty: num(raw.qty),
+    entryPx: num(raw.entryPx),
+    entryUtc: str(raw.entryUtc),
+    notionalUsdAtEntry: num(raw.notionalUsdAtEntry),
+    leverage: num(raw.leverage),
+    stopPx: num(raw.stopPx),
+    hardFloorPx: num(raw.hardFloorPx),
+    targetPctExcess: parseLoHi(raw.targetPctExcess),
+    horizonUtc: strOrNull(raw.horizonUtc),
+    extendedOnce: bool(raw.extendedOnce),
+    signalT0Utc: strOrNull(raw.signalT0Utc),
+    baselinePx: num(raw.baselinePx),
+    benchmarkBaselinePx: num(raw.benchmarkBaselinePx),
+    beta: num(raw.beta),
+    trailArmed: bool(raw.trailArmed),
+    highestClosePx: num(raw.highestClosePx),
+    markPx: num(raw.markPx),
+    unrealizedPnlUsd: num(raw.unrealizedPnlUsd)
+  };
+}
+
+const POST_EVENT_KNOWN_KEYS = new Set(["ts", "type", "pnlUsd"]);
+
+function parsePostEvent(raw: unknown): PostEventView | null {
+  if (!isRec(raw)) return null;
+  const extras: Array<{ key: string; value: string }> = [];
+  for (const [key, value] of Object.entries(raw)) {
+    if (POST_EVENT_KNOWN_KEYS.has(key)) continue;
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      extras.push({ key, value: String(value) });
+    }
+  }
+  return { ts: str(raw.ts), type: str(raw.type), pnlUsd: num(raw.pnlUsd), extras };
+}
+
+function parseNews(raw: unknown): NewsView | null {
+  if (!isRec(raw)) return null;
+  const title = str(raw.title);
+  if (title.length === 0) return null; // a case without a headline is unrenderable
+  return {
+    newsId: str(raw.newsId),
+    title,
+    publishedUtc: str(raw.publishedUtc),
+    kind: str(raw.kind),
+    prefix: str(raw.prefix),
+    seenAtUtc: str(raw.seenAtUtc),
+    url: strOrNull(raw.url)
+  };
+}
+
+function parseCase(raw: unknown): CaseView | null {
+  if (!isRec(raw)) return null;
+  const news = parseNews(raw.news);
+  if (!news) return null;
+  return {
+    news,
+    signal: parseSignal(raw.signal),
+    thesis: parseThesis(raw.thesis),
+    decision: parseDecision(raw.decision),
+    execution: parseExecution(raw.execution),
+    positionNow: parsePosition(raw.positionNow),
+    postEvents: Array.isArray(raw.postEvents)
+      ? raw.postEvents.flatMap((e) => {
+          const parsed = parsePostEvent(e);
+          return parsed ? [parsed] : [];
+        })
+      : []
+  };
+}
+
+function parsePortfolio(raw: unknown): PortfolioView | null {
+  if (!isRec(raw)) return null;
+  return {
+    mode: str(raw.mode),
+    initialCapitalUsd: num(raw.initialCapitalUsd),
+    realizedPnlUsd: num(raw.realizedPnlUsd),
+    positions: Array.isArray(raw.positions)
+      ? raw.positions.flatMap((p) => {
+          const parsed = parsePosition(p);
+          return parsed ? [parsed] : [];
+        })
+      : [],
+    halted: raw.halted === true,
+    haltedReason: strOrNull(raw.haltedReason),
+    updatedAtUtc: str(raw.updatedAtUtc)
+  };
+}
+
+function parseReflection(raw: unknown): ReflectionView | null {
+  if (!isRec(raw)) return null;
+  const funnelRec = isRec(raw.funnel) ? raw.funnel : null;
+  const deltaTRec = isRec(raw.deltaT) ? raw.deltaT : null;
+  const m1Rec = isRec(raw.m1Calibration) ? raw.m1Calibration : null;
+  const contRec = isRec(raw.contamination) ? raw.contamination : null;
+  const bookRec = isRec(raw.book) ? raw.book : null;
+  const fwdRec = m1Rec && isRec(m1Rec.forwarded) ? m1Rec.forwarded : null;
+  const afrRec = m1Rec && isRec(m1Rec.archivedFullReverse) ? m1Rec.archivedFullReverse : null;
+  return {
+    date: str(raw.date),
+    generatedAtUtc: str(raw.generatedAtUtc),
+    funnel: funnelRec
+      ? {
+          newsSeen: num(funnelRec.newsSeen),
+          signals: num(funnelRec.signals),
+          archivedNoTicker: num(funnelRec.archivedNoTicker),
+          archivedNotMaterial: num(funnelRec.archivedNotMaterial),
+          archivedStale: num(funnelRec.archivedStale),
+          archivedPricedIn: num(funnelRec.archivedPricedIn),
+          theses: num(funnelRec.theses),
+          decisionsOpen: num(funnelRec.decisionsOpen),
+          decisionsNoTrade: num(funnelRec.decisionsNoTrade)
+        }
+      : null,
+    pricedInDistribution: isRec(raw.pricedInDistribution)
+      ? Object.entries(raw.pricedInDistribution).flatMap(([status, count]) => {
+          const n = num(count);
+          return n === null ? [] : [{ status, count: n }];
+        })
+      : [],
+    deltaT: deltaTRec ? { n: num(deltaTRec.n), medianMinutes: num(deltaTRec.medianMinutes) } : null,
+    m1Calibration: m1Rec
+      ? {
+          forwarded: fwdRec ? { n: num(fwdRec.n), hits: num(fwdRec.hits), hitRate: num(fwdRec.hitRate) } : null,
+          archivedFullReverse: afrRec ? { n: num(afrRec.n), movedWithNews: num(afrRec.movedWithNews) } : null
+        }
+      : null,
+    contamination: contRec
+      ? { theses: num(contRec.theses), hard: num(contRec.hard), soft: num(contRec.soft), rate: num(contRec.rate) }
+      : null,
+    engines: isRec(raw.engines)
+      ? Object.entries(raw.engines).flatMap(([name, count]) => {
+          const n = num(count);
+          return n === null ? [] : [{ name, count: n }];
+        })
+      : [],
+    noTradeReasons: Array.isArray(raw.noTradeReasons)
+      ? raw.noTradeReasons.flatMap((r) => {
+          if (!isRec(r)) return [];
+          const count = num(r.count);
+          return [{ reason: str(r.reason), count: count ?? 0 }];
+        })
+      : [],
+    book: bookRec
+      ? {
+          equityUsd: num(bookRec.equityUsd),
+          realizedPnlUsd: num(bookRec.realizedPnlUsd),
+          positions: num(bookRec.positions),
+          halted: bool(bookRec.halted)
+        }
+      : null
+  };
+}
+
+/**
+ * Decode the audit payload. Returns null only when the payload is not an
+ * object with a `cases` array — every field inside is optional.
+ * Cases are re-sorted newest-first by news.seenAtUtc.
+ */
+export function parseAuditPayload(json: unknown): AuditPayload | null {
+  if (!isRec(json) || !Array.isArray(json.cases)) return null;
+  const cases = json.cases.flatMap((c) => {
+    const parsed = parseCase(c);
+    return parsed ? [parsed] : [];
+  });
+  cases.sort((a, b) => {
+    const ta = Date.parse(a.news.seenAtUtc);
+    const tb = Date.parse(b.news.seenAtUtc);
+    return (Number.isFinite(tb) ? tb : 0) - (Number.isFinite(ta) ? ta : 0);
+  });
+  return {
+    generatedAtUtc: str(json.generatedAtUtc),
+    bookStartedUtc: strOrNull(json.bookStartedUtc),
+    portfolio: parsePortfolio(json.portfolio),
+    latestReflection: parseReflection(json.latestReflection),
+    cases
+  };
+}

--- a/apps/web/lib/live-delta-pm/fixture.json
+++ b/apps/web/lib/live-delta-pm/fixture.json
@@ -1,0 +1,1720 @@
+{
+  "generatedAtUtc": "2026-08-23T08:57:06.731Z",
+  "bookStartedUtc": "2026-08-21T18:53:20.930Z",
+  "equitySource": "portfolio.json",
+  "portfolio": {
+    "mode": "shadow",
+    "initialCapitalUsd": 10000,
+    "realizedPnlUsd": 0,
+    "positions": [
+      {
+        "ticker": "SNDK",
+        "hlSymbol": "xyz:SNDK",
+        "direction": "long",
+        "qty": 1.8710225568608436,
+        "entryPx": 1603.4012999999998,
+        "entryUtc": "2026-08-21T19:07:33.238Z",
+        "notionalUsdAtEntry": 3000,
+        "leverage": 1.4657076431269982,
+        "stopPx": 1580.4,
+        "hardFloorPx": 1282.08,
+        "targetPctExcess": {
+          "lo": 6,
+          "hi": 13
+        },
+        "horizonUtc": "2026-08-26T19:07:33.238Z",
+        "extendedOnce": false,
+        "thesisId": "th-6429a40c70377956-SNDK-mt3bn65v",
+        "decisionId": "pmd-th-6429a40c70377956-SNDK-mt3bn65v-mt3bn65y",
+        "signalT0Utc": "2026-08-21T19:04:42.567Z",
+        "baselinePx": 1600.2,
+        "benchmarkBaselinePx": 29291,
+        "beta": 3.303858631847057,
+        "trailArmed": false,
+        "highestClosePx": 1603.4012999999998
+      }
+    ],
+    "halted": false,
+    "haltedReason": null,
+    "lastStopOutUtc": {},
+    "updatedAtUtc": "2026-08-23T08:31:53.740Z"
+  },
+  "latestReflection": {
+    "date": "2026-08-22",
+    "generatedAtUtc": "2026-08-22T13:01:52.493Z",
+    "funnel": {
+      "newsSeen": 30,
+      "signals": 30,
+      "archivedNoTicker": 21,
+      "archivedNotMaterial": 5,
+      "archivedStale": 1,
+      "archivedPricedIn": 1,
+      "theses": 2,
+      "decisionsOpen": 1,
+      "decisionsNoTrade": 1
+    },
+    "pricedInDistribution": {
+      "not_evaluated": 27,
+      "none": 2,
+      "reverse": 1
+    },
+    "deltaT": {
+      "n": 3,
+      "medianMinutes": 1.3509333333333333
+    },
+    "m1Calibration": {
+      "forwarded": {
+        "n": 0,
+        "hits": 0,
+        "hitRate": null
+      },
+      "archivedFullReverse": {
+        "n": 1,
+        "movedWithNews": 0
+      }
+    },
+    "contamination": {
+      "theses": 2,
+      "hard": 1,
+      "soft": 0,
+      "rate": 0.5
+    },
+    "engines": {
+      "rules": 19,
+      "claude-cli": 12
+    },
+    "noTradeReasons": [
+      {
+        "reason": "thesis hard-contaminated by price reaction — analyst must re",
+        "count": 1
+      }
+    ],
+    "book": {
+      "equityUsd": 9992.887681954606,
+      "realizedPnlUsd": 0,
+      "positions": 1,
+      "halted": false
+    }
+  },
+  "cases": [
+    {
+      "news": {
+        "newsId": "tag:www.theinformation.com,2005:Article/17689",
+        "title": "Nvidia AI Chip Prices to Rise About 17%, Server Makers Tell Customers",
+        "publishedUtc": "2026-08-22T23:45:39.000Z",
+        "kind": "article",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-23T00:25:07.227Z"
+      },
+      "signal": {
+        "id": "sig-038ffa18507d9d00-mt52k88l",
+        "newsId": "tag:www.theinformation.com,2005:Article/17689",
+        "fingerprint": "038ffa18507d9d00",
+        "firstSeenUtc": "2026-08-22T23:45:39.000Z",
+        "firstSeenBasis": "The Information item — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": true,
+          "score": 55,
+          "eventType": "product_tech",
+          "factLevel": "forecast",
+          "tickers": [
+            "NVDA"
+          ],
+          "surpriseNote": "rules fallback: no consensus comparison performed",
+          "reason": "rules fallback matched category product_tech"
+        },
+        "pricedIn": {
+          "status": "none",
+          "tEvalUtc": "2026-08-23T00:28:51.395Z",
+          "deltaTMinutes": 43.206583333333334,
+          "realizedExcessPct": 0.10691968343732312,
+          "volumeZ": null,
+          "dataBasis": "hl_perp",
+          "sessionBucket": "weekend",
+          "benchmarkUsed": "XYZ100",
+          "betaUsed": 1.2330231096757356,
+          "confidence": "low",
+          "note": "realized 0.11% vs band-mid 1.3% (expected-by-now 0.23% at Δt=43min; volume baseline too young)"
+        },
+        "createdAtUtc": "2026-08-23T00:28:51.765Z",
+        "title": "Nvidia AI Chip Prices to Rise About 17%, Server Makers Tell Customers"
+      },
+      "thesis": {
+        "id": "th-038ffa18507d9d00-NVDA-mt52kc23",
+        "signalId": "sig-038ffa18507d9d00-mt52k88l",
+        "ticker": "NVDA",
+        "direction": "long",
+        "tradeType": "event",
+        "fairImpactPct": {
+          "min": 0.2,
+          "max": 1,
+          "point": 0.5
+        },
+        "impactPath": [
+          {
+            "step": "rules fallback — no analyst model available",
+            "value": "band placeholder from coarse impact band floor"
+          }
+        ],
+        "evidence": [],
+        "contamination": "none",
+        "horizonHours": 48,
+        "catalysts": [],
+        "falsifiers": [
+          "rules fallback thesis — must not trade"
+        ],
+        "limitations": [
+          "produced by rules fallback; entry threshold will reject"
+        ],
+        "confidence": "low",
+        "provider": "rules",
+        "createdAtUtc": "2026-08-23T00:28:56.715Z"
+      },
+      "decision": {
+        "id": "pmd-th-038ffa18507d9d00-NVDA-mt52kc23-mt52kc6g",
+        "thesisId": "th-038ffa18507d9d00-NVDA-mt52kc23",
+        "ticker": "NVDA",
+        "action": "no_trade",
+        "direction": null,
+        "refPx": 216.17,
+        "sizeUsd": 0,
+        "leverage": null,
+        "stop": null,
+        "targetPctExcess": null,
+        "horizonUtc": null,
+        "intendedRiskPct": null,
+        "realizedRiskPct": null,
+        "bindingConstraint": null,
+        "residualEdgePct": null,
+        "reason": "residual edge 0.09% below threshold 1.19% (conservative 0.2%, realized 0.11%)",
+        "createdAtUtc": "2026-08-23T00:28:56.872Z",
+        "ts": "2026-08-23T00:28:56.873Z"
+      },
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "tag:www.theinformation.com,2005:Article/17687",
+        "title": "No, AI Probably Won’t Cure Cancer Anytime Soon, Scientists Say",
+        "publishedUtc": "2026-08-22T14:17:10.000Z",
+        "kind": "article",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-22T15:45:56.507Z"
+      },
+      "signal": null,
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "tag:www.theinformation.com,2005:Article/17688",
+        "title": "America Really, Really Hates Data Centers",
+        "publishedUtc": "2026-08-22T15:00:59.000Z",
+        "kind": "article",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-22T15:45:56.504Z"
+      },
+      "signal": {
+        "id": "sig-2f729ee850c9540e-mt4jvqxq",
+        "newsId": "tag:www.theinformation.com,2005:Article/17688",
+        "fingerprint": "2f729ee850c9540e",
+        "firstSeenUtc": "2026-08-22T15:00:59.000Z",
+        "firstSeenBasis": "The Information item — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 10,
+          "eventType": "order_contract",
+          "factLevel": "fact",
+          "tickers": [],
+          "surpriseNote": "rules fallback: no consensus comparison performed",
+          "reason": "no universe ticker matched"
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-22T15:45:56.510Z",
+        "title": "America Really, Really Hates Data Centers"
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "sitemap:https://www.theinformation.com/newsletters/ai-infrastructure/nvidia-using-land-electricity-deals-lock-hardware-bundle",
+        "title": "Nvidia is Using Land and Electricity Deals to Lock In Its Hardware Bundle",
+        "publishedUtc": "2026-08-21T21:40:11.000Z",
+        "kind": "article",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-22T08:21:57.415Z"
+      },
+      "signal": {
+        "id": "sig-d51c2a29d9eabcc1-mt441nsq",
+        "newsId": "sitemap:https://www.theinformation.com/newsletters/ai-infrastructure/nvidia-using-land-electricity-deals-lock-hardware-bundle",
+        "fingerprint": "d51c2a29d9eabcc1",
+        "firstSeenUtc": "2026-08-21T21:40:11.000Z",
+        "firstSeenBasis": "The Information item — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "mixed",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 16,
+          "eventType": "supply_chain",
+          "factLevel": "opinion",
+          "tickers": [
+            "NVDA"
+          ],
+          "surpriseNote": "Baseline missing. Investigative strategy framing ('is using land/electricity deals to lock in its hardware bundle') describes an ongoing, widely-discussed ecosystem/moat narrative rather than a discrete new transaction. No specific deal, counterparty, size, or timing disclosed — low novelty beyond known lock-in theme.",
+          "reason": "Category-wise this touches supply_chain (datacenter land/power for AI infrastructure), but the item is an analytical/investigative think-piece, not a discrete catalyst: no announced deal, no counterparties, no magnitudes, empty body. factLevel is opinion/interpretation, which is never tradeable alone. NVDA is the clear headline actor but there is no consensus-beating surprise to price. Not tradeable."
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-22T08:22:38.522Z",
+        "title": "Nvidia is Using Land and Electricity Deals to Lock In Its Hardware Bundle"
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "sitemap:https://www.theinformation.com/briefings/tiktok-reaches-400-million-settlement-doj-child-privacy-lawsuit",
+        "title": "TikTok Reaches $400 Million Settlement With DOJ Over Child Privacy Lawsuit",
+        "publishedUtc": "2026-08-22T06:14:22.000Z",
+        "kind": "briefing",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-22T08:21:57.412Z"
+      },
+      "signal": {
+        "id": "sig-ce2da531aabe3bb3-mt440s2y",
+        "newsId": "sitemap:https://www.theinformation.com/briefings/tiktok-reaches-400-million-settlement-doj-child-privacy-lawsuit",
+        "fingerprint": "ce2da531aabe3bb3",
+        "firstSeenUtc": "2026-08-22T06:14:22.000Z",
+        "firstSeenBasis": "The Information item — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bearish",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 10,
+          "eventType": "regulatory_legal",
+          "factLevel": "fact",
+          "tickers": [],
+          "surpriseNote": "rules fallback: no consensus comparison performed",
+          "reason": "no universe ticker matched"
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-22T08:21:57.418Z",
+        "title": "TikTok Reaches $400 Million Settlement With DOJ Over Child Privacy Lawsuit"
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "sitemap:https://www.theinformation.com/briefings/exclusive-openai-explored-stake-stargate-power-developer-lancium",
+        "title": "Exclusive: OpenAI Explored Stake in Stargate Power Developer Lancium",
+        "publishedUtc": "2026-08-21T23:32:58.000Z",
+        "kind": "briefing",
+        "prefix": "exclusive",
+        "seenAtUtc": "2026-08-22T08:21:57.389Z"
+      },
+      "signal": {
+        "id": "sig-8ed53e841b9753f2-mt440vf1",
+        "newsId": "sitemap:https://www.theinformation.com/briefings/exclusive-openai-explored-stake-stargate-power-developer-lancium",
+        "fingerprint": "8ed53e841b9753f2",
+        "firstSeenUtc": "2026-08-21T23:32:58.000Z",
+        "firstSeenBasis": "The Information exclusive — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 10,
+          "eventType": "other",
+          "factLevel": "fact",
+          "tickers": [
+            "ORCL"
+          ],
+          "surpriseNote": "rules fallback: no consensus comparison performed",
+          "reason": "rules fallback: no tradeable category pattern"
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-22T08:22:01.741Z",
+        "title": "Exclusive: OpenAI Explored Stake in Stargate Power Developer Lancium"
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "tag:www.theinformation.com,2005:Briefing/17912",
+        "title": "TikTok Reaches $400 Million Settlement With DOJ Over Child Privacy Lawsuit",
+        "publishedUtc": "2026-08-22T06:14:22.000Z",
+        "kind": "briefing",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-22T08:18:30.341Z"
+      },
+      "signal": {
+        "id": "sig-6532989c94286643-mt43wcb1",
+        "newsId": "tag:www.theinformation.com,2005:Briefing/17912",
+        "fingerprint": "6532989c94286643",
+        "firstSeenUtc": "2026-08-22T06:14:22.000Z",
+        "firstSeenBasis": "The Information item — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bearish",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 10,
+          "eventType": "order_contract",
+          "factLevel": "fact",
+          "tickers": [],
+          "surpriseNote": "rules fallback: no consensus comparison performed",
+          "reason": "no universe ticker matched"
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-22T08:18:30.349Z",
+        "title": "TikTok Reaches $400 Million Settlement With DOJ Over Child Privacy Lawsuit"
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "tag:www.theinformation.com,2005:Briefing/17911",
+        "title": "Exclusive: OpenAI Explored Stake in Stargate Power Developer Lancium",
+        "publishedUtc": "2026-08-21T23:32:58.000Z",
+        "kind": "briefing",
+        "prefix": "exclusive",
+        "seenAtUtc": "2026-08-21T23:34:33.994Z"
+      },
+      "signal": {
+        "id": "sig-8f40c09070ddc9a6-mt3l76ru",
+        "newsId": "tag:www.theinformation.com,2005:Briefing/17911",
+        "fingerprint": "8f40c09070ddc9a6",
+        "firstSeenUtc": "2026-08-21T23:32:58.000Z",
+        "firstSeenBasis": "The Information exclusive — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "mixed",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 12,
+          "eventType": "mna",
+          "factLevel": "fact",
+          "tickers": [],
+          "surpriseNote": "Baseline missing. Story is corporate-development chatter about private entities: OpenAI explored a stake in/acquisition of private power developer Lancium. Nvidia's billions-dollar stake is stated as already-completed backward context, not fresh news, and is immaterial versus NVDA's multi-trillion cap. ORCL is not mentioned at all.",
+          "reason": "Headline actors are OpenAI (private, not in universe) and Lancium (private). NVDA appears only as a secondary, already-reported financing detail — not the headline actor, and a 'billions' stake is negligible relative to NVDA scale, so no excess move justified. ORCL absent from the item entirely. No tradeable event for any universe symbol; empty ticker list."
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-21T23:35:03.690Z",
+        "title": "Exclusive: OpenAI Explored Stake in Stargate Power Developer Lancium"
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "tag:www.theinformation.com,2005:Article/17685",
+        "title": "Nvidia is Using Land and Electricity Deals to Lock In Its Hardware Bundle",
+        "publishedUtc": "2026-08-21T21:40:11.000Z",
+        "kind": "article",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-21T21:40:33.945Z"
+      },
+      "signal": {
+        "id": "sig-571ed2afb17ab409-mt3h4qya",
+        "newsId": "tag:www.theinformation.com,2005:Article/17685",
+        "fingerprint": "571ed2afb17ab409",
+        "firstSeenUtc": "2026-08-21T21:40:11.000Z",
+        "firstSeenBasis": "The Information item — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 22,
+          "eventType": "supply_chain",
+          "factLevel": "fact",
+          "tickers": [
+            "NVDA"
+          ],
+          "surpriseNote": "Baseline missing; judged conservatively on novelty. This is the THIRD minority infra stake in rapid succession (after Lancium and SB Energy), so the power-securing strategy is already known and priced as an ongoing theme — low incremental surprise. Terms undisclosed, stake is non-controlling in a two-year-old firm, and 'chip overhang' framing is analyst forecast, not a disclosed financial event.",
+          "reason": "NVDA is the clear headline actor, and securing power/land capacity so its chips aren't left idle is a genuine supply_chain-category event at fact level. But materiality fails the gate: a small, undisclosed, non-controlling minority stake — third in a repeated pattern — is immaterial against a ~$4T market cap and does not justify an excess move. Category present, surprise absent → not tradeable alone."
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-21T21:41:11.410Z",
+        "title": "Nvidia is Using Land and Electricity Deals to Lock In Its Hardware Bundle"
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "sitemap:https://www.theinformation.com/briefings/exclusive-key-openai-sales-executive-kaylin-voss-resigns",
+        "title": "Exclusive: Key OpenAI Sales Executive Kaylin Voss Resigns",
+        "publishedUtc": "2026-08-21T19:20:07.000Z",
+        "kind": "briefing",
+        "prefix": "exclusive",
+        "seenAtUtc": "2026-08-21T19:57:31.456Z"
+      },
+      "signal": {
+        "id": "sig-e539dd1b780ff3b4-mt3dffm0",
+        "newsId": "sitemap:https://www.theinformation.com/briefings/exclusive-key-openai-sales-executive-kaylin-voss-resigns",
+        "fingerprint": "e539dd1b780ff3b4",
+        "firstSeenUtc": "2026-08-21T19:20:07.000Z",
+        "firstSeenBasis": "The Information exclusive — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 10,
+          "eventType": "other",
+          "factLevel": "fact",
+          "tickers": [],
+          "surpriseNote": "rules fallback: no consensus comparison performed",
+          "reason": "no universe ticker matched"
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-21T19:57:31.464Z",
+        "title": "Exclusive: Key OpenAI Sales Executive Kaylin Voss Resigns"
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "tag:www.theinformation.com,2005:Briefing/17910",
+        "title": "Exclusive: Key OpenAI Sales Executive Kaylin Voss Resigns",
+        "publishedUtc": "2026-08-21T19:20:07.000Z",
+        "kind": "briefing",
+        "prefix": "exclusive",
+        "seenAtUtc": "2026-08-21T19:20:56.576Z"
+      },
+      "signal": {
+        "id": "sig-dced744333a3f851-mt3c4e10",
+        "newsId": "tag:www.theinformation.com,2005:Briefing/17910",
+        "fingerprint": "dced744333a3f851",
+        "firstSeenUtc": "2026-08-21T19:20:07.000Z",
+        "firstSeenBasis": "The Information exclusive — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 10,
+          "eventType": "earnings_guidance",
+          "factLevel": "fact",
+          "tickers": [],
+          "surpriseNote": "rules fallback: no consensus comparison performed",
+          "reason": "no universe ticker matched"
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-21T19:20:56.580Z",
+        "title": "Exclusive: Key OpenAI Sales Executive Kaylin Voss Resigns"
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "manual:mt3bjih3",
+        "title": "E2E TEST 2: SanDisk wins exclusive 3-year enterprise NAND contract with hyperscaler, worth about $9 billion",
+        "publishedUtc": "2026-08-21T19:04:42.567Z",
+        "kind": "manual",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-21T19:04:42.567Z"
+      },
+      "signal": {
+        "id": "sig-6429a40c70377956-mt3bke15",
+        "newsId": "manual:mt3bjih3",
+        "fingerprint": "6429a40c70377956",
+        "firstSeenUtc": "2026-08-21T19:04:42.567Z",
+        "firstSeenBasis": "The Information item — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "large",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": true,
+          "score": 84,
+          "eventType": "order_contract",
+          "factLevel": "fact",
+          "tickers": [
+            "SNDK"
+          ],
+          "surpriseNote": "Baseline missing — judged on novelty, not absolute size. What is beyond routine: the deal is exclusive, previously unreported, multi-year, priced ~20% ABOVE current enterprise NAND spot (margin-accretive, not a discount grab), and carries prepayments funding a dedicated line (demand + capex de-risking). These structural terms, not the $9B headline number, are the surprise. Scored conservatively absent consensus.",
+          "reason": "Order/contract win with SanDisk as the sole headline actor. Fact-level (reported as an executed agreement via people familiar), not forecast or opinion, so it clears the materiality gate. A ~$9B exclusive 3-year supply lock at premium pricing with prepayments is a multi-year revenue and margin event large relative to SNDK, justifying a large excess-move band. MU excluded: Micron is a NAND peer that could see sympathy/read-through, but it is not a headline actor of THIS news, so it is not tagged per the actor rule."
+        },
+        "pricedIn": {
+          "status": "none",
+          "tEvalUtc": "2026-08-21T19:05:23.462Z",
+          "deltaTMinutes": 0.6815833333333333,
+          "realizedExcessPct": 0,
+          "volumeZ": null,
+          "dataBasis": "hl_perp",
+          "sessionBucket": "rth",
+          "benchmarkUsed": "XYZ100",
+          "betaUsed": 3.303858631847057,
+          "confidence": "high",
+          "note": "realized 0.00% vs band-mid 13.0% (expected-by-now 0.65% at Δt=1min; volume baseline too young)"
+        },
+        "createdAtUtc": "2026-08-21T19:05:23.465Z",
+        "title": "E2E TEST 2: SanDisk wins exclusive 3-year enterprise NAND contract with hyperscaler, worth about $9 billion"
+      },
+      "thesis": {
+        "id": "th-6429a40c70377956-SNDK-mt3bn65v",
+        "signalId": "sig-6429a40c70377956-mt3bke15",
+        "ticker": "SNDK",
+        "direction": "long",
+        "tradeType": "event",
+        "fairImpactPct": {
+          "min": 6,
+          "max": 24,
+          "point": 13
+        },
+        "impactPath": [
+          {
+            "step": "Deal scope → annual revenue run-rate",
+            "value": "$9B total over 3 years ≈ $3.0B/yr of enterprise NAND revenue. This is very large vs an assumed ~$8–9B/yr total company revenue (~33–38% of sales at full run-rate)."
+          },
+          {
+            "step": "Incrementality (net-new vs reallocated)",
+            "value": "Prepayments fund a DEDICATED production line ⇒ mostly new capacity, not cannibalized existing wafers. Assume ~75–80% incremental → ~$2.3–2.4B/yr net-new revenue at steady state."
+          },
+          {
+            "step": "Margin impact (20% above spot)",
+            "value": "Premium pricing + upcycle: est. incremental gross ~40%, incremental operating margin ~28% after opex/depreciation on the new line → ~$670M/yr steady-state EBIT; after tax (~20%) ≈ $540M/yr net. (Prepayments cut cash capex but the line still carries depreciation.)"
+          },
+          {
+            "step": "Ramp timing",
+            "value": "A dedicated NAND line takes ~12–24 months to reach full output. Next-FY (FY27) contribution assumed ~40% of run-rate ≈ $215M after-tax; full run-rate (FY28–29) ≈ $540M/yr."
+          },
+          {
+            "step": "EPS revision vs consensus (assumed baseline)",
+            "value": "Assume ~145M shares and baseline EPS ~$10 (upcycle net income ~$1.5B). Incremental after-tax: next-FY +$1.5/sh ≈ +15% vs consensus; steady-state +$3.7/sh ≈ +35%. Baseline is an EXPLICIT ASSUMPTION — consensus was MISSING."
+          },
+          {
+            "step": "Valuation → fair excess move",
+            "value": "Contract is FINITE (3 yrs), so the market will NOT capitalize the run-rate at a full P/E. Blend: 3-yr after-tax profit NPV ≈ $1.0–1.2B ≈ +6–9% of an assumed ~$18B market cap, PLUS a partial re-rate for a demonstrated exclusive hyperscaler win / renewal optionality / reduced cyclicality, NET of single-customer concentration risk. → point ≈ +13% excess move; multiple only modestly re-rated (most of the move is NPV/earnings, not re-rating)."
+          }
+        ],
+        "evidence": [
+          {
+            "point": "$9B total, exclusive, 3-year enterprise NAND supply contract with a major US hyperscaler",
+            "source": "News text (single-sourced, 'people familiar with the deal')",
+            "url": null,
+            "credibility": "medium"
+          },
+          {
+            "point": "Pricing locked ~20% above current enterprise NAND spot → margin-accretive, not a discount grab",
+            "source": "News text",
+            "url": null,
+            "credibility": "medium"
+          },
+          {
+            "point": "Prepayments fund a dedicated production line → demand + capex de-risking, implies incremental capacity",
+            "source": "News text",
+            "url": null,
+            "credibility": "medium"
+          },
+          {
+            "point": "Baseline financials (market cap ~$18B, ~145M shares, revenue ~$8–9B, EPS ~$10) — ASSUMED because consensus was MISSING",
+            "source": "Analyst assumption (SanDisk standalone post-WD spin, NAND upcycle)",
+            "url": null,
+            "credibility": "low"
+          }
+        ],
+        "contamination": "none",
+        "horizonHours": 120,
+        "catalysts": [
+          "8-K / material-contract SEC filing confirming the deal and terms",
+          "Company press release or on-record confirmation from SanDisk or the hyperscaler",
+          "Sell-side estimate revisions to FY27–FY29 revenue/EPS",
+          "Next earnings call: management guidance on the dedicated line, ramp schedule, and margin uplift",
+          "Hyperscaler capex/AI-storage commentary corroborating enterprise NAND demand"
+        ],
+        "falsifiers": [
+          "Within a week, no 8-K / material-contract filing appears despite a deal this size for a company this size (would normally require disclosure) — suggests the report is overstated or inaccurate",
+          "SanDisk or the hyperscaler denies the report, or a filing reveals value/term materially below ~$9B or NOT exclusive",
+          "Disclosure reveals the volume largely reallocates existing capacity (not incremental) and/or the '20% above spot' premium is contradicted by margin guidance — collapsing the net revenue/EPS add"
+        ],
+        "limitations": [
+          "Consensus and baseline (market cap, shares, EPS, revenue) were MISSING — all baseline figures are explicit assumptions; fairImpactPct is anchored on the % EPS-revision method to reduce sensitivity to the market-cap guess, but the NPV cross-check depends directly on it",
+          "Single-sourced, unconfirmed report ('people familiar') — existence and exact terms not yet corroborated by filing",
+          "Ramp timing and the incremental-vs-reallocated split (~75–80%) are estimates; slower ramp or more reallocation pushes toward the min",
+          "Assumed incremental operating margin (~28%) and tax rate (~20%) are estimates; NAND is highly cyclical so out-year earnings are uncertain",
+          "Single-customer concentration and the finite 3-year term cap the fair re-rate; a renewal/expansion (not assumed) would justify the max"
+        ],
+        "confidence": "medium",
+        "provider": "claude-cli",
+        "createdAtUtc": "2026-08-21T19:07:33.235Z"
+      },
+      "decision": {
+        "id": "pmd-th-6429a40c70377956-SNDK-mt3bn65v-mt5kpvdz",
+        "thesisId": "th-6429a40c70377956-SNDK-mt3bn65v",
+        "ticker": "SNDK",
+        "action": "open",
+        "direction": "long",
+        "refPx": 1593.7,
+        "sizeUsd": 3000,
+        "leverage": 1.4657076431269982,
+        "stop": {
+          "initialPx": 1585,
+          "hardFloorPx": 1274.96,
+          "rule": "max(entry ∓ 1.5×ATR20d, recent RTH swing) bounded by −20% user hard floor; trail chandelier(2.5×ATR) arms at 50% of target",
+          "atr20d": 182.9525,
+          "trailArmed": false
+        },
+        "targetPctExcess": {
+          "lo": 6,
+          "hi": 13
+        },
+        "horizonUtc": "2026-08-28T08:57:08.135Z",
+        "intendedRiskPct": 0.01,
+        "realizedRiskPct": 0.0016376984375980508,
+        "bindingConstraint": "tier1_cap",
+        "residualEdgePct": 5.9,
+        "reason": "open long SNDK: residual 5.90% ≥ threshold 5.64%; risk 0.16% (intended 1.0%, clipped by tier1_cap)",
+        "audit": {
+          "vetoedBy": null,
+          "edge": {
+            "conservativePct": 6,
+            "pointPct": 13,
+            "realizedPct": 0.1,
+            "residualPct": 5.9
+          },
+          "threshold": {
+            "takerFeePct": 0.009000000000000001,
+            "slippagePct": 0.05,
+            "fundingPct": 0.075,
+            "roundTripPct": 0.193,
+            "costFloorPct": 0.579,
+            "volFloorPct": 5.642843237781729,
+            "thresholdPct": 5.642843237781729
+          },
+          "stopMenu": {
+            "atr20d": 182.9525,
+            "atrStopPx": 1319.2713,
+            "swingPx": 1585,
+            "hardFloorPx": 1274.96,
+            "chosenPx": 1585,
+            "stopDistPct": 0.005458994791993503
+          },
+          "sizing": {
+            "equityUsd": 10000,
+            "riskBudgetPct": 0.01,
+            "intendedNotionalUsd": 18318,
+            "guards": [
+              {
+                "name": "tier1_cap",
+                "capUsd": 3000,
+                "notionalAfterUsd": 3000,
+                "clipped": true
+              },
+              {
+                "name": "gross_cap",
+                "capUsd": 15000,
+                "notionalAfterUsd": 3000,
+                "clipped": false
+              },
+              {
+                "name": "net_cap",
+                "capUsd": 10000,
+                "notionalAfterUsd": 3000,
+                "clipped": false
+              },
+              {
+                "name": "cluster_cap:storage",
+                "capUsd": 4000,
+                "notionalAfterUsd": 3000,
+                "clipped": false
+              },
+              {
+                "name": "cluster_cap:semiconductors",
+                "capUsd": 4000,
+                "notionalAfterUsd": 3000,
+                "clipped": false
+              },
+              {
+                "name": "cluster_cap:nand",
+                "capUsd": 4000,
+                "notionalAfterUsd": 3000,
+                "clipped": false
+              }
+            ],
+            "finalNotionalUsd": 3000,
+            "leverage": {
+              "configCap": 3,
+              "volCap": 1.4657,
+              "venueCap": 10,
+              "chosen": 1.4657
+            }
+          },
+          "marketView": {
+            "markPx": 1593.7,
+            "dailyVolPct": 0.11285686475563457,
+            "maxDailyMovePct": 0.3411321502924556,
+            "fundingHourly": 0.00000625,
+            "beta": 3.363273167517224
+          }
+        },
+        "createdAtUtc": "2026-08-23T08:57:08.135Z",
+        "ts": "2026-08-23T08:57:08.136Z"
+      },
+      "execution": {
+        "ts": "2026-08-21T19:07:33.238Z",
+        "type": "paper_open",
+        "ticker": "SNDK",
+        "direction": "long",
+        "qty": 1.8710225568608436,
+        "fillPx": 1603.4012999999998,
+        "sizeUsd": 3000,
+        "decisionId": "pmd-th-6429a40c70377956-SNDK-mt3bn65v-mt3bn65y",
+        "signalId": "sig-6429a40c70377956-mt3bke15"
+      },
+      "positionNow": {
+        "ticker": "SNDK",
+        "hlSymbol": "xyz:SNDK",
+        "direction": "long",
+        "qty": 1.8710225568608436,
+        "entryPx": 1603.4012999999998,
+        "entryUtc": "2026-08-21T19:07:33.238Z",
+        "notionalUsdAtEntry": 3000,
+        "leverage": 1.4657076431269982,
+        "stopPx": 1580.4,
+        "hardFloorPx": 1282.08,
+        "targetPctExcess": {
+          "lo": 6,
+          "hi": 13
+        },
+        "horizonUtc": "2026-08-26T19:07:33.238Z",
+        "extendedOnce": false,
+        "thesisId": "th-6429a40c70377956-SNDK-mt3bn65v",
+        "decisionId": "pmd-th-6429a40c70377956-SNDK-mt3bn65v-mt3bn65y",
+        "signalT0Utc": "2026-08-21T19:04:42.567Z",
+        "baselinePx": 1600.2,
+        "benchmarkBaselinePx": 29291,
+        "beta": 3.303858631847057,
+        "trailArmed": false,
+        "highestClosePx": 1603.4012999999998
+      },
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "manual:mt3bi4j9",
+        "title": "E2E TEST: Micron signs multi-year HBM4 supply agreement with major AI accelerator maker, capacity fully booked through 2028",
+        "publishedUtc": "2026-08-21T19:03:37.845Z",
+        "kind": "manual",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-21T19:03:37.846Z"
+      },
+      "signal": {
+        "id": "sig-684d9cad33c14c08-mt3bj1xr",
+        "newsId": "manual:mt3bi4j9",
+        "fingerprint": "684d9cad33c14c08",
+        "firstSeenUtc": "2026-08-21T19:03:37.845Z",
+        "firstSeenBasis": "The Information item — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "medium",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": true,
+          "score": 72,
+          "eventType": "order_contract",
+          "factLevel": "fact",
+          "tickers": [
+            "MU"
+          ],
+          "surpriseNote": "Baseline missing — judging novelty conservatively. Beyond-consensus elements are the multi-year HBM4 lock-up booking the MAJORITY of MU's 2027-2028 output (forward revenue visibility) and, most notably, contract pricing ~15% ABOVE current HBM3E (pricing power / margin signal). HBM4 ramp and strong AI-memory demand are already consensus; the incremental surprise is the pricing uplift and multi-year capacity commitment, not the deal's existence. Not scoring the absolute output/price figures, only the delta vs the known narrative.",
+          "reason": "Named customer supply contract with MU as the clear headline actor; reported as a signed agreement ('direct knowledge'), so factLevel=fact, not forecast/opinion. order_contract is a tradeable category. Positive on both visibility (majority of 2027-28 booked) and margins (15% price premium), hence bullish. Medium band: incrementally positive but directionally in line with the existing AI-HBM narrative and baseline is missing, so conservative. Counterparty accelerator maker is unnamed and not in universe → only MU tagged."
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-21T19:04:21.135Z",
+        "title": "E2E TEST: Micron signs multi-year HBM4 supply agreement with major AI accelerator maker, capacity fully booked through 2028"
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "manual:mt3b9y7w",
+        "title": "E2E TEST: Micron signs multi-year HBM4 supply agreement with major AI accelerator maker, capacity fully booked through 2028",
+        "publishedUtc": "2026-08-21T18:57:16.412Z",
+        "kind": "manual",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-21T18:57:16.413Z"
+      },
+      "signal": {
+        "id": "sig-3c9e0023b96116f8-mt3bbrab",
+        "newsId": "manual:mt3b9y7w",
+        "fingerprint": "3c9e0023b96116f8",
+        "firstSeenUtc": "2026-08-21T18:57:16.412Z",
+        "firstSeenBasis": "The Information item — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "large",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": true,
+          "score": 82,
+          "eventType": "order_contract",
+          "factLevel": "fact",
+          "tickers": [
+            "MU"
+          ],
+          "surpriseNote": "Baseline missing for MU; judged conservatively on novelty. Previously unreported multi-year HBM4 deal locking the majority of 2027-2028 output at ~15% premium to HBM3E — signals durable pricing power and demand visibility well beyond a routine supply update.",
+          "reason": "Micron is the headline actor in a newly signed, not-previously-reported multi-year HBM4 supply agreement covering most of its 2027-2028 output, plus a ~15% price premium and stated capacity expansion. Concrete signed-fact order/contract event with clear revenue and margin implications — tradeable on category, not sentiment."
+        },
+        "pricedIn": {
+          "status": "none",
+          "tEvalUtc": "2026-08-21T18:58:37.468Z",
+          "deltaTMinutes": 1.3509333333333333,
+          "realizedExcessPct": 0,
+          "volumeZ": null,
+          "dataBasis": "hl_perp",
+          "sessionBucket": "rth",
+          "benchmarkUsed": "XYZ100",
+          "betaUsed": 2.8998126714562686,
+          "confidence": "high",
+          "note": "realized 0.00% vs band-mid 13.0% (expected-by-now 0.65% at Δt=1min; volume baseline too young)"
+        },
+        "createdAtUtc": "2026-08-21T18:58:40.739Z",
+        "title": "E2E TEST: Micron signs multi-year HBM4 supply agreement with major AI accelerator maker, capacity fully booked through 2028"
+      },
+      "thesis": {
+        "id": "th-3c9e0023b96116f8-MU-mt3bdsvb",
+        "signalId": "sig-3c9e0023b96116f8-mt3bbrab",
+        "ticker": "MU",
+        "direction": "long",
+        "tradeType": "event",
+        "fairImpactPct": {
+          "min": 3,
+          "max": 13,
+          "point": 7
+        },
+        "impactPath": [
+          {
+            "step": "News → affected line item: HBM4 volume. A single leading AI-accelerator customer books the majority of Micron's 2027–2028 HBM4 output; capacity said fully booked through 2028.",
+            "value": "De-risks 2 years of HBM demand; converts an expected-but-uncertain revenue stream into a contracted one. Primarily a risk/visibility effect, not new volume vs. consensus (Street already models Micron as a 3rd HBM supplier)."
+          },
+          {
+            "step": "News → ASP/margin: HBM4 contracted ~15% above current HBM3E pricing.",
+            "value": "Next-gen HBM normally carries a premium, so assume Street already baked in roughly half of this step-up. Incremental ASP surprise ≈ +5–8% on the HBM segment only."
+          },
+          {
+            "step": "Revenue/gross profit: apply to assumed FY2027 HBM revenue base.",
+            "value": "ASSUMPTION: HBM ≈ $15B of FY2027 revenue (Micron ~20–25% share of a ~$60–80B HBM TAM). +5–8% ASP surprise → +$0.75–1.2B revenue; HBM GM >50% → +$0.4–0.7B incremental gross profit, mostly drop-through."
+          },
+          {
+            "step": "Next-FY (FY2027, Sept'26–Aug'27) EPS revision vs consensus.",
+            "value": "ASSUMPTION: FY2027 net income base ≈ $10B (mkt cap ~$140B ÷ fwd P/E ~14x). +$0.4–0.7B after-tax ≈ +4–7% EPS. Base case +5%."
+          },
+          {
+            "step": "Fair price move at unchanged multiple ≈ EPS revision.",
+            "value": "≈ +5% (base)."
+          },
+          {
+            "step": "Multiple re-rate: durable pricing power + 2-year demand visibility reduces the cyclical trough-earnings risk premium that caps memory multiples.",
+            "value": "Modest re-rate, +2–3%. Justified because for a cyclical memory name, visibility de-risks the multiple; but one contract does not remove cyclicality, so kept small. Partly offset by single-customer concentration risk."
+          },
+          {
+            "step": "Total fair EXCESS move vs semiconductor benchmark (idiosyncratic, MU-specific contract).",
+            "value": "≈ +5% EPS-driven + ~+2% re-rate = +7% base; +3% if largely pre-modeled, +13% if ASP surprise + HBM base + de-risk re-rate all run high (e.g., customer is Nvidia, volume above Street)."
+          }
+        ],
+        "evidence": [
+          {
+            "point": "Deal covers majority of 2027–2028 HBM4 output at ~15% premium to HBM3E; capacity booked through 2028.",
+            "source": "News text (single-sourced, 'people with direct knowledge'; company-unconfirmed, 'not previously reported').",
+            "url": null,
+            "credibility": "medium"
+          },
+          {
+            "point": "HBM is Micron's primary growth and margin driver; HBM gross margin runs above corporate average.",
+            "source": "Micron disclosures / sell-side consensus on HBM economics.",
+            "url": null,
+            "credibility": "high"
+          },
+          {
+            "point": "Micron is one of three HBM suppliers, so Street already models material HBM4 revenue in 2027–2028 — the incremental is the ASP/visibility delta, not the whole segment.",
+            "source": "Industry structure / analyst models.",
+            "url": null,
+            "credibility": "high"
+          },
+          {
+            "point": "Consensus EPS, market cap, forward multiple, and FY2027 HBM revenue used here are stated assumptions, not confirmed baselines.",
+            "source": "Analyst assumption (baseline MISSING in input).",
+            "url": null,
+            "credibility": "low"
+          }
+        ],
+        "contamination": "hard",
+        "horizonHours": 72,
+        "catalysts": [
+          "Micron official confirmation (8-K / press release) of the agreement",
+          "Disclosure of the customer's identity (Nvidia would be a materially larger signal)",
+          "Next earnings call: FY2027 HBM4 booking %, pricing, and updated capex guidance for Boise/Taichung",
+          "Sell-side estimate revisions to FY2027–FY2028 HBM revenue/ASP"
+        ],
+        "falsifiers": [
+          "Within a week, Micron or the customer denies the agreement or declines to confirm, or company IR calls the report inaccurate.",
+          "Sell-side notes state the ~15% HBM4 premium is in line with or below the HBM3E→HBM4 step-up already in estimates (i.e., no upward revisions follow).",
+          "Follow-up reporting contradicts 'majority of output to one customer' (multiple customers / smaller allocation), weakening both the visibility and concentration read.",
+          "No published FY2027/FY2028 estimate revisions from major brokers within a week, indicating the deal was already modeled."
+        ],
+        "limitations": [
+          "No consensus baseline supplied — EPS revision % rests on assumed FY2027 net income (~$10B), HBM revenue (~$15B), fwd P/E (~14x), and market cap (~$140B); real figures could shift the point estimate by several points.",
+          "Single-sourced, company-unconfirmed report; existence/terms could be overstated.",
+          "Cannot cleanly separate 'genuinely incremental' from 'already priced' without the actual sell-side model — the pre-modeled share is the biggest swing factor.",
+          "Single-customer concentration (majority of output to one buyer) is a real downside risk that partially offsets the visibility premium and is hard to quantify blind.",
+          "The 'E2E TEST' headline prefix suggests this may be synthetic test input; analysis is on its stated merits regardless."
+        ],
+        "confidence": "medium",
+        "provider": "claude-cli",
+        "createdAtUtc": "2026-08-21T19:00:16.103Z"
+      },
+      "decision": {
+        "id": "pmd-th-3c9e0023b96116f8-MU-mt3bdsvb-mt3bdsve",
+        "thesisId": "th-3c9e0023b96116f8-MU-mt3bdsvb",
+        "ticker": "MU",
+        "action": "no_trade",
+        "direction": null,
+        "refPx": 969.04,
+        "sizeUsd": 0,
+        "leverage": null,
+        "stop": null,
+        "targetPctExcess": null,
+        "horizonUtc": null,
+        "intendedRiskPct": null,
+        "realizedRiskPct": null,
+        "bindingConstraint": null,
+        "residualEdgePct": null,
+        "reason": "thesis hard-contaminated by price reaction — analyst must re-run blind",
+        "createdAtUtc": "2026-08-21T19:00:16.106Z",
+        "ts": "2026-08-21T19:00:16.106Z",
+        "audit": {
+          "vetoedBy": null,
+          "edge": {
+            "conservativePct": 6,
+            "pointPct": 13,
+            "realizedPct": 0.4,
+            "residualPct": 5.6
+          },
+          "threshold": {
+            "takerFeePct": 0.009000000000000001,
+            "slippagePct": 0.05,
+            "fundingPct": 0.075,
+            "roundTripPct": 0.193,
+            "costFloorPct": 0.579,
+            "volFloorPct": 5.642843237781729,
+            "thresholdPct": 5.642843237781729
+          },
+          "stopMenu": null,
+          "sizing": null,
+          "marketView": {
+            "markPx": 1593.7,
+            "dailyVolPct": 0.11285686475563457,
+            "maxDailyMovePct": 0.3411321502924556,
+            "fundingHourly": 0.00000625,
+            "beta": 3.363273167517224
+          }
+        }
+      },
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "sitemap:https://www.theinformation.com/newsletters/dealmaker/barclays-loses-tech-bankers-vcs-get-exits-poolside-openrouter",
+        "title": "Barclays Loses Tech Bankers; VCs Get Exits From Poolside, OpenRouter",
+        "publishedUtc": "2026-08-21T00:15:33.000Z",
+        "kind": "article",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-21T18:53:26.482Z"
+      },
+      "signal": {
+        "id": "sig-e539dd1b780ff3b4-mt3b6m97",
+        "newsId": "sitemap:https://www.theinformation.com/newsletters/dealmaker/barclays-loses-tech-bankers-vcs-get-exits-poolside-openrouter",
+        "fingerprint": "e539dd1b780ff3b4",
+        "firstSeenUtc": "2026-08-21T00:15:33.000Z",
+        "firstSeenBasis": "The Information item — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 10,
+          "eventType": "other",
+          "factLevel": "fact",
+          "tickers": [],
+          "surpriseNote": "rules fallback: no consensus comparison performed",
+          "reason": "no universe ticker matched"
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-21T18:54:40.939Z",
+        "followUp24h": {
+          "realizedExcessPct": null,
+          "directionHit": null,
+          "computedAtUtc": "2026-08-22T13:01:52.479Z"
+        }
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "sitemap:https://www.theinformation.com/articles/new-robotics-arms-race-can-craziest-hype-video",
+        "title": "The New Robotics ‘Arms Race’: Who Can Do the Craziest Hype Video?",
+        "publishedUtc": "2026-08-21T14:12:21.000Z",
+        "kind": "article",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-21T18:53:26.482Z"
+      },
+      "signal": {
+        "id": "sig-e539dd1b780ff3b4-mt3b6m96",
+        "newsId": "sitemap:https://www.theinformation.com/articles/new-robotics-arms-race-can-craziest-hype-video",
+        "fingerprint": "e539dd1b780ff3b4",
+        "firstSeenUtc": "2026-08-21T14:12:21.000Z",
+        "firstSeenBasis": "The Information item — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 10,
+          "eventType": "other",
+          "factLevel": "fact",
+          "tickers": [],
+          "surpriseNote": "rules fallback: no consensus comparison performed",
+          "reason": "no universe ticker matched"
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-21T18:54:40.938Z"
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "sitemap:https://www.theinformation.com/newsletters/the-briefing/walmarts-slowdown-spotlights-amazons-strength",
+        "title": "Walmart’s Slowdown Spotlights Amazon’s Strength",
+        "publishedUtc": "2026-08-21T00:00:35.000Z",
+        "kind": "article",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-21T18:53:26.482Z"
+      },
+      "signal": {
+        "id": "sig-6a29b33dcc0d7e5e-mt3b6wcw",
+        "newsId": "sitemap:https://www.theinformation.com/newsletters/the-briefing/walmarts-slowdown-spotlights-amazons-strength",
+        "fingerprint": "6a29b33dcc0d7e5e",
+        "firstSeenUtc": "2026-08-21T00:00:35.000Z",
+        "firstSeenBasis": "The Information item — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 12,
+          "eventType": "other",
+          "factLevel": "opinion",
+          "tickers": [],
+          "surpriseNote": "Baseline missing. This is a well-worn narrative (Walmart deceleration vs. Amazon relative strength) with an empty body and no new datum — no earnings figure, guidance, contract, or disclosed metric beyond the existing consensus story. Novelty judged conservatively as near-zero.",
+          "reason": "Opinion/analysis comparison piece, not a tradeable event category. No fact-level catalyst: Amazon is characterized ('strength'), not shown taking a concrete material action, and the actual subject of the 'slowdown' (Walmart) is not in the universe. Category gate fails and factLevel=opinion is never tradeable, so no ticker attribution."
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-21T18:54:54.032Z",
+        "followUp24h": {
+          "realizedExcessPct": null,
+          "directionHit": null,
+          "computedAtUtc": "2026-08-22T13:01:52.479Z"
+        }
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "sitemap:https://www.theinformation.com/newsletters/applied-ai/t-using-open-source-models-curb-anthropic-bills",
+        "title": "AT&T is Using Open Source Models to Curb Anthropic Bills",
+        "publishedUtc": "2026-08-20T18:55:44.000Z",
+        "kind": "article",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-21T18:53:26.482Z"
+      },
+      "signal": {
+        "id": "sig-e539dd1b780ff3b4-mt3b698e",
+        "newsId": "sitemap:https://www.theinformation.com/newsletters/applied-ai/t-using-open-source-models-curb-anthropic-bills",
+        "fingerprint": "e539dd1b780ff3b4",
+        "firstSeenUtc": "2026-08-20T18:55:44.000Z",
+        "firstSeenBasis": "The Information item — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 10,
+          "eventType": "other",
+          "factLevel": "fact",
+          "tickers": [],
+          "surpriseNote": "rules fallback: no consensus comparison performed",
+          "reason": "no universe ticker matched"
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-21T18:54:24.062Z",
+        "followUp24h": {
+          "realizedExcessPct": null,
+          "directionHit": null,
+          "computedAtUtc": "2026-08-21T19:55:15.989Z"
+        }
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "sitemap:https://www.theinformation.com/articles/nvidia-plots-china-comeback-new-ai-chip",
+        "title": "Nvidia Plots China Comeback With New AI Chip",
+        "publishedUtc": "2026-08-20T16:58:10.000Z",
+        "kind": "article",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-21T18:53:26.481Z"
+      },
+      "signal": {
+        "id": "sig-b17ab5344d169241-mt3b6sx1",
+        "newsId": "sitemap:https://www.theinformation.com/articles/nvidia-plots-china-comeback-new-ai-chip",
+        "fingerprint": "b17ab5344d169241",
+        "firstSeenUtc": "2026-08-20T16:58:10.000Z",
+        "firstSeenBasis": "The Information item — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": true,
+          "score": 42,
+          "eventType": "product_tech",
+          "factLevel": "forecast",
+          "tickers": [
+            "NVDA"
+          ],
+          "surpriseNote": "Baseline missing — judging novelty conservatively. A China-compliant Nvidia chip is a long-running, already-reported theme (post-H20 export-control saga), and 'plots' signals a plan, not a shipped product or approved sale. Novelty beyond the known narrative is low; no confirmed chip specs, volume, or regulatory clearance disclosed.",
+          "reason": "Nvidia is the headline actor and a new AI chip is a product_tech event, so it clears the category gate. But factLevel is forecast (a reported plan/intention, not a done deal), and the China-comeback storyline is well-worn and contingent on export-control approval. Tradeable but low materiality — a plan-stage headline on a priced-in theme."
+        },
+        "pricedIn": {
+          "status": "reverse",
+          "tEvalUtc": "2026-08-21T18:54:47.580Z",
+          "deltaTMinutes": 1556.6263333333334,
+          "realizedExcessPct": -1.2377563957456847,
+          "volumeZ": null,
+          "dataBasis": "hl_perp",
+          "sessionBucket": "rth",
+          "benchmarkUsed": "XYZ100",
+          "betaUsed": 1.2546653553875757,
+          "confidence": "high",
+          "note": "realized -1.24% vs band-mid 1.3% (expected-by-now 1.25% at Δt=1557min; volume baseline too young)"
+        },
+        "createdAtUtc": "2026-08-21T18:54:49.573Z",
+        "title": "Nvidia Plots China Comeback With New AI Chip",
+        "followUp24h": {
+          "realizedExcessPct": -1.1053886951074812,
+          "directionHit": false,
+          "computedAtUtc": "2026-08-21T19:55:15.989Z"
+        }
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "sitemap:https://www.theinformation.com/newsletters/ai-agenda/robots-gpt-2-era",
+        "title": "Robots Are in Their GPT-2 Era",
+        "publishedUtc": "2026-08-20T14:00:39.000Z",
+        "kind": "article",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-21T18:53:26.481Z"
+      },
+      "signal": {
+        "id": "sig-e539dd1b780ff3b4-mt3b5v2o",
+        "newsId": "sitemap:https://www.theinformation.com/newsletters/ai-agenda/robots-gpt-2-era",
+        "fingerprint": "e539dd1b780ff3b4",
+        "firstSeenUtc": "2026-08-20T14:00:39.000Z",
+        "firstSeenBasis": "The Information item — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 10,
+          "eventType": "other",
+          "factLevel": "fact",
+          "tickers": [],
+          "surpriseNote": "rules fallback: no consensus comparison performed",
+          "reason": "no universe ticker matched"
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-21T18:54:05.712Z",
+        "followUp24h": {
+          "realizedExcessPct": null,
+          "directionHit": null,
+          "computedAtUtc": "2026-08-21T19:55:15.989Z"
+        }
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "sitemap:https://www.theinformation.com/articles/anthropics-enterprise-ai-venture-buys-consultancy",
+        "title": "Anthropic’s Enterprise AI Venture Buys Consultancy",
+        "publishedUtc": "2026-08-20T13:00:42.000Z",
+        "kind": "article",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-21T18:53:26.481Z"
+      },
+      "signal": {
+        "id": "sig-e539dd1b780ff3b4-mt3b5v2n",
+        "newsId": "sitemap:https://www.theinformation.com/articles/anthropics-enterprise-ai-venture-buys-consultancy",
+        "fingerprint": "e539dd1b780ff3b4",
+        "firstSeenUtc": "2026-08-20T13:00:42.000Z",
+        "firstSeenBasis": "The Information item — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 10,
+          "eventType": "other",
+          "factLevel": "fact",
+          "tickers": [],
+          "surpriseNote": "rules fallback: no consensus comparison performed",
+          "reason": "no universe ticker matched"
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-21T18:54:05.711Z",
+        "followUp24h": {
+          "realizedExcessPct": null,
+          "directionHit": null,
+          "computedAtUtc": "2026-08-21T19:55:15.989Z"
+        }
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "sitemap:https://www.theinformation.com/newsletters/the-briefing/stripe-takes-openrouter",
+        "title": "Stripe Takes OpenRouter",
+        "publishedUtc": "2026-08-20T00:00:42.000Z",
+        "kind": "article",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-21T18:53:26.480Z"
+      },
+      "signal": {
+        "id": "sig-e539dd1b780ff3b4-mt3b5v2m",
+        "newsId": "sitemap:https://www.theinformation.com/newsletters/the-briefing/stripe-takes-openrouter",
+        "fingerprint": "e539dd1b780ff3b4",
+        "firstSeenUtc": "2026-08-20T00:00:42.000Z",
+        "firstSeenBasis": "The Information item — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 10,
+          "eventType": "other",
+          "factLevel": "fact",
+          "tickers": [],
+          "surpriseNote": "rules fallback: no consensus comparison performed",
+          "reason": "no universe ticker matched"
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-21T18:54:05.710Z",
+        "followUp24h": {
+          "realizedExcessPct": null,
+          "directionHit": null,
+          "computedAtUtc": "2026-08-21T19:55:15.989Z"
+        }
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "sitemap:https://www.theinformation.com/newsletters/the-electric/enovix-next-gen-batteries-terrific-obsolete",
+        "title": "Enovix Next-Gen Batteries Are Terrific. Are They Also Obsolete?",
+        "publishedUtc": "2026-08-19T19:01:05.000Z",
+        "kind": "article",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-21T18:53:26.480Z"
+      },
+      "signal": {
+        "id": "sig-e539dd1b780ff3b4-mt3b5v2k",
+        "newsId": "sitemap:https://www.theinformation.com/newsletters/the-electric/enovix-next-gen-batteries-terrific-obsolete",
+        "fingerprint": "e539dd1b780ff3b4",
+        "firstSeenUtc": "2026-08-19T19:01:05.000Z",
+        "firstSeenBasis": "The Information item — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 10,
+          "eventType": "other",
+          "factLevel": "fact",
+          "tickers": [],
+          "surpriseNote": "rules fallback: no consensus comparison performed",
+          "reason": "no universe ticker matched"
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-21T18:54:05.708Z",
+        "followUp24h": {
+          "realizedExcessPct": null,
+          "directionHit": null,
+          "computedAtUtc": "2026-08-21T19:55:15.989Z"
+        }
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "sitemap:https://www.theinformation.com/briefings/openai-integrates-chatgpt-apple-messages-mac",
+        "title": "OpenAI Integrates ChatGPT into Apple Messages on Mac",
+        "publishedUtc": "2026-08-21T17:55:36.000Z",
+        "kind": "briefing",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-21T18:53:26.480Z"
+      },
+      "signal": {
+        "id": "sig-8ddd7a90e22f9076-mt3b5v2g",
+        "newsId": "sitemap:https://www.theinformation.com/briefings/openai-integrates-chatgpt-apple-messages-mac",
+        "fingerprint": "8ddd7a90e22f9076",
+        "firstSeenUtc": "2026-08-21T17:55:36.000Z",
+        "firstSeenBasis": "The Information item — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "mixed",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 12,
+          "eventType": "product_tech",
+          "factLevel": "fact",
+          "tickers": [],
+          "surpriseNote": "baseline missing. Extends the already-known Apple–OpenAI/ChatGPT partnership (Apple Intelligence) to Mac Messages — an incremental feature rollout, not new strategic ground. Low novelty.",
+          "reason": "Headline actor is OpenAI (a private company, not in the universe); Apple/Messages is the passive integration surface, not the initiating actor. A single client-app integration feature is immaterial to AAPL fundamentals and carries no meaningful surprise beyond the existing partnership, so no tradeable AAPL edge. No universe symbol is a headline actor."
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-21T18:54:05.704Z"
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "sitemap:https://www.theinformation.com/briefings/dragoneer-founder-stad-buy-timberwolves-controlling-stake",
+        "title": "Dragoneer Founder Stad to Buy Timberwolves Controlling Stake",
+        "publishedUtc": "2026-08-21T17:48:10.000Z",
+        "kind": "briefing",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-21T18:53:26.480Z"
+      },
+      "signal": {
+        "id": "sig-d2469b7d3604b546-mt3b50t6",
+        "newsId": "sitemap:https://www.theinformation.com/briefings/dragoneer-founder-stad-buy-timberwolves-controlling-stake",
+        "fingerprint": "d2469b7d3604b546",
+        "firstSeenUtc": "2026-08-21T17:48:10.000Z",
+        "firstSeenBasis": "The Information item — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 10,
+          "eventType": "mna",
+          "factLevel": "fact",
+          "tickers": [],
+          "surpriseNote": "rules fallback: no consensus comparison performed",
+          "reason": "no universe ticker matched"
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-21T18:53:26.490Z"
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "sitemap:https://www.theinformation.com/briefings/nvidia-reportedly-pay-6-billion-licensing-hiring-deal-ai-model-startup-poolside",
+        "title": "Nvidia to Reportedly Pay $6 Billion in Licensing and Hiring Deal with AI Model Startup Poolside",
+        "publishedUtc": "2026-08-20T20:35:30.000Z",
+        "kind": "briefing",
+        "prefix": "reportedly",
+        "seenAtUtc": "2026-08-21T18:53:26.479Z"
+      },
+      "signal": {
+        "id": "sig-aad9073003a3cbfe-mt3b698b",
+        "newsId": "sitemap:https://www.theinformation.com/briefings/nvidia-reportedly-pay-6-billion-licensing-hiring-deal-ai-model-startup-poolside",
+        "fingerprint": "aad9073003a3cbfe",
+        "firstSeenUtc": null,
+        "firstSeenBasis": "aggregated report ('Reportedly'): original ran earlier elsewhere; t0 uses published as an upper bound (Phase 0 simplification — online first-seen verification arrives with the claude-cli engine)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 27,
+          "eventType": "mna",
+          "factLevel": "fact",
+          "tickers": [
+            "NVDA"
+          ],
+          "surpriseNote": "Baseline missing → judged conservatively. Never scoring the raw $6B: relative to NVDA's ~$4T market cap it is ~0.15%, immaterial to earnings/cash. Structure is a reverse-acquihire (licensing + hiring, not an equity acquisition), and it is unconfirmed ('reportedly'/The Information briefing). Novelty is modest — Nvidia deepening into AI-model talent/IP fits its known ecosystem-investment pattern, not a surprise on strategy.",
+          "reason": "NVDA is the headline actor (the payer), so it qualifies on category (mna-style strategic transaction) and factLevel (reported deal terms = fact, though hedged 'reportedly'). But materiality fails: a $6B acquihire is a rounding error for a ~$4T company, and the excess move it could justify sits at the low end of the small band. Not material enough to trade on alone; Poolside is private and not in the universe."
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-21T18:54:24.060Z"
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "sitemap:https://www.theinformation.com/briefings/walmarts-u-s-sales-slowdown-sends-stock-tumbling-9",
+        "title": "Walmart’s U.S. Sales Slowdown Sends Stock Tumbling 9%",
+        "publishedUtc": "2026-08-20T18:15:47.000Z",
+        "kind": "briefing",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-21T18:53:26.479Z"
+      },
+      "signal": {
+        "id": "sig-6dfe46508302b1ea-mt3b50t4",
+        "newsId": "sitemap:https://www.theinformation.com/briefings/walmarts-u-s-sales-slowdown-sends-stock-tumbling-9",
+        "fingerprint": "6dfe46508302b1ea",
+        "firstSeenUtc": "2026-08-20T18:15:47.000Z",
+        "firstSeenBasis": "The Information item — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 10,
+          "eventType": "other",
+          "factLevel": "fact",
+          "tickers": [],
+          "surpriseNote": "rules fallback: no consensus comparison performed",
+          "reason": "no universe ticker matched"
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-21T18:53:26.488Z",
+        "followUp24h": {
+          "realizedExcessPct": null,
+          "directionHit": null,
+          "computedAtUtc": "2026-08-21T19:55:15.989Z"
+        }
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "sitemap:https://www.theinformation.com/briefings/alibaba-ceo-expects-ai-related-arr-reach-10-billion-september",
+        "title": "Alibaba CEO Expects AI-Related ARR to Reach $10 Billion by September",
+        "publishedUtc": "2026-08-20T13:54:11.000Z",
+        "kind": "briefing",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-21T18:53:26.479Z"
+      },
+      "signal": {
+        "id": "sig-934643caf01b320f-mt3b50t4",
+        "newsId": "sitemap:https://www.theinformation.com/briefings/alibaba-ceo-expects-ai-related-arr-reach-10-billion-september",
+        "fingerprint": "934643caf01b320f",
+        "firstSeenUtc": "2026-08-20T13:54:11.000Z",
+        "firstSeenBasis": "The Information item — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 10,
+          "eventType": "management",
+          "factLevel": "fact",
+          "tickers": [],
+          "surpriseNote": "rules fallback: no consensus comparison performed",
+          "reason": "no universe ticker matched"
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-21T18:53:26.488Z",
+        "followUp24h": {
+          "realizedExcessPct": null,
+          "directionHit": null,
+          "computedAtUtc": "2026-08-21T19:55:15.989Z"
+        }
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "sitemap:https://www.theinformation.com/briefings/exclusive-ubs-hires-jp-morgan-banker-su-ramp-ai-banking-efforts",
+        "title": "Exclusive: UBS Hires JP Morgan Banker Su to Ramp Up AI Banking Efforts",
+        "publishedUtc": "2026-08-20T13:05:42.000Z",
+        "kind": "briefing",
+        "prefix": "exclusive",
+        "seenAtUtc": "2026-08-21T18:53:26.479Z"
+      },
+      "signal": {
+        "id": "sig-e539dd1b780ff3b4-mt3b50t3",
+        "newsId": "sitemap:https://www.theinformation.com/briefings/exclusive-ubs-hires-jp-morgan-banker-su-ramp-ai-banking-efforts",
+        "fingerprint": "e539dd1b780ff3b4",
+        "firstSeenUtc": "2026-08-20T13:05:42.000Z",
+        "firstSeenBasis": "The Information exclusive — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 10,
+          "eventType": "other",
+          "factLevel": "fact",
+          "tickers": [],
+          "surpriseNote": "rules fallback: no consensus comparison performed",
+          "reason": "no universe ticker matched"
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-21T18:53:26.487Z",
+        "followUp24h": {
+          "realizedExcessPct": null,
+          "directionHit": null,
+          "computedAtUtc": "2026-08-21T19:55:15.989Z"
+        }
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    },
+    {
+      "news": {
+        "newsId": "sitemap:https://www.theinformation.com/briefings/veteran-barclays-semiconductor-banker-tim-luke-join-morgan-stanley",
+        "title": "Veteran Barclays Semiconductor Banker Tim Luke to Join Morgan Stanley",
+        "publishedUtc": "2026-08-20T01:56:01.000Z",
+        "kind": "briefing",
+        "prefix": "none",
+        "seenAtUtc": "2026-08-21T18:53:26.478Z"
+      },
+      "signal": {
+        "id": "sig-e539dd1b780ff3b4-mt3b50t2",
+        "newsId": "sitemap:https://www.theinformation.com/briefings/veteran-barclays-semiconductor-banker-tim-luke-join-morgan-stanley",
+        "fingerprint": "e539dd1b780ff3b4",
+        "firstSeenUtc": "2026-08-20T01:56:01.000Z",
+        "firstSeenBasis": "The Information item — published timestamp equals first public appearance (feed <published> verified against sitemap publication_date)",
+        "expectedDirection": "bullish",
+        "coarseImpactBand": "small",
+        "consensusBaselineAsOf": null,
+        "materiality": {
+          "tradeable": false,
+          "score": 10,
+          "eventType": "other",
+          "factLevel": "fact",
+          "tickers": [],
+          "surpriseNote": "rules fallback: no consensus comparison performed",
+          "reason": "no universe ticker matched"
+        },
+        "pricedIn": null,
+        "createdAtUtc": "2026-08-21T18:53:26.486Z",
+        "followUp24h": {
+          "realizedExcessPct": null,
+          "directionHit": null,
+          "computedAtUtc": "2026-08-21T19:55:15.989Z"
+        }
+      },
+      "thesis": null,
+      "decision": null,
+      "execution": null,
+      "positionNow": null,
+      "postEvents": []
+    }
+  ]
+}

--- a/apps/web/lib/live-delta-pm/labels.ts
+++ b/apps/web/lib/live-delta-pm/labels.ts
@@ -1,0 +1,207 @@
+// Chinese labels + number formatters for the Delta PM audit page. Every enum
+// keeps its raw value visible in the UI (small mono next to the translated
+// label) so a reviewer can line the page up against the raw ledger; the maps
+// here fall back to the raw string for unknown values instead of hiding them.
+
+const pick = (map: Record<string, string>, raw: string): string => map[raw] ?? raw;
+
+export const zhKind = (raw: string): string =>
+  pick({ article: "文章", briefing: "简报", manual: "手工录入" }, raw);
+
+export const zhPrefix = (raw: string): string =>
+  pick(
+    {
+      exclusive: "独家（本刊首发，t0=发布时刻）",
+      reportedly: "转述（转引他家报道，须核实真实首见时间）",
+      none: "常规"
+    },
+    raw
+  );
+
+export const zhEventType = (raw: string): string =>
+  pick(
+    {
+      earnings_guidance: "业绩/指引",
+      order_contract: "订单/合同",
+      mna: "并购",
+      product_tech: "产品/技术",
+      regulatory_legal: "监管/法律",
+      management: "管理层",
+      supply_chain: "供应链",
+      macro_direct: "宏观直接",
+      other: "其他"
+    },
+    raw
+  );
+
+export const zhFactLevel = (raw: string): string =>
+  pick({ fact: "事实", forecast: "预测", opinion: "观点" }, raw);
+
+export const zhNewsDirection = (raw: string): string =>
+  pick({ bullish: "利多", bearish: "利空", mixed: "多空混合" }, raw);
+
+export const zhTradeDirection = (raw: string): string => pick({ long: "做多", short: "做空" }, raw);
+
+export const zhImpactBand = (raw: string): string =>
+  pick({ small: "小（0.5–2%）", medium: "中（2–6%）", large: "大（6–20%）" }, raw);
+
+export const zhPricedIn = (raw: string): string =>
+  pick(
+    {
+      none: "未定价",
+      partial: "部分定价",
+      full: "已定价",
+      leaked: "疑似泄露",
+      reverse: "反向",
+      awaiting_market: "待行情"
+    },
+    raw
+  );
+
+/** Tone class key for the six priced-in states (report.module.css chip colors). */
+const PRICED_IN_TONES: Record<string, string> = {
+  none: "pinNone",
+  partial: "pinPartial",
+  full: "pinFull",
+  leaked: "pinLeaked",
+  reverse: "pinReverse",
+  awaiting_market: "pinAwait"
+};
+
+export const pricedInTone = (raw: string): string => PRICED_IN_TONES[raw] ?? "pinOther";
+
+export const zhSession = (raw: string): string =>
+  pick({ rth: "常规交易时段", offhours: "盘前/盘后", weekend: "周末" }, raw);
+
+export const zhConfidence = (raw: string): string => pick({ high: "高", medium: "中", low: "低" }, raw);
+
+export const zhContamination = (raw: string): string =>
+  pick({ none: "无污染", soft: "轻度污染", hard: "重度污染" }, raw);
+
+export const zhAction = (raw: string): string =>
+  pick({ open: "开仓", add: "加仓", trim: "减仓", close: "平仓", flip: "反手", no_trade: "不开仓" }, raw);
+
+export const zhBenchmark = (raw: string): string => pick({ none: "无基准（原始反应）" }, raw);
+
+export const zhProvider = (raw: string): string =>
+  pick({ rules: "规则回退（非分析引擎）", "claude-cli": "Claude CLI", deepseek: "DeepSeek" }, raw);
+
+export const zhCredibility = (raw: string): string =>
+  pick({ high: "可信度高", medium: "可信度中", low: "可信度低" }, raw);
+
+export const zhPostEvent = (raw: string): string =>
+  pick(
+    {
+      stop_loss: "止损触发",
+      hard_floor_stop: "硬性红线止损（−20%）",
+      paper_close: "模拟平仓",
+      paper_open: "模拟开仓",
+      halt: "账本熔断",
+      resume: "恢复"
+    },
+    raw
+  );
+
+export const zhGuard = (raw: string): string => {
+  const fixed: Record<string, string> = {
+    tier1_cap: "一档流动性上限",
+    tier2_cap: "二档流动性上限",
+    tier3_cap: "三档流动性上限",
+    gross_cap: "总敞口上限",
+    net_cap: "净敞口上限",
+    isolated_margin_cap: "逐仓保证金上限"
+  };
+  if (fixed[raw]) return fixed[raw];
+  if (raw.startsWith("cluster_cap:")) return `关联簇上限（${raw.slice("cluster_cap:".length)}）`;
+  return raw;
+};
+
+// ---------------------------------------------------------------------------
+// Number formatting. Two percent conventions coexist in the ledger:
+//  - percent-unit fields (5.9 => "5.90%"): edge/threshold/fairImpact/realizedExcess
+//  - fraction fields (0.01 => "1.00%"): riskBudgetPct/stopDistPct/dailyVolPct/funding
+// fmtPct handles the former; fmtFracPct multiplies by 100 first.
+
+const usd2 = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2
+});
+
+export function fmtUsd(value: number | null): string {
+  return value === null ? "—" : usd2.format(value);
+}
+
+export function fmtSignedUsd(value: number | null): string {
+  if (value === null) return "—";
+  const sign = value > 0 ? "+" : value < 0 ? "-" : "±";
+  return `${sign}${usd2.format(Math.abs(value))}`;
+}
+
+/** Percent-unit input: 5.9 => "5.90%". Tiny non-zero values keep 2 significant digits. */
+export function fmtPct(value: number | null, opts?: { signed?: boolean }): string {
+  if (value === null) return "—";
+  const abs = Math.abs(value);
+  const body = abs === 0 ? "0.00" : abs < 0.005 ? abs.toPrecision(2) : abs.toFixed(2);
+  const sign = opts?.signed ? (value > 0 ? "+" : value < 0 ? "-" : "±") : value < 0 ? "-" : "";
+  return `${sign}${body}%`;
+}
+
+/** Fraction input: 0.0055 => "0.55%". */
+export function fmtFracPct(value: number | null, opts?: { signed?: boolean }): string {
+  return value === null ? "—" : fmtPct(value * 100, opts);
+}
+
+export function fmtPx(value: number | null): string {
+  if (value === null) return "—";
+  const digits = Math.abs(value) >= 1 ? 2 : 4;
+  return value.toLocaleString("en-US", { minimumFractionDigits: digits, maximumFractionDigits: digits });
+}
+
+export function fmtQty(value: number | null): string {
+  if (value === null) return "—";
+  return value.toLocaleString("en-US", { maximumFractionDigits: 4 });
+}
+
+export function fmtX(value: number | null): string {
+  return value === null ? "—" : `${value.toFixed(2)}×`;
+}
+
+export function fmtBeta(value: number | null): string {
+  return value === null ? "—" : value.toFixed(2);
+}
+
+export function fmtInt(value: number | null): string {
+  return value === null ? "—" : value.toLocaleString("en-US");
+}
+
+export function fmtUtc(iso: string | null): string {
+  if (!iso || iso.length < 16 || !Number.isFinite(Date.parse(iso))) return iso && iso.length > 0 ? iso : "—";
+  return `${iso.slice(0, 10)} ${iso.slice(11, 16)} UTC`;
+}
+
+/** Minute count for Δt displays: 43.2 => "43.2 分钟", 1500 => "25.0 小时". */
+export function fmtMinutes(mins: number | null): string {
+  if (mins === null) return "—";
+  if (mins < 1) return `${(mins * 60).toFixed(0)} 秒`;
+  if (mins < 120) return `${mins.toFixed(1)} 分钟`;
+  if (mins < 48 * 60) return `${(mins / 60).toFixed(1)} 小时`;
+  return `${(mins / 1440).toFixed(1)} 天`;
+}
+
+export function fmtHours(hours: number | null): string {
+  if (hours === null) return "—";
+  if (hours < 48) return `${hours} 小时`;
+  const days = hours / 24;
+  return `${hours} 小时（≈ ${Number.isInteger(days) ? days : days.toFixed(1)} 天）`;
+}
+
+/** Minutes between two ISO timestamps (b − a); null when either is invalid. */
+export function minutesBetween(a: string | null, b: string | null): number | null {
+  if (!a || !b) return null;
+  const ta = Date.parse(a);
+  const tb = Date.parse(b);
+  if (!Number.isFinite(ta) || !Number.isFinite(tb)) return null;
+  return (tb - ta) / 60_000;
+}

--- a/apps/web/lib/live-delta-pm/live.ts
+++ b/apps/web/lib/live-delta-pm/live.ts
@@ -1,0 +1,85 @@
+// Live data path for /live-delta-pm: server-side fetch of the Tokyo VM's
+// /delta-pm/audit feed (the shadow-trading decision chain, newest 30 cases).
+// Any failure — network, timeout, auth, shape drift — returns null and the
+// caller falls back to the baked fixture, so the page never breaks when the
+// VM is unreachable. The page banner names which source rendered.
+
+import { parseAuditPayload, type AuditPayload } from "./decode";
+import fixtureJson from "./fixture.json";
+
+const DEFAULT_UPSTREAM = "http://34.85.97.32:8787";
+const AUDIT_LIMIT = 30;
+const FETCH_TIMEOUT_MS = 5000;
+// Warm-instance memos: the success TTL keeps repeat views off the VM (the
+// footer documents the 60s cache), and the failure backoff stops every view
+// from paying the full timeout while the VM is down (deploys, instance stop —
+// SYNs are silently dropped there).
+const SUCCESS_TTL_MS = 60_000;
+const FAILURE_BACKOFF_MS = 30_000;
+
+function upstreamUrl(): string {
+  const base = process.env.DELTA_PM_AUDIT_UPSTREAM?.trim() || DEFAULT_UPSTREAM;
+  return `${base.replace(/\/+$/, "")}/delta-pm/audit?limit=${AUDIT_LIMIT}`;
+}
+
+function upstreamToken(): string {
+  // The page's own invite code doubles as the API credential (the endpoint
+  // accepts it alongside the main API token, same as /paper/snapshot) — no
+  // extra secret to provision. SECURITY: this header crosses the public
+  // internet as plain HTTP (bare-IP VM, no TLS yet). NEVER configure the real
+  // FORECAST_API_TOKEN / RAVEN_ACCESS_TOKEN in this slot — the invite code is
+  // the only credential that may travel this wire until the VM endpoint is
+  // fronted by TLS.
+  return process.env.LIVE_DELTA_PM_UPSTREAM_TOKEN?.trim() || "raven-labs";
+}
+
+let bakedMemo: AuditPayload | null = null;
+
+/** The checked-in fixture (real run data), decoded once per process. */
+export function bakedAuditPayload(): AuditPayload {
+  if (!bakedMemo) {
+    const parsed = parseAuditPayload(fixtureJson);
+    if (!parsed) {
+      // The fixture is checked in next to this file; failing to decode it is a
+      // build defect, not a runtime condition — fail loudly.
+      throw new Error("live-delta-pm fixture.json does not decode");
+    }
+    bakedMemo = parsed;
+  }
+  return bakedMemo;
+}
+
+let successMemo: { at: number; payload: AuditPayload } | null = null;
+let lastFailureAt = 0;
+
+/**
+ * Fetch + decode the live audit feed. Returns null on any failure (caller
+ * falls back to the baked fixture). LIVE_DELTA_PM_MOCK=1 short-circuits to
+ * null so local dev renders the fixture deterministically.
+ */
+export async function fetchLiveAudit(nowMs: number = Date.now()): Promise<AuditPayload | null> {
+  if (process.env.LIVE_DELTA_PM_MOCK === "1") return null;
+  if (successMemo && nowMs - successMemo.at < SUCCESS_TTL_MS) return successMemo.payload;
+  if (nowMs - lastFailureAt < FAILURE_BACKOFF_MS) return null;
+  try {
+    const res = await fetch(upstreamUrl(), {
+      headers: { authorization: `Bearer ${upstreamToken()}` },
+      cache: "no-store",
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
+    });
+    if (!res.ok) {
+      lastFailureAt = nowMs;
+      return null;
+    }
+    const payload = parseAuditPayload(await res.json());
+    if (payload) {
+      successMemo = { at: nowMs, payload };
+    } else {
+      lastFailureAt = nowMs;
+    }
+    return payload;
+  } catch {
+    lastFailureAt = nowMs;
+    return null;
+  }
+}

--- a/packages/delta-pm-contracts/src/index.ts
+++ b/packages/delta-pm-contracts/src/index.ts
@@ -171,6 +171,68 @@ export type TradeThesis = z.infer<typeof tradeThesisSchema>;
 
 export const PM_ACTIONS = ["open", "add", "trim", "close", "flip", "no_trade"] as const;
 
+// Full decision arithmetic for human audit (the hedge-fund IC-memo view):
+// every number that produced the decision, itemized — never just a verdict.
+export const decisionAuditSchema = z.object({
+  vetoedBy: z.string().nullable(), // pre-arithmetic veto (halted/cooldown/earnings/...), null when arithmetic ran
+  edge: z
+    .object({
+      conservativePct: z.number(), // fairImpact conservative end
+      pointPct: z.number(),
+      realizedPct: z.number(), // excess realized since t0 at decision time
+      residualPct: z.number() // conservative − realized, signed toward trade direction
+    })
+    .nullable(),
+  threshold: z
+    .object({
+      takerFeePct: z.number(),
+      slippagePct: z.number(),
+      fundingPct: z.number(), // signed holding-period funding cost (floored at 0)
+      roundTripPct: z.number(),
+      costFloorPct: z.number(), // entryCostMultiple × roundTrip
+      volFloorPct: z.number(), // entryVolFraction × dailyVol × holdFactor
+      thresholdPct: z.number() // max(costFloor, volFloor)
+    })
+    .nullable(),
+  stopMenu: z
+    .object({
+      atr20d: z.number(),
+      atrStopPx: z.number(),
+      swingPx: z.number().nullable(),
+      hardFloorPx: z.number(),
+      chosenPx: z.number(),
+      stopDistPct: z.number()
+    })
+    .nullable(),
+  sizing: z
+    .object({
+      equityUsd: z.number(),
+      riskBudgetPct: z.number(),
+      intendedNotionalUsd: z.number(),
+      guards: z.array(
+        z.object({
+          name: z.string(), // tier1_cap / gross_cap / net_cap / cluster_cap:<tag> / isolated_margin_cap
+          capUsd: z.number(),
+          notionalAfterUsd: z.number(),
+          clipped: z.boolean()
+        })
+      ),
+      finalNotionalUsd: z.number(),
+      leverage: z.object({ configCap: z.number(), volCap: z.number(), venueCap: z.number(), chosen: z.number() })
+    })
+    .nullable(),
+  marketView: z
+    .object({
+      markPx: z.number(),
+      dailyVolPct: z.number(),
+      maxDailyMovePct: z.number(),
+      fundingHourly: z.number().nullable(),
+      beta: z.number().nullable()
+    })
+    .nullable()
+});
+export type DecisionAudit = z.infer<typeof decisionAuditSchema>;
+
 export const pmDecisionSchema = z.object({
   id: z.string().min(1),
   thesisId: z.string().nullable(), // null for pure risk-driven exits (stop/floor)
@@ -197,6 +259,7 @@ export const pmDecisionSchema = z.object({
   bindingConstraint: z.string().nullable(), // which guard clipped the size
   residualEdgePct: z.number().nullable(),
   reason: z.string().min(1),
+  audit: decisionAuditSchema.nullable().default(null),
   createdAtUtc: z.string().datetime({ offset: true })
 });
 export type PMDecision = z.infer<typeof pmDecisionSchema>;

--- a/services/delta-pm/src/policy.test.ts
+++ b/services/delta-pm/src/policy.test.ts
@@ -117,6 +117,29 @@ describe("decideEntry", () => {
     const d = decideEntry(ctx({ thesis: thesis({ fairImpactPct: { min: 0.5, max: 2, point: 1 } }), view: view({ realizedExcessSinceT0Pct: 0.4 }) }));
     expect(d.action).toBe("no_trade");
     expect(d.reason).toContain("residual edge");
+    // Audit carries the full rejection arithmetic (IC-memo view).
+    expect(d.audit?.edge?.residualPct).toBeCloseTo(0.1, 5);
+    expect(d.audit?.threshold?.thresholdPct).toBeGreaterThan(0);
+    expect(d.audit?.threshold?.volFloorPct).toBeGreaterThan(d.audit!.threshold!.costFloorPct);
+  });
+
+  it("open decision carries the complete audit trail", () => {
+    const d = decideEntry(ctx());
+    expect(d.action).toBe("open");
+    const a = d.audit!;
+    expect(a.vetoedBy).toBeNull();
+    expect(a.edge!.conservativePct).toBe(3);
+    expect(a.stopMenu!.chosenPx).toBeCloseTo(192);
+    expect(a.stopMenu!.hardFloorPx).toBeCloseTo(160);
+    expect(a.sizing!.intendedNotionalUsd).toBe(2500);
+    expect(a.sizing!.guards.length).toBeGreaterThanOrEqual(4);
+    expect(a.sizing!.guards.every((g) => typeof g.capUsd === "number")).toBe(true);
+    expect(a.sizing!.leverage.chosen).toBeLessThanOrEqual(3);
+  });
+
+  it("vetoes are tagged in the audit", () => {
+    const d = decideEntry(ctx({ portfolio: portfolio({ halted: true, haltedReason: "x" }) }));
+    expect(d.audit?.vetoedBy).toBe("portfolio_halt");
   });
 
   it("adverse drift reclassifies instead of chasing inflated edge", () => {

--- a/services/delta-pm/src/policy.ts
+++ b/services/delta-pm/src/policy.ts
@@ -6,8 +6,24 @@
 // position; portfolio halt at −25% total loss from initial capital. Both are
 // enforced here and (the stop) mirrored venue-side in later phases.
 
-import type { PMDecision, Portfolio, Position, TradeThesis, UniverseEntry } from "@autopoly/delta-pm-contracts";
+import type { DecisionAudit, PMDecision, Portfolio, Position, TradeThesis, UniverseEntry } from "@autopoly/delta-pm-contracts";
 import { config } from "./config.js";
+
+// --- audit helpers: every decision carries its full arithmetic (IC-memo view)
+
+function auditMarketView(view: MarketView): NonNullable<DecisionAudit["marketView"]> {
+  return {
+    markPx: view.markPx,
+    dailyVolPct: view.dailyVolPct,
+    maxDailyMovePct: view.maxDailyMovePct,
+    fundingHourly: view.fundingHourly,
+    beta: view.beta
+  };
+}
+
+function vetoAudit(vetoedBy: string, view?: MarketView): DecisionAudit {
+  return { vetoedBy, edge: null, threshold: null, stopMenu: null, sizing: null, marketView: view ? auditMarketView(view) : null };
+}
 
 export interface MarketView {
   markPx: number;
@@ -53,8 +69,13 @@ function decisionBase(ctx: EntryContext, action: PMDecision["action"], reason: s
     bindingConstraint: null,
     residualEdgePct: null,
     reason,
+    audit: null,
     createdAtUtc: ctx.nowUtc
   };
+}
+
+function veto(ctx: EntryContext, reason: string, vetoedBy: string): PMDecision {
+  return { ...decisionBase(ctx, "no_trade", reason), audit: vetoAudit(vetoedBy, ctx.view) };
 }
 
 export function grossNotional(portfolio: Portfolio, marks: Map<string, number>): number {
@@ -85,21 +106,22 @@ export function decideEntry(ctx: EntryContext): PMDecision {
   const dirSign = thesis.direction === "long" ? 1 : -1;
 
   // Ordered vetoes — cheapest and most absolute first.
-  if (portfolio.halted) return decisionBase(ctx, "no_trade", `portfolio halted: ${portfolio.haltedReason ?? "unknown"}`);
-  if (thesis.contamination === "hard") return decisionBase(ctx, "no_trade", "thesis hard-contaminated by price reaction — analyst must re-run blind");
-  if (ctx.dayPnlPct <= -config.dailyLossStopPct) return decisionBase(ctx, "no_trade", `daily loss stop: day PnL ${(ctx.dayPnlPct * 100).toFixed(1)}% ≤ −${config.dailyLossStopPct * 100}%`);
+  if (portfolio.halted) return veto(ctx, `portfolio halted: ${portfolio.haltedReason ?? "unknown"}`, "portfolio_halt");
+  if (thesis.contamination === "hard") return veto(ctx, "thesis hard-contaminated by price reaction — analyst must re-run blind", "contamination_hard");
+  if (ctx.dayPnlPct <= -config.dailyLossStopPct)
+    return veto(ctx, `daily loss stop: day PnL ${(ctx.dayPnlPct * 100).toFixed(1)}% ≤ −${config.dailyLossStopPct * 100}%`, "daily_loss_stop");
 
   const existing = portfolio.positions.find((p) => p.ticker === thesis.ticker);
   if (existing) {
     if (existing.direction !== thesis.direction) {
-      return decisionBase(ctx, "no_trade", "conflicting direction vs open position — one net position per ticker; flip requires explicit review, not auto-entry");
+      return veto(ctx, "conflicting direction vs open position — one net position per ticker; flip requires explicit review, not auto-entry", "position_conflict");
     }
-    return decisionBase(ctx, "no_trade", "position already open in this direction (adds not enabled in V1)");
+    return veto(ctx, "position already open in this direction (adds not enabled in V1)", "position_exists");
   }
 
   const lastStop = portfolio.lastStopOutUtc[`${thesis.ticker}:${thesis.direction}`];
   if (lastStop && Date.parse(ctx.nowUtc) - Date.parse(lastStop) < config.cooldownHours * 3600_000) {
-    return decisionBase(ctx, "no_trade", `cooldown: stopped out same ticker+direction ${lastStop}, ${config.cooldownHours}h lockout`);
+    return veto(ctx, `cooldown: stopped out same ticker+direction ${lastStop}, ${config.cooldownHours}h lockout`, "cooldown");
   }
 
   // Earnings-calendar guard: never hold a fresh event trade into the name's
@@ -107,7 +129,7 @@ export function decideEntry(ctx: EntryContext): PMDecision {
   // so the guard is absolute; ops maintains nextEarningsUtc).
   const horizonUtc = new Date(Date.parse(ctx.nowUtc) + thesis.horizonHours * 3600_000).toISOString();
   if (entry.nextEarningsUtc && entry.nextEarningsUtc > ctx.nowUtc && entry.nextEarningsUtc < horizonUtc) {
-    return decisionBase(ctx, "no_trade", `scheduled earnings ${entry.nextEarningsUtc} inside horizon — event-gap risk exceeds the risk budget`);
+    return veto(ctx, `scheduled earnings ${entry.nextEarningsUtc} inside horizon — event-gap risk exceeds the risk budget`, "earnings_calendar");
   }
 
   // Residual edge on the CONSERVATIVE end of the fair-impact interval.
@@ -119,7 +141,7 @@ export function decideEntry(ctx: EntryContext): PMDecision {
   // Adverse-drift guard: market moving against the thesis inflates the naive
   // residual — that is disagreement, not opportunity.
   if (realizedPct * dirSign < -config.adverseDriftVolFraction * view.dailyVolPct * 100) {
-    return decisionBase(ctx, "no_trade", `adverse drift: market moved ${realizedPct.toFixed(2)}% against the thesis since t0 — reclassify, don't chase`);
+    return veto(ctx, `adverse drift: market moved ${realizedPct.toFixed(2)}% against the thesis since t0 — reclassify, don't chase`, "adverse_drift");
   }
 
   const holdDays = thesis.horizonHours / 24;
@@ -129,14 +151,36 @@ export function decideEntry(ctx: EntryContext): PMDecision {
   const fundingCostPct = Math.max(0, hourlyFunding * dirSign * thesis.horizonHours * 100);
   const slippagePct = config.slippageBudgetPctByTier[entry.liquidityTier] * 100;
   const roundTripPct = 2 * config.takerFeeRate * 100 + 2 * slippagePct + fundingCostPct;
-  const threshold = Math.max(config.entryCostMultiple * roundTripPct, config.entryVolFraction * view.dailyVolPct * 100 * Math.min(1, holdDays));
+  const costFloorPct = config.entryCostMultiple * roundTripPct;
+  const volFloorPct = config.entryVolFraction * view.dailyVolPct * 100 * Math.min(1, holdDays);
+  const threshold = Math.max(costFloorPct, volFloorPct);
+
+  const auditEdge: NonNullable<DecisionAudit["edge"]> = {
+    conservativePct,
+    pointPct: thesis.fairImpactPct.point,
+    realizedPct,
+    residualPct: residualSigned
+  };
+  const auditThreshold: NonNullable<DecisionAudit["threshold"]> = {
+    takerFeePct: config.takerFeeRate * 100,
+    slippagePct,
+    fundingPct: fundingCostPct,
+    roundTripPct,
+    costFloorPct,
+    volFloorPct,
+    thresholdPct: threshold
+  };
 
   if (residualSigned < threshold) {
-    return decisionBase(
-      ctx,
-      "no_trade",
-      `residual edge ${residualSigned.toFixed(2)}% below threshold ${threshold.toFixed(2)}% (conservative ${conservativePct}%, realized ${realizedPct.toFixed(2)}%)`
-    );
+    return {
+      ...decisionBase(
+        ctx,
+        "no_trade",
+        `residual edge ${residualSigned.toFixed(2)}% below threshold ${threshold.toFixed(2)}% (conservative ${conservativePct}%, realized ${realizedPct.toFixed(2)}%)`
+      ),
+      residualEdgePct: residualSigned,
+      audit: { vetoedBy: null, edge: auditEdge, threshold: auditThreshold, stopMenu: null, sizing: null, marketView: auditMarketView(view) }
+    };
   }
 
   // --- stop menu (deterministic, replayable) ---
@@ -147,21 +191,37 @@ export function decideEntry(ctx: EntryContext): PMDecision {
       ? Math.max(mark - 1.5 * atr, view.swingLowPx ?? 0)
       : Math.min(mark + 1.5 * atr, view.swingHighPx ?? Infinity);
   const hardFloorPx = mark * (1 - dirSign * config.hardStopAdversePct);
+  const atrStopPx = thesis.direction === "long" ? mark - 1.5 * atr : mark + 1.5 * atr;
   // Stop can never be looser than the user's −20% hard floor.
   stopPx = thesis.direction === "long" ? Math.max(stopPx, hardFloorPx) : Math.min(stopPx, hardFloorPx);
   const stopDistPct = Math.abs(mark - stopPx) / mark;
-  if (stopDistPct < 0.003) return decisionBase(ctx, "no_trade", "stop distance under 0.3% — structure too tight to size sanely");
+  const auditStopMenu: NonNullable<DecisionAudit["stopMenu"]> = {
+    atr20d: round(atr),
+    atrStopPx: round(atrStopPx),
+    swingPx: thesis.direction === "long" ? view.swingLowPx : view.swingHighPx,
+    hardFloorPx: round(hardFloorPx),
+    chosenPx: round(stopPx),
+    stopDistPct
+  };
+  if (stopDistPct < 0.003)
+    return {
+      ...decisionBase(ctx, "no_trade", "stop distance under 0.3% — structure too tight to size sanely"),
+      audit: { vetoedBy: "stop_too_tight", edge: auditEdge, threshold: auditThreshold, stopMenu: auditStopMenu, sizing: null, marketView: auditMarketView(view) }
+    };
 
   // --- sizing: fixed risk, then guard clipping (downward only) ---
   const riskBudget = thesis.confidence === "high" ? config.riskBudgetHighConfPct : config.riskBudgetPct;
   const intendedNotional = (equityUsd * riskBudget) / stopDistPct;
   let notional = intendedNotional;
   let binding: string | null = null;
+  const guardLog: NonNullable<DecisionAudit["sizing"]>["guards"] = [];
   const clip = (cap: number, label: string) => {
-    if (notional > cap) {
+    const clipped = notional > cap;
+    if (clipped) {
       notional = cap;
       binding = label;
     }
+    guardLog.push({ name: label, capUsd: Math.round(cap), notionalAfterUsd: Math.round(notional), clipped });
   };
 
   clip(equityUsd * config.tierCapPct[entry.liquidityTier], `tier${entry.liquidityTier}_cap`);
@@ -175,7 +235,8 @@ export function decideEntry(ctx: EntryContext): PMDecision {
     clip(Math.max(0, equityUsd * config.clusterCapPct - clusterGross), `cluster_cap:${tag}`);
   }
 
-  const leverage = Math.min(config.maxLeverage, 1 / (2 * view.maxDailyMovePct), entry.maxLeverageOnVenue);
+  const volLeverageCap = 1 / (2 * view.maxDailyMovePct);
+  const leverage = Math.min(config.maxLeverage, volLeverageCap, entry.maxLeverageOnVenue);
   if (entry.marginMode === "isolated") {
     const isolatedMarginUsed = portfolio.positions
       .filter((p) => p.leverage > 0)
@@ -184,8 +245,28 @@ export function decideEntry(ctx: EntryContext): PMDecision {
     clip(marginHeadroom * leverage, "isolated_margin_cap");
   }
 
+  const auditSizing: NonNullable<DecisionAudit["sizing"]> = {
+    equityUsd: Math.round(equityUsd),
+    riskBudgetPct: riskBudget,
+    intendedNotionalUsd: Math.round(intendedNotional),
+    guards: guardLog,
+    finalNotionalUsd: Math.floor(notional),
+    leverage: { configCap: config.maxLeverage, volCap: round(volLeverageCap), venueCap: entry.maxLeverageOnVenue, chosen: round(leverage) }
+  };
+  const fullAudit: DecisionAudit = {
+    vetoedBy: null,
+    edge: auditEdge,
+    threshold: auditThreshold,
+    stopMenu: auditStopMenu,
+    sizing: auditSizing,
+    marketView: auditMarketView(view)
+  };
+
   if (notional < config.minTradeUsd) {
-    return decisionBase(ctx, "no_trade", `clipped notional $${notional.toFixed(0)} below min trade $${config.minTradeUsd} (binding: ${binding ?? "risk_budget"})`);
+    return {
+      ...decisionBase(ctx, "no_trade", `clipped notional $${notional.toFixed(0)} below min trade $${config.minTradeUsd} (binding: ${binding ?? "risk_budget"})`),
+      audit: { ...fullAudit, vetoedBy: "below_min_trade" }
+    };
   }
 
   const realizedRiskPct = (notional * stopDistPct) / equityUsd;
@@ -213,7 +294,8 @@ export function decideEntry(ctx: EntryContext): PMDecision {
     residualEdgePct: residualSigned,
     reason:
       `open ${thesis.direction} ${thesis.ticker}: residual ${residualSigned.toFixed(2)}% ≥ threshold ${threshold.toFixed(2)}%; ` +
-      `risk ${(realizedRiskPct * 100).toFixed(2)}% (intended ${(riskBudget * 100).toFixed(1)}%${binding ? `, clipped by ${binding}` : ""})`
+      `risk ${(realizedRiskPct * 100).toFixed(2)}% (intended ${(riskBudget * 100).toFixed(1)}%${binding ? `, clipped by ${binding}` : ""})`,
+    audit: fullAudit
   };
 }
 

--- a/services/forecast-api/src/delta-pm-audit.test.ts
+++ b/services/forecast-api/src/delta-pm-audit.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, appendFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { buildDeltaPmAudit } from "./delta-pm-audit";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "dpm-audit-"));
+  mkdirSync(path.join(dir, "signals"), { recursive: true });
+  mkdirSync(path.join(dir, "theses"), { recursive: true });
+});
+
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+function ledger(event: Record<string, unknown>): void {
+  appendFileSync(path.join(dir, "ledger.jsonl"), JSON.stringify(event) + "\n");
+}
+
+describe("buildDeltaPmAudit", () => {
+  it("returns null when no ledger exists", () => {
+    expect(buildDeltaPmAudit(path.join(dir, "missing"))).toBeNull();
+  });
+
+  it("joins news → signal → thesis → decision → execution → position", () => {
+    ledger({ ts: "2026-08-22T10:00:00Z", type: "service_start" });
+    ledger({ ts: "2026-08-22T10:01:00Z", type: "news_seen", newsId: "n1", title: "SNDK wins contract", publishedUtc: "2026-08-22T09:55:00Z", kind: "manual", prefix: "none" });
+    writeFileSync(path.join(dir, "signals", "s1.json"), JSON.stringify({ id: "sig1", newsId: "n1", title: "SNDK wins contract", materiality: { tickers: ["SNDK"] }, pricedIn: { status: "none" } }));
+    writeFileSync(path.join(dir, "theses", "t1.json"), JSON.stringify({ id: "th1", signalId: "sig1", ticker: "SNDK", direction: "long" }));
+    ledger({ ts: "2026-08-22T10:05:00Z", type: "decision", decision: { id: "d1", thesisId: "th1", action: "open", audit: { vetoedBy: null } } });
+    ledger({ ts: "2026-08-22T10:05:10Z", type: "paper_open", decisionId: "d1", ticker: "SNDK", fillPx: 1603.4 });
+    ledger({ ts: "2026-08-23T09:00:00Z", type: "stop_loss", ticker: "SNDK", exitPx: 1580, pnlUsd: -44 });
+    writeFileSync(path.join(dir, "portfolio.json"), JSON.stringify({ positions: [{ ticker: "SNDK", direction: "long" }] }));
+
+    const audit = buildDeltaPmAudit(dir)!;
+    expect(audit.cases).toHaveLength(1);
+    const c = audit.cases[0] as Record<string, any>;
+    expect(c.news.newsId).toBe("n1");
+    expect(c.signal.id).toBe("sig1");
+    expect(c.thesis.id).toBe("th1");
+    expect(c.decision.id).toBe("d1");
+    expect(c.decision.ts).toBe("2026-08-22T10:05:00Z");
+    expect(c.execution.fillPx).toBe(1603.4);
+    expect(c.positionNow.ticker).toBe("SNDK");
+    expect(c.postEvents).toHaveLength(1);
+    expect(audit.bookStartedUtc).toBe("2026-08-22T10:00:00Z");
+  });
+
+  it("keeps archived news as chain-less cases and dedupes restart re-logs, newest first", () => {
+    ledger({ ts: "2026-08-22T10:00:00Z", type: "news_seen", newsId: "old", title: "Old" });
+    ledger({ ts: "2026-08-22T11:00:00Z", type: "news_seen", newsId: "new", title: "New" });
+    ledger({ ts: "2026-08-22T12:00:00Z", type: "news_seen", newsId: "old", title: "Old re-logged" });
+    const audit = buildDeltaPmAudit(dir)!;
+    expect(audit.cases.map((c: any) => c.news.newsId)).toEqual(["old", "new"]);
+    expect(audit.cases[0]).toMatchObject({ signal: null, thesis: null, decision: null });
+  });
+});

--- a/services/forecast-api/src/delta-pm-audit.ts
+++ b/services/forecast-api/src/delta-pm-audit.ts
@@ -1,0 +1,155 @@
+// Delta PM audit-chain aggregation for the /live-delta-pm review page.
+//
+// Joins the shadow agent's on-disk artifacts (shared runtime-artifacts
+// volume, written by services/delta-pm) into per-news "IC memo" cases: news
+// desk → analyst thesis → market check → PM arithmetic → risk guards →
+// execution — every number the decision consumed, nothing summarized away.
+// Read-only; simulation data only (the delta-pm service holds no keys).
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { repoRoot } from "./repo";
+
+const CACHE_TTL_MS = 60_000;
+
+function deltaPmRoot(): string {
+  const explicit = process.env.DELTA_PM_ARTIFACTS_DIR?.trim();
+  if (explicit) return explicit;
+  const shared = process.env.ARTIFACT_STORAGE_ROOT?.trim();
+  if (shared) return path.join(shared, "delta-pm");
+  return path.join(repoRoot(), "runtime-artifacts", "delta-pm");
+}
+
+type Json = Record<string, unknown>;
+
+function readJson(file: string): Json | null {
+  try {
+    return JSON.parse(readFileSync(file, "utf8")) as Json;
+  } catch {
+    return null;
+  }
+}
+
+function readJsonl(file: string): Json[] {
+  if (!existsSync(file)) return [];
+  const out: Json[] = [];
+  for (const line of readFileSync(file, "utf8").split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      out.push(JSON.parse(line) as Json);
+    } catch {
+      // torn tail line
+    }
+  }
+  return out;
+}
+
+function readDir(dir: string): Json[] {
+  if (!existsSync(dir)) return [];
+  const out: Json[] = [];
+  for (const f of readdirSync(dir)) {
+    if (!f.endsWith(".json")) continue;
+    const v = readJson(path.join(dir, f));
+    if (v) out.push(v);
+  }
+  return out;
+}
+
+export interface DeltaPmAuditPayload {
+  generatedAtUtc: string;
+  bookStartedUtc: string | null;
+  equitySource: "portfolio.json";
+  portfolio: Json | null;
+  latestReflection: Json | null;
+  cases: Json[];
+}
+
+let cache: { at: number; payload: DeltaPmAuditPayload } | null = null;
+
+export function buildDeltaPmAudit(rootDir: string = deltaPmRoot(), limit = 30): DeltaPmAuditPayload | null {
+  const ledgerFile = path.join(rootDir, "ledger.jsonl");
+  if (!existsSync(ledgerFile)) return null;
+
+  const ledger = readJsonl(ledgerFile);
+  const signals = readDir(path.join(rootDir, "signals"));
+  const theses = readDir(path.join(rootDir, "theses"));
+  const portfolio = readJson(path.join(rootDir, "portfolio.json"));
+
+  const signalsByNews = new Map<string, Json>();
+  for (const s of signals) if (typeof s.newsId === "string") signalsByNews.set(s.newsId, s);
+  const thesesBySignal = new Map<string, Json>();
+  for (const t of theses) if (typeof t.signalId === "string") thesesBySignal.set(t.signalId, t);
+
+  const decisionsByThesis = new Map<string, Json>();
+  const opensByDecision = new Map<string, Json>();
+  const closesByTicker = new Map<string, Json[]>();
+  const newsSeen: Json[] = [];
+  for (const e of ledger) {
+    if (e.type === "news_seen") newsSeen.push(e);
+    else if (e.type === "decision") {
+      const d = e.decision as Json | undefined;
+      if (d && typeof d.thesisId === "string") decisionsByThesis.set(d.thesisId, { ...d, ts: e.ts });
+    } else if (e.type === "paper_open" && typeof e.decisionId === "string") {
+      opensByDecision.set(e.decisionId, e);
+    } else if ((e.type === "paper_close" || e.type === "stop_loss" || e.type === "hard_floor_stop") && typeof e.ticker === "string") {
+      const arr = closesByTicker.get(e.ticker) ?? [];
+      arr.push(e);
+      closesByTicker.set(e.ticker, arr);
+    }
+  }
+
+  // Newest first; dedupe repeated news_seen (restarts re-log backfills).
+  const seenIds = new Set<string>();
+  const cases: Json[] = [];
+  for (const n of [...newsSeen].reverse()) {
+    const newsId = String(n.newsId ?? "");
+    if (!newsId || seenIds.has(newsId)) continue;
+    seenIds.add(newsId);
+    const signal = signalsByNews.get(newsId) ?? null;
+    const thesis = signal && typeof signal.id === "string" ? thesesBySignal.get(signal.id) ?? null : null;
+    const decision = thesis && typeof thesis.id === "string" ? decisionsByThesis.get(thesis.id) ?? null : null;
+    const execution = decision && typeof decision.id === "string" ? opensByDecision.get(decision.id) ?? null : null;
+    const ticker = (thesis?.ticker as string | undefined) ?? null;
+    const positionNow =
+      ticker && portfolio && Array.isArray(portfolio.positions)
+        ? ((portfolio.positions as Json[]).find((p) => p.ticker === ticker) ?? null)
+        : null;
+    cases.push({
+      news: { newsId, title: n.title ?? null, publishedUtc: n.publishedUtc ?? null, kind: n.kind ?? null, prefix: n.prefix ?? null, seenAtUtc: n.ts ?? null },
+      signal,
+      thesis,
+      decision,
+      execution,
+      positionNow,
+      postEvents: ticker ? (closesByTicker.get(ticker) ?? []) : []
+    });
+    if (cases.length >= limit) break;
+  }
+
+  const reportsDir = path.join(rootDir, "reports");
+  let latestReflection: Json | null = null;
+  if (existsSync(reportsDir)) {
+    const files = readdirSync(reportsDir).filter((f) => f.endsWith("-reflection.json")).sort();
+    const latest = files.at(-1);
+    if (latest) latestReflection = readJson(path.join(reportsDir, latest));
+  }
+
+  const serviceStart = ledger.find((e) => e.type === "service_start");
+  return {
+    generatedAtUtc: new Date().toISOString(),
+    bookStartedUtc: serviceStart ? String(serviceStart.ts ?? "") : null,
+    equitySource: "portfolio.json",
+    portfolio,
+    latestReflection,
+    cases
+  };
+}
+
+export function getDeltaPmAudit(limit = 30): DeltaPmAuditPayload | null {
+  if (cache && Date.now() - cache.at < CACHE_TTL_MS && cache.payload.cases.length >= Math.min(limit, cache.payload.cases.length)) {
+    return cache.payload;
+  }
+  const payload = buildDeltaPmAudit(undefined, limit);
+  if (payload) cache = { at: Date.now(), payload };
+  return payload;
+}

--- a/services/forecast-api/src/server.ts
+++ b/services/forecast-api/src/server.ts
@@ -18,6 +18,7 @@ import { z } from "zod";
 import { buildAnswer, verdictFor, pct } from "./answer";
 import { isAuthorized } from "./auth";
 import type { ServiceConfig } from "./config";
+import { getDeltaPmAudit } from "./delta-pm-audit";
 import { authorizeInviteUse, describeInviteState, inviteState } from "./invites";
 import { log } from "./log";
 import { handleMcpRequest } from "./mcp";
@@ -276,6 +277,25 @@ async function route(req: IncomingMessage, res: ServerResponse, config: ServiceC
       return;
     }
     sendJson(res, 200, snapshot);
+    return;
+  }
+
+  // Delta PM audit chain for the /live-delta-pm review page: per-news IC-memo
+  // cases (news → analyst thesis → market check → PM arithmetic → guards →
+  // execution). Simulation data only; same credential rules as /paper/snapshot.
+  if (url.pathname === "/delta-pm/audit" && method === "GET") {
+    if (!isAuthorized(req, url, config.token) && !isAuthorized(req, url, config.inviteCode)) {
+      sendJson(res, 401, { error: "unauthorized — provide the access token or invite code (Authorization: Bearer, x-api-key, or ?token=)" });
+      return;
+    }
+    const requestedLimit = Number(url.searchParams.get("limit") ?? "30");
+    const limit = Number.isInteger(requestedLimit) && requestedLimit >= 1 && requestedLimit <= 100 ? requestedLimit : 30;
+    const audit = getDeltaPmAudit(limit);
+    if (!audit) {
+      sendJson(res, 503, { error: "delta-pm book not found on this host — check ARTIFACT_STORAGE_ROOT / volume mounts" });
+      return;
+    }
+    sendJson(res, 200, audit);
     return;
   }
 


### PR DESCRIPTION
## 这是什么

解决『抽象写法没法审计』:把决策记录、聚合 API、审阅页三层打通,按**对冲基金内部决策链**呈现每条新闻——六台席(情报台→重要性→交易台定价检查→研究 memo→PM 台→执行/风控),每个数字摊开。

## 最值得核对
1. 截图(见 PR 评论区/会话):SNDK 案例整页——门槛分解逐行、sizing 链 $10,000×1.00%÷0.55%=$18,318 → 六道 guard 表(tier1_cap binding 高亮)→ 杠杆三帽 → 执行滑点
2. `services/delta-pm/src/policy.ts` decisionAudit 构造(否决带标签,拒单带完整算术)
3. `services/forecast-api/src/delta-pm-audit.ts` 六环 join
4. `apps/web/app/live-delta-pm/report.tsx` 六站渲染
5. 页面门禁与 live-predict-raven 同模式(默认邀请码同、cookie 命名空间隔离)

## 验证
- 全仓 1070 + 新增(delta-pm 58 / forecast-api 3 / web 15)全绿;web build 通过
- 网页真实运行验收:解锁流程 Playwright 走通,桌面+移动 0 pageerror(移动端一处溢出已修)
- fixture = 30 条真实 run 数据(含重放出的满血审计开仓与毫厘拒单)

## 部署(合并后我执行)
- VM:重建镜像 + `up -d --no-deps delta-pm forecast-api`(其余容器零接触)
- Web:`gh workflow run wc-results.yml`;Vercel 无需新 env(默认值即用)