### PR TITLE
paper-agent: random per-category market-scan pick, widen scan pool

### DIFF
--- a/services/paper-agent/src/market-scan.test.ts
+++ b/services/paper-agent/src/market-scan.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_SCAN_OPTIONS, filterScanRows, type ScanRow } from "./market-scan";
+import { DEFAULT_SCAN_OPTIONS, filterScanRows, scanMarkets, type ScanRow } from "./market-scan";
 
 const NOW = Date.parse("2026-07-03T00:00:00Z");
 const FUTURE = "2026-09-01T00:00:00Z";
@@ -57,5 +57,32 @@ describe("filterScanRows", () => {
     const rows = Array.from({ length: 20 }, (_, i) => ({ ...base, slug: `m${i}` }));
     const out = filterScanRows(rows, "geopolitics", { ...DEFAULT_SCAN_OPTIONS, perCategory: 3 }, NOW);
     expect(out).toHaveLength(3);
+  });
+});
+
+describe("scanMarkets", () => {
+  // Same shortlist behind every category tag — only the rng differs between cases.
+  const rows = Array.from({ length: 5 }, (_, i) => ({ ...base, slug: `m${i}`, volume24hr: 50_000 - i * 1000 }));
+  const fetchFn = (async () => ({ ok: true, json: async () => rows })) as unknown as typeof fetch;
+
+  it("draws exactly one candidate per category, not the whole shortlist", async () => {
+    const out = await scanMarkets(["finance", "tech"], DEFAULT_SCAN_OPTIONS, fetchFn, () => 0);
+    expect(out).toHaveLength(2);
+  });
+
+  it("a different rng draws a different candidate from the same shortlist", async () => {
+    const first = await scanMarkets(["finance"], DEFAULT_SCAN_OPTIONS, fetchFn, () => 0);
+    const last = await scanMarkets(["finance"], DEFAULT_SCAN_OPTIONS, fetchFn, () => 0.999);
+    expect(first[0]?.slug).toBe("m0");
+    expect(last[0]?.slug).toBe("m4");
+    expect(first[0]?.slug).not.toBe(last[0]?.slug);
+  });
+
+  it("never draws the same slug twice across categories that see overlapping rows", async () => {
+    // rng pinned at 0 would pick "m0" for both categories if dedup didn't apply —
+    // assert the second category's pick is excluded from repeating the first's.
+    const out = await scanMarkets(["finance", "tech"], DEFAULT_SCAN_OPTIONS, fetchFn, () => 0);
+    const slugs = out.map((c) => c.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
   });
 });

--- a/services/paper-agent/src/market-scan.ts
+++ b/services/paper-agent/src/market-scan.ts
@@ -4,6 +4,12 @@
 // Filters mirror the repo's standing risk gates: liquidity ≥ $5k hard floor,
 // binary Yes/No only, sane price band (no longshot junk), open + not expiring
 // imminently.
+//
+// Selection is a random draw of one candidate per category (2026-08-24), not
+// the top-of-list walk it used to be: always evaluating the same handful of
+// highest-24h-volume markets meant the fleet's new-entry attention converged
+// on a narrow, repeat set of "usual suspects" instead of sampling the wider
+// pool that clears the risk gates.
 
 import { log } from "./log";
 
@@ -58,7 +64,7 @@ export const DEFAULT_SCAN_OPTIONS: ScanOptions = {
   perCategory: 12, // widened with the volume gate: the top-8 cap was binding before the gate could
 
   minHoursToEnd: 48, // skip markets resolving imminently — no time to re-evaluate
-  priceBand: [0.05, 0.95]
+  priceBand: [0.02, 0.98] // widened from [0.05, 0.95] (user 2026-08-24) — only cut the true no-edge extremes
 };
 
 function parseArray(raw: unknown): string[] {
@@ -104,10 +110,17 @@ export function filterScanRows(rows: ScanRow[], category: string, opts: ScanOpti
   return out;
 }
 
+// Uniform pick — swappable for a seeded RNG in tests without touching callers.
+function pickRandom<T>(items: readonly T[], rng: () => number = Math.random): T | undefined {
+  if (!items.length) return undefined;
+  return items[Math.floor(rng() * items.length)];
+}
+
 export async function scanMarkets(
   categories: string[],
   opts: ScanOptions = DEFAULT_SCAN_OPTIONS,
-  fetchFn: typeof fetch = fetch
+  fetchFn: typeof fetch = fetch,
+  rng: () => number = Math.random
 ): Promise<ScanCandidate[]> {
   const seen = new Set<string>();
   const all: ScanCandidate[] = [];
@@ -119,21 +132,26 @@ export async function scanMarkets(
     }
     try {
       const res = await fetchFn(
-        `${GAMMA}/markets?closed=false&tag_id=${tagId}&order=volume24hr&ascending=false&limit=40`,
+        `${GAMMA}/markets?closed=false&tag_id=${tagId}&order=volume24hr&ascending=false&limit=100`,
         { headers: { accept: "application/json" }, signal: AbortSignal.timeout(15_000) }
       );
       if (!res.ok) throw new Error(`gamma scan ${res.status}`);
       const rows = (await res.json()) as ScanRow[];
-      for (const c of filterScanRows(rows, category, opts, Date.now())) {
-        if (!seen.has(c.slug)) {
-          seen.add(c.slug);
-          all.push(c);
-        }
+      // Filter first (still capped at opts.perCategory, still ranked by 24h
+      // volume within the filter step), THEN draw one at random from that
+      // shortlist — the ranking decides who clears the risk gate, not who
+      // gets evaluated.
+      const shortlist = filterScanRows(rows, category, opts, Date.now()).filter((c) => !seen.has(c.slug));
+      const pick = pickRandom(shortlist, rng);
+      if (pick) {
+        seen.add(pick.slug);
+        all.push(pick);
       }
     } catch (error) {
       log.error(`scan failed for ${category}: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
-  // Highest 24h volume first — evaluation budget goes to the liveliest books.
+  // Highest 24h volume first among this cycle's random draws — ties in
+  // remaining eval budget still go to the livelier pick.
   return all.sort((a, b) => b.volume24hUsd - a.volume24hUsd);
 }


### PR DESCRIPTION
## Summary
- Discovery scan pulls the top 100 markets per tag now, was 40.
- Price band widened to [0.02, 0.98] (was [0.05, 0.95]) — only cut the true no-edge extremes.
- Selection changed from walking the shortlist top-to-bottom by 24h volume to a random draw of **one** candidate per category — the old behavior always evaluated the same handful of highest-volume markets every cycle; new-entry attention now samples the wider risk-gated pool instead of converging on repeat "usual suspects".
- `filterScanRows` (the risk-gate filter itself: liquidity ≥ $5k, binary Yes/No, ≥48h to resolution, price band, capped at `perCategory`=12) is unchanged — only what happens with the filtered shortlist changed.

## Why
Per-category eval attention was concentrating on the same top-volume names cycle after cycle. Widening the raw pool (100 vs 40) plus a random draw from each category's filtered top-12 spreads new-entry evaluation across more of what actually clears the risk gates.

## Test plan
- [x] `pnpm exec vitest run services/paper-agent/src/market-scan.test.ts` — 7/7 pass (4 existing + 3 new covering the random draw: exactly one pick per category, different rng picks different candidates, no duplicate picks across categories sharing rows)
- [x] `pnpm typecheck` in `services/paper-agent` — clean
- [ ] Not yet deployed to the live fleet on raven-labs-server-001 — flagging per this repo's CLAUDE.md (line 118): trading/executor changes wait for explicit merge confirmation, and merging `main` also triggers the Vercel auto-deploy.