### PR TITLE
docs: dashboard-sample front-end style reference for public metrics pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,7 @@
 | 风控完整规则 | [`docs/risk-controls.md`](docs/risk-controls.md) |
 | forecasting 流程开销画像 | [`docs/diagrams/forecasting-cost-profile.md`](docs/diagrams/forecasting-cost-profile.md) |
 | 命令速查 / 部署形态 / 依赖矩阵 | [`docs/diagrams/dev-reference.md`](docs/diagrams/dev-reference.md) |
+| 上线页面前端样式样本（对外指标页优先套用） | [`docs/diagrams/dashboard-style-reference.md`](docs/diagrams/dashboard-style-reference.md) |
 | 资金与账号配置（4 字段） | README "Wallet and Account Setup" 节 |
 | 实盘运行总结归档 | `runtime-artifacts/pulse-live/<ts>-<runId>/run-summary.md` |
 | Forecasting AI 推理报告 | `runtime-artifacts/reports/pulse/YYYY/MM/DD/pulse-*.md` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@
 | 风控完整规则 | [`docs/risk-controls.md`](docs/risk-controls.md) |
 | forecasting 流程开销画像 | [`docs/diagrams/forecasting-cost-profile.md`](docs/diagrams/forecasting-cost-profile.md) |
 | 命令速查 / 部署形态 / 依赖矩阵 | [`docs/diagrams/dev-reference.md`](docs/diagrams/dev-reference.md) |
+| 上线页面前端样式样本（对外指标页优先套用） | [`docs/diagrams/dashboard-style-reference.md`](docs/diagrams/dashboard-style-reference.md) |
 | 资金与账号配置（4 字段） | README "Wallet and Account Setup" 节 |
 | 实盘运行总结归档 | `runtime-artifacts/pulse-live/<ts>-<runId>/run-summary.md` |
 | Forecasting AI 推理报告 | `runtime-artifacts/reports/pulse/YYYY/MM/DD/pulse-*.md` |

--- a/docs/diagrams/dashboard-style-reference.en.md
+++ b/docs/diagrams/dashboard-style-reference.en.md
@@ -1,0 +1,37 @@
+# Launch-page style sample: dashboard-sample
+
+> Last updated: 2026-08-24
+> Chinese original: [`dashboard-style-reference.md`](dashboard-style-reference.md)
+
+**Sample repo: https://github.com/Alchemist-X/dashboard-sample** (MIT, our own code — copy freely)
+
+A dark "live model-usage metrics" page design study (a layout study of poolside.ai/pulse; all content is fictional mock data). Zero dependencies, zero build: plain HTML + CSS + vanilla JS, with charts generated as hand-written SVG strings. **When this repo ships a public-facing data page for a launched service/product, consider this visual language first** — it looks professional, is light to implement, and carries no chart-library dependency.
+
+## Where it fits
+
+- **Public paper-fleet board**: the 5 simulated books on Huginn (fable / opus / sonnet / kimi-k3 / ds-flash) — balance curves plus a ranking; the sample's "stacked bars + leaderboard (movement arrows + own-entry highlight)" transfers almost as-is
+- **/world-cup/performance visual refresh**: stat tiles for Brier / Mock PNL and event-annotated time series
+- **delta / delta-pm public read-only views**: throughput/hit-rate metrics for the news→impact engine
+- Any future "since launch" public metrics page (tokens, calls, downloads, accuracy tracking)
+
+## What the style consists of (directly liftable)
+
+| Element | Value / pattern |
+| --- | --- |
+| Ground / text | `#1a1a1a` background; white body text, secondary grays `#d6d5cf` → `#878580` |
+| Accents | ice blue `#ace2ef` (brand/highlight) + green `#9bd85b` (links/up) + orange-red `#ff7a59` (down) |
+| Chart series | ice / teal `#18a9b6` / yellow `#fed354` / purple `#bb56ff` / green `#67ae00` / orange `#ff8040` |
+| Type | grotesque body (Inter); **all data labels/axes/footnote markers in JetBrains Mono** |
+| Headlines | bold white lead + dimmed gray tail (`32px/500`), e.g. "**11.6 trillion** tokens … <span style="color:#878580">since our first launch.</span>" |
+| Chart titles | below the chart, uppercase mono small caps + `*`, with a footnote paragraph explaining methodology (transparent data caveats are core to the style's character) |
+| Stat tiles | 4-column grid, 1px top rule, big number + two-line gray label |
+| Chart patterns | 100% stacked area (share), daily stacked bars (dashed launch-event markers; today's bar gets a hatched "projected tip" extrapolated from the elapsed fraction of the day), leaderboard list |
+| Interaction | radio-pill model filter re-rendering all charts and numbers; hover guide line + tooltip; scroll fade-ins honoring `prefers-reduced-motion` |
+
+## How to lift it
+
+- Design tokens: copy the `:root` variable block at the top of `css/style.css` wholesale
+- Charts: `js/charts.js` is a dependency-free SVG string generator (stacked area / stacked bars / grid / event markers / hatch pattern / tooltip); in Next.js either inject the generated markup via `dangerouslySetInnerHTML` or port its coordinate logic to JSX; for static pages copy the file as-is
+- The mock data layer `js/data.js` shows the "seeded PRNG + timeline anchored to today" trick — handy for demo/placeholder pages
+- ⚠️ The sample's brands (meridian / Lumen / GatewayHub) and every number are fictional; lift the styling and components only — keep the fake brand words out of product copy
+- ⚠️ When wiring into predict-raven's `apps/web`, the CLAUDE.md front-end trio still applies (tri-lingual i18n / mobile fit / local build + screenshot self-review)

--- a/docs/diagrams/dashboard-style-reference.md
+++ b/docs/diagrams/dashboard-style-reference.md
@@ -1,0 +1,37 @@
+# 上线页面样式样本：dashboard-sample
+
+> 最后更新：2026-08-24
+> 英文版见 [`dashboard-style-reference.en.md`](dashboard-style-reference.en.md)
+
+**样本仓库：https://github.com/Alchemist-X/dashboard-sample**（MIT，自家代码，可随意搬）
+
+一个"模型用量实时面板"风格的深色 metrics 页设计习作（对 poolside.ai/pulse 版式的复刻研究，内容全部为虚构 mock 数据）。零依赖零构建：纯 HTML + CSS + vanilla JS，图表是手写 SVG 字符串生成。**本仓库以后给对外上线的服务/产品做公开数据页时，优先考虑套用这套视觉语言**——效果专业、实现轻、没有图表库依赖。
+
+## 适合用在哪
+
+- **paper-fleet 公开面板**：Huginn 上 5 个模拟账本（fable / opus / sonnet / kimi-k3 / ds-flash）的余额曲线对比 + 排行——样本里的"堆叠柱状图 + 排行榜（名次升降箭头 + 自家条目高亮）"几乎原样可用
+- **/world-cup/performance 视觉升级**：Brier / Mock PNL 的统计块（stat tiles）与带事件标注的时间序列
+- **delta / delta-pm 对外只读视图**：新闻→影响引擎的吞吐/命中指标页
+- 未来任何"since launch"性质的公开指标页（token 量、调用量、下载量、准确率跟踪）
+
+## 这套风格的构成（可直接抄的部分）
+
+| 要素 | 取值 / 模式 |
+| --- | --- |
+| 底色 / 文字 | `#1a1a1a` 底；正文白，次级 `#d6d5cf` → `#878580` 三档灰 |
+| 强调色 | 冰蓝 `#ace2ef`（品牌/高亮）+ 绿 `#9bd85b`（链接/上涨）+ 橙红 `#ff7a59`（下跌） |
+| 图表系列色 | 冰蓝 / 青 `#18a9b6` / 黄 `#fed354` / 紫 `#bb56ff` / 绿 `#67ae00` / 橙 `#ff8040` |
+| 字体 | 正文 grotesque（Inter）；**所有数据标签/坐标轴/脚注编号用 JetBrains Mono** |
+| 大标题 | 白色粗句首 + 灰色弱化后半句（`32px/500`），例："**11.6 trillion** tokens … <span style="color:#878580">since our first launch.</span>" |
+| 图表标题 | 图下方、全大写等宽小字 + `*` 星号，脚注段落解释口径（数据口径透明是这个风格的核心气质） |
+| 统计块 | 4 列 grid，顶部 1px 分隔线，大数字 + 两行灰色标签 |
+| 图表模式 | 100% 堆叠面积图（份额）、每日堆叠柱（含发布事件虚线标注、今日柱"斜线阴影投影尖端"按当日已过时间外推）、排行榜列表 |
+| 交互 | 顶部 radio 胶囊筛选器联动全部图表与数字；hover 竖线 + tooltip；滚动淡入（尊重 `prefers-reduced-motion`） |
+
+## 搬运方式
+
+- 设计 token：`css/style.css` 顶部 `:root` 变量块整段可抄
+- 图表：`js/charts.js` 是无依赖的 SVG 字符串生成器（堆叠面积 / 堆叠柱 / 网格 / 事件标注 / hatch pattern / tooltip），Next.js 里可直接把生成的 markup 塞进 `dangerouslySetInnerHTML`，或照它的坐标逻辑改写成 JSX；静态页直接整文件搬
+- mock 数据层 `js/data.js` 展示了"种子 PRNG + 时间轴锚定今天"的手法，做 demo/占位页时好用
+- ⚠️ 样本里的品牌（meridian / Lumen / GatewayHub）与全部数字是虚构的，搬运时只取样式与组件，不要把假品牌词带进产品文案
+- ⚠️ 接入 predict-raven 的 `apps/web` 时照常执行 CLAUDE.md 前端三件套（i18n 三语 / 移动端适配 / 本地 build + 截图自评）

--- a/docs/en/AGENTS.md
+++ b/docs/en/AGENTS.md
@@ -134,6 +134,7 @@ For any user-visible change, close out with: **screenshot → read the image →
 | Full risk-control rules | [`docs/risk-controls.en.md`](../risk-controls.en.md) |
 | Forecasting cost profile | [`docs/diagrams/forecasting-cost-profile.en.md`](../diagrams/forecasting-cost-profile.en.md) |
 | Command cheatsheet / deployment / dependency matrix | [`docs/diagrams/dev-reference.en.md`](../diagrams/dev-reference.en.md) |
+| Launch-page front-end style sample (default for public metrics pages) | [`docs/diagrams/dashboard-style-reference.en.md`](../diagrams/dashboard-style-reference.en.md) |
 | Wallet & account setup (4 fields) | README "Wallet and Account Setup" section |
 | Live run summary archive | `runtime-artifacts/pulse-live/<ts>-<runId>/run-summary.md` |
 | Forecasting AI reasoning report | `runtime-artifacts/reports/pulse/YYYY/MM/DD/pulse-*.md` |

--- a/docs/en/CLAUDE.md
+++ b/docs/en/CLAUDE.md
@@ -142,6 +142,7 @@ For any user-visible change, close out with: **screenshot → read the image →
 | Full risk-control rules | [`docs/risk-controls.en.md`](../risk-controls.en.md) |
 | Forecasting cost profile | [`docs/diagrams/forecasting-cost-profile.en.md`](../diagrams/forecasting-cost-profile.en.md) |
 | Command cheatsheet / deployment / dependency matrix | [`docs/diagrams/dev-reference.en.md`](../diagrams/dev-reference.en.md) |
+| Launch-page front-end style sample (default for public metrics pages) | [`docs/diagrams/dashboard-style-reference.en.md`](../diagrams/dashboard-style-reference.en.md) |
 | Wallet & account setup (4 fields) | README "Wallet and Account Setup" section |
 | Live run summary archive | `runtime-artifacts/pulse-live/<ts>-<runId>/run-summary.md` |
 | Forecasting AI reasoning report | `runtime-artifacts/reports/pulse/YYYY/MM/DD/pulse-*.md` |


### PR DESCRIPTION
## What

Adds a bilingual reference doc pointing at https://github.com/Alchemist-X/dashboard-sample — a dark, zero-dependency "live model-usage metrics" page design study (mock data) — and registers it in the CLAUDE/AGENTS quick-reference table as the default visual language to consider for future public-facing metrics pages.

- New: `docs/diagrams/dashboard-style-reference.md` + `.en.md` — where it fits (public paper-fleet board, /world-cup/performance refresh, delta read-only views), the liftable design tokens/patterns, how to port the dependency-free SVG chart builders into `apps/web`, and the caveats (fictional brands stay out of product copy; front-end trio still applies).
- Updated: one table row in `CLAUDE.md`, `AGENTS.md`, `docs/en/CLAUDE.md`, `docs/en/AGENTS.md`.

Docs-only; no code paths touched.

## Verification

- Docs-only diff (4 one-line insertions + 2 new files); zh/en pairs added together per the bilingual rule.
- Note: `docs/en/CLAUDE.md` and `docs/en/AGENTS.md` already differ from each other on main (pre-existing drift, untouched here — only the shared table row was added to both).