### PR TITLE
fix(delta-pm): contamination detector FP #2 (product price vs expectations haircut)

### DIFF
--- a/services/delta-pm/src/analyzer.ts
+++ b/services/delta-pm/src/analyzer.ts
@@ -38,9 +38,13 @@ export function scrubPriceReactions(text: string): { scrubbed: string; removed: 
 // EXPECTATIONS channel — exactly the surprise-vs-consensus discipline we
 // demand — while "the stock has already moved/is already up 5%" is the price
 // channel we ban.
-const EXPECTATION_CONTEXT = /already priced[^.]{0,50}\b(consensus|estimates?|expectations?|models?|the street|guidance)\b/i;
+const EXPECTATION_CONTEXT =
+  /(['\u2018\u2019"]?already priced[ -]?in['\u2018\u2019"]?)[^.]{0,60}\b(haircut|consensus|estimates?|expectations?|models?|the street|guidance|judgment|assumption)\b/i;
 const HARD_CONTAMINATION = [
-  /\b(stock|shares?|price|market|equity|股价|盘面)\b[^.。]{0,50}\balready (moved|reacted|jumped|risen|fallen|rallied|sold off|priced)/i,
+  // NOTE: bare "price" removed from the subject list — PRODUCT prices in the
+  // news itself ("the price increase") kept colliding with expectations-channel
+  // phrases downstream (live false positive #2, 2026-08-24).
+  /\b(stock|shares?|market|equity|股价|盘面)\b[^.。]{0,50}\balready (moved|reacted|jumped|risen|fallen|rallied|sold off|priced)/i,
   /\balready (up|down)\s+\d+(?:\.\d+)?%/i,
   /\b(since|after) the (news|report|announcement)\b[^.。]{0,60}\d+(?:\.\d+)?%/i,
   /股价已(经)?(上涨|下跌|反应|走)/,

--- a/services/delta-pm/src/gate.test.ts
+++ b/services/delta-pm/src/gate.test.ts
@@ -274,6 +274,16 @@ describe("M2 blindness plumbing", () => {
     expect(detectContamination("EPS revision of +4% vs consensus")).toBe("none");
   });
 
+  it("product-price wording + expectations haircut is NOT contamination (live false positive #2, 2026-08-24)", () => {
+    expect(
+      detectContamination(
+        "costs that could partially offset the price increase The 'already priced in' haircut (55-60%) is a subjective judgment given no visible consensus"
+      )
+    ).toBe("none");
+    // The real price channel still trips.
+    expect(detectContamination("the market has already priced this move")).toBe("hard");
+  });
+
   it("expectations-channel language is NOT contamination (live false positive 2026-08-22)", () => {
     expect(
       detectContamination("Cannot cleanly separate 'genuinely incremental' from 'already priced' without the actual sell-side consensus model")


### PR DESCRIPTION
VM 实弹抓到第二类污染误杀:新闻里的**产品价格**("the price increase")撞上正则主语表,把合法的预期折扣语言("'already priced in' haircut ... subjective judgment")判成 hard 污染否决。修法:主语表剔除裸 price、预期白名单扩 haircut/judgment/assumption;真实样本回归测试;真价格通道("the market has already priced this move")仍然否决。93 测试绿。