### PR TITLE
fix(delta-pm): resolve news identity by URL so sitemap backfill stops re-ingesting feed stories

### DIFF
--- a/services/delta-pm/src/feed.test.ts
+++ b/services/delta-pm/src/feed.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
-import { parseAtom, stripHtml } from "./feed.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { NewsItem } from "@autopoly/delta-pm-contracts";
+import { parseAtom, parseSitemap, selectSitemapBackfill, stripHtml } from "./feed.js";
+import { upsertNewsItem } from "./store.js";
 
 const FIXTURE = `<?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
@@ -59,5 +64,72 @@ describe("parseAtom", () => {
 describe("stripHtml", () => {
   it("converts breaks/paragraphs to newlines and decodes entities", () => {
     expect(stripHtml("a&lt;b<br/>c</p>d &amp; e")).toBe("a<b\nc\nd & e");
+  });
+});
+
+
+const SITEMAP = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
+  <url>
+    <loc>https://www.theinformation.com/briefings/openai-integrates-chatgpt</loc>
+    <news:news>
+      <news:publication_date>2026-08-21T17:55:36Z</news:publication_date>
+      <news:title>Exclusive: OpenAI Integrates ChatGPT into Apple Messages on Mac</news:title>
+    </news:news>
+  </url>
+  <url>
+    <loc>https://www.theinformation.com/articles/meta-hatch-agent-platform</loc>
+    <news:news>
+      <news:publication_date>2026-08-24T22:40:37Z</news:publication_date>
+      <news:title>Meta Plans to Launch Hatch AI Agent Platform</news:title>
+    </news:news>
+  </url>
+</urlset>`;
+
+describe("sitemap backfill", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "delta-pm-feed-"));
+    process.env.ARTIFACT_STORAGE_ROOT = dir;
+  });
+
+  afterEach(() => {
+    delete process.env.ARTIFACT_STORAGE_ROOT;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("parses url blocks into items keyed by a sitemap id", () => {
+    const items = parseSitemap(SITEMAP, "2026-08-25T06:39:00.000Z");
+    expect(items).toHaveLength(2);
+    expect(items[0].id).toBe("sitemap:https://www.theinformation.com/briefings/openai-integrates-chatgpt");
+    expect(items[0].kind).toBe("briefing");
+    expect(items[0].prefix).toBe("exclusive");
+    expect(items[0].publishedUtc).toBe("2026-08-21T17:55:36.000Z");
+    expect(items[0].teaser).toBe("");
+  });
+
+  it("skips a story already archived under its Atom feed id (regression: 2026-08-25 restart re-ingest)", () => {
+    const fromFeed = parseAtom(FIXTURE, "2026-08-22T00:00:00.000Z")[0];
+    expect(fromFeed.url).toBe("https://www.theinformation.com/briefings/openai-integrates-chatgpt");
+    upsertNewsItem(fromFeed);
+
+    const fresh = selectSitemapBackfill(parseSitemap(SITEMAP, "2026-08-25T06:39:00.000Z"), [fromFeed.id]);
+    expect(fresh.map((i) => i.url)).toEqual(["https://www.theinformation.com/articles/meta-hatch-agent-platform"]);
+  });
+
+  it("still recovers stories the feed window missed", () => {
+    const fresh = selectSitemapBackfill(parseSitemap(SITEMAP, "2026-08-25T06:39:00.000Z"), []);
+    expect(fresh).toHaveLength(2);
+  });
+
+  it("ignores trailing-slash and query differences when matching URLs", () => {
+    const archived: NewsItem = {
+      ...parseAtom(FIXTURE, "2026-08-22T00:00:00.000Z")[1],
+      url: "https://www.theinformation.com/articles/meta-hatch-agent-platform/?utm_source=feed"
+    };
+    upsertNewsItem(archived);
+    const fresh = selectSitemapBackfill(parseSitemap(SITEMAP, "2026-08-25T06:39:00.000Z"), []);
+    expect(fresh.map((i) => i.url)).toEqual(["https://www.theinformation.com/briefings/openai-integrates-chatgpt"]);
   });
 });

--- a/services/delta-pm/src/feed.ts
+++ b/services/delta-pm/src/feed.ts
@@ -15,7 +15,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { NewsItem } from "@autopoly/delta-pm-contracts";
 import { config } from "./config.js";
-import { paths, readJson, writeJsonAtomic } from "./store.js";
+import { findNewsIdByUrl, paths, readJson, writeJsonAtomic } from "./store.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -208,23 +208,15 @@ export async function pollFeed(): Promise<PollResult> {
 // publication_date + title (no teaser). Items recovered here carry an empty
 // teaser and are flagged via kind detection only — still enough for gate 1
 // to decide whether a (delayed) analysis is worth it.
-export async function backfillFromSitemap(): Promise<NewsItem[]> {
-  const res = await curlFetch(config.sitemapNewsUrl, { accept: "application/xml" });
-  if (res.status !== 200) throw new Error(`GET sitemap-news → ${res.status}`);
-  const xml = res.body;
-  const state = loadFeedState();
-  const seen = new Set(state.seenIds);
-  const nowIso = new Date().toISOString();
+export function parseSitemap(xml: string, fetchedAtUtc: string): NewsItem[] {
   const out: NewsItem[] = [];
   for (const u of blocks(xml, "url")) {
     const loc = text(u, "loc");
     const pub = text(u, "news:publication_date") ?? text(u, "publication_date");
     const title = text(u, "news:title") ?? text(u, "title");
     if (!loc || !pub || !title) continue;
-    const id = `sitemap:${loc}`;
-    if (seen.has(id) || state.seenIds.some((s) => s.includes(loc))) continue;
     out.push({
-      id,
+      id: `sitemap:${loc}`,
       source: "the-information",
       kind: kindFromUrl(loc),
       title,
@@ -235,9 +227,28 @@ export async function backfillFromSitemap(): Promise<NewsItem[]> {
       publishedUtc: new Date(pub).toISOString(),
       updatedUtc: null,
       prefix: titlePrefix(title),
-      fetchedAtUtc: nowIso
+      fetchedAtUtc
     });
   }
+  return out;
+}
+
+// Items the sitemap re-offers must be filtered by URL, not just by id: the feed
+// knows a story as `tag:www.theinformation.com,2005:Briefing/17919` while the
+// sitemap knows the same story as `sitemap:<url>`, so an id-only check let every
+// restart re-ingest the whole 48h window (measured on the VM 2026-08-25: 16
+// duplicate re-analyses in one restart, each paying gate 1 + coverage search).
+export function selectSitemapBackfill(items: NewsItem[], seenIds: string[]): NewsItem[] {
+  const seen = new Set(seenIds);
+  return items.filter((i) => !seen.has(i.id) && !findNewsIdByUrl(i.url));
+}
+
+export async function backfillFromSitemap(): Promise<NewsItem[]> {
+  const res = await curlFetch(config.sitemapNewsUrl, { accept: "application/xml" });
+  if (res.status !== 200) throw new Error(`GET sitemap-news → ${res.status}`);
+  const state = loadFeedState();
+  const nowIso = new Date().toISOString();
+  const out = selectSitemapBackfill(parseSitemap(res.body, nowIso), state.seenIds);
   if (out.length) {
     state.seenIds = [...out.map((i) => i.id), ...state.seenIds].slice(0, SEEN_CAP);
     saveFeedState(state);

--- a/services/delta-pm/src/run-cycle.ts
+++ b/services/delta-pm/src/run-cycle.ts
@@ -29,7 +29,7 @@ import { marketState } from "./market.js";
 import { checkHalt, decideEntry, equityOf, reviewPosition, updateTrailingStop, type MarketView } from "./policy.js";
 import { advance, finishRun, setTickers, startRun } from "./progress.js";
 import { push } from "./notify.js";
-import { appendLedger, paths, readJson, upsertNewsItem, writeJsonAtomic } from "./store.js";
+import { appendLedger, findNewsIdByUrl, paths, readJson, upsertNewsItem, writeJsonAtomic } from "./store.js";
 import { fetchCandles } from "./hyperliquid.js";
 
 // --- two-lane writer -------------------------------------------------------
@@ -181,7 +181,13 @@ export async function processNews(rawItem: unknown, deps: PipelineDeps): Promise
   // identity and timing, so a re-ingest (console 补全原文 paste) only fills
   // gaps and becomes a RERUN of the original signal, driven by the merged
   // record.
-  const upsert = upsertNewsItem(parsed.data);
+  // Identity resolves by URL as well as by id: the feed and the sitemap gap
+  // backfill hand the SAME story two different ids, and only the first one may
+  // own t0. An alias therefore folds into the original record instead of
+  // starting a second signal with a later timestamp.
+  const canonicalId = findNewsIdByUrl(parsed.data.url);
+  const aliasOf = canonicalId && canonicalId !== parsed.data.id ? parsed.data.id : null;
+  const upsert = upsertNewsItem(aliasOf ? { ...parsed.data, id: canonicalId as string } : parsed.data);
   const item: NewsItem = upsert.item;
   appendLedger({
     type: "news_seen",
@@ -191,8 +197,16 @@ export async function processNews(rawItem: unknown, deps: PipelineDeps): Promise
     kind: item.kind,
     prefix: item.prefix,
     rerun: upsert.existed,
+    aliasOf,
     hasFullText: Boolean(item.fullText)
   });
+  // A cross-path duplicate that carries no new text has nothing to add: the
+  // original already ran the gates under this t0. Paste reruns (which DO carry
+  // full text) still go through.
+  if (aliasOf && !upsert.fullTextAttached) {
+    appendLedger({ type: "news_duplicate_url", newsId: item.id, duplicateId: aliasOf, url: item.url });
+    return;
+  }
   const run = startRun(item.id, item.title);
 
   await withAnalysisSlot(async () => {

--- a/services/delta-pm/src/run-cycle.ts
+++ b/services/delta-pm/src/run-cycle.ts
@@ -235,7 +235,17 @@ export async function processNews(rawItem: unknown, deps: PipelineDeps): Promise
       if (!gate1.tradeable || !gate1.tickers.length) {
         const signal = buildSignal(item, gate1, fingerprint, null, null, coverage);
         writeJsonAtomic(path.join(paths.signalsDir(), `${signal.id}.json`), { ...signal, title: item.title });
-        appendLedger({ type: "signal_archived", signalId: signal.id, newsId: item.id, why: gate1.reason, engine: g1.engine });
+        // fallbackReason distinguishes the designed zero-LLM rules path
+        // (out-of-universe items) from a real claude-cli failure that degraded
+        // into it — without it both look identical in the ledger.
+        appendLedger({
+          type: "signal_archived",
+          signalId: signal.id,
+          newsId: item.id,
+          why: gate1.reason,
+          engine: g1.engine,
+          fallbackReason: g1.fallbackReason
+        });
         finishRun(run, `归档:未过重要性闸门(${gate1.reason.slice(0, 80)})`);
         return;
       }
@@ -285,7 +295,8 @@ export async function processNews(rawItem: unknown, deps: PipelineDeps): Promise
         pricedIn: pricedIn.status,
         deltaTMinutes: pricedIn.deltaTMinutes,
         t0Utc: new Date(t0Ms).toISOString(),
-        engine: g1.engine
+        engine: g1.engine,
+        fallbackReason: g1.fallbackReason
       });
 
       if (!["none", "partial", "leaked"].includes(pricedIn.status)) {

--- a/services/delta-pm/src/store.test.ts
+++ b/services/delta-pm/src/store.test.ts
@@ -6,6 +6,7 @@ import type { NewsItem } from "@autopoly/delta-pm-contracts";
 import {
   acquireBookLock,
   appendLedger,
+  findNewsIdByUrl,
   loadNewsItem,
   paths,
   readJson,
@@ -112,5 +113,19 @@ describe("news source-of-truth archive", () => {
     const res = upsertNewsItem(item({ fullText: null }));
     expect(res.fullTextAttached).toBe(false);
     expect(res.item.fullText).toBe("attached earlier");
+  });
+
+  it("resolves identity by URL so a second id for the same story finds the original", () => {
+    upsertNewsItem(item());
+    expect(findNewsIdByUrl("https://www.theinformation.com/articles/x")).toBe(item().id);
+    expect(findNewsIdByUrl("https://www.theinformation.com/articles/x/?utm_campaign=rss")).toBe(item().id);
+    expect(findNewsIdByUrl("https://www.theinformation.com/articles/never-seen")).toBeNull();
+    expect(findNewsIdByUrl(null)).toBeNull();
+  });
+
+  it("the earliest arrival owns a URL when two ids already claim it", () => {
+    upsertNewsItem(item({ id: "sitemap:https://www.theinformation.com/articles/x", fetchedAtUtc: "2026-08-25T06:39:00.000Z" }));
+    upsertNewsItem(item({ fetchedAtUtc: "2026-08-23T08:05:00.000Z" }));
+    expect(findNewsIdByUrl("https://www.theinformation.com/articles/x")).toBe(item().id);
   });
 });

--- a/services/delta-pm/src/store.ts
+++ b/services/delta-pm/src/store.ts
@@ -72,6 +72,60 @@ export function loadNewsItem(newsId: string): NewsItem | null {
   return parsed.success && parsed.data.id === newsId ? parsed.data : null;
 }
 
+// The same article can arrive under two ids: the Atom entry id from the feed
+// (`tag:...`) and `sitemap:<url>` from the gap backfill. Identity therefore
+// also resolves by URL — the FIRST record to claim a URL owns it, so a second
+// arrival is a re-ingest of the original (t0 preserved), not a second signal.
+// The index is per-root and rebuilt lazily so tests can swap artifact roots.
+interface UrlClaim {
+  id: string;
+  fetchedAtUtc: string;
+}
+
+let urlIndexDir: string | null = null;
+let urlIndex: Map<string, UrlClaim> | null = null;
+
+export function normalizeNewsUrl(url: string): string {
+  return url.trim().replace(/[?#].*$/, "").replace(/\/+$/, "").toLowerCase();
+}
+
+function newsUrlIndex(): Map<string, UrlClaim> {
+  const dir = paths.newsDir();
+  if (urlIndex && urlIndexDir === dir) return urlIndex;
+  const index = new Map<string, UrlClaim>();
+  if (existsSync(dir)) {
+    for (const file of readdirSync(dir)) {
+      if (!file.endsWith(".json")) continue;
+      const parsed = newsItemSchema.safeParse(readJson<unknown>(path.join(dir, file)));
+      if (!parsed.success) continue;
+      claimUrl(index, parsed.data);
+    }
+  }
+  urlIndex = index;
+  urlIndexDir = dir;
+  return index;
+}
+
+// Earliest arrival owns the URL — the same rule the merge uses for identity,
+// applied identically whether the index is rebuilt from disk or updated live.
+function claimUrl(index: Map<string, UrlClaim>, item: NewsItem): void {
+  if (!item.url) return;
+  const key = normalizeNewsUrl(item.url);
+  const incumbent = index.get(key);
+  if (incumbent && incumbent.fetchedAtUtc <= item.fetchedAtUtc) return;
+  index.set(key, { id: item.id, fetchedAtUtc: item.fetchedAtUtc });
+}
+
+function rememberNewsUrl(item: NewsItem): void {
+  claimUrl(newsUrlIndex(), item);
+}
+
+// Canonical news id that already owns this URL, or null when the URL is new.
+export function findNewsIdByUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  return newsUrlIndex().get(normalizeNewsUrl(url))?.id ?? null;
+}
+
 export interface NewsUpsertResult {
   item: NewsItem; // the merged record actually persisted
   existed: boolean; // a record for this id was already on disk (=> this is a re-ingest)
@@ -86,6 +140,7 @@ export function upsertNewsItem(incoming: NewsItem): NewsUpsertResult {
   const existing = loadNewsItem(incoming.id);
   if (!existing) {
     writeJsonAtomic(newsFile(incoming.id), incoming);
+    rememberNewsUrl(incoming);
     return { item: incoming, existed: false, fullTextAttached: Boolean(incoming.fullText) };
   }
   const merged: NewsItem = {
@@ -97,6 +152,7 @@ export function upsertNewsItem(incoming: NewsItem): NewsUpsertResult {
     updatedUtc: incoming.updatedUtc ?? existing.updatedUtc
   };
   writeJsonAtomic(newsFile(incoming.id), merged);
+  rememberNewsUrl(merged);
   return { item: merged, existed: true, fullTextAttached: Boolean(incoming.fullText && !existing.fullText) };
 }
 


### PR DESCRIPTION
## 问题

`backfillFromSitemap` 只按 id 去重，那句 `state.seenIds.some((s) => s.includes(loc))` 永远匹配不上——feed 的 id 是 Atom tag URI（`tag:www.theinformation.com,2005:Briefing/17919`），里面根本没有文章 URL。结果：**每次重启（以及每次轮询中断 >1h）都会把 48h sitemap 窗口整个重新收一遍**，同一篇报道以 `sitemap:<url>` 的第二身份再走一次全流程。

2026-08-25 在东京 VM 实测（部署 #124 重启 delta-pm 时抓到）：

- 一次重启重放 16 条已判过的新闻，每条都付了闸门 1 + ~15s 跨源既有报道检索的钱
- 新闻存档从 20 条涨到 36 条，其中含重复身份（违反"首条记录拥有身份+时间"）
- 校准切片被污染：`news_seen` 重复计数，Δt 中位被回填条目的旧 published 拉到 408 分钟

## 改法

身份判定从"只看 id"扩到"id + URL"：

- `store.ts`：新闻存档维护 URL→id 索引（**最早到达者拥有该 URL**，与 merge 的身份/时间规则一致），导出 `findNewsIdByUrl`；索引按 artifacts root 缓存，落盘与内存走同一条规则
- `feed.ts`：抽出纯函数 `parseSitemap` + `selectSitemapBackfill`（可测），回填按 id **和** URL 双重过滤；feed 真正漏掉的报道照常补回
- `run-cycle.ts`：入口做身份归一——URL 已被别的 id 占据时，本次 ingest 折叠进原记录（t0 不变）；这种跨通路重复若没带来新原文，记一条 `news_duplicate_url` 后直接返回，不再进闸门。粘贴补全原文（带 fullText）不受影响，照常重跑

## 验证

- 新增 6 个测试：sitemap 解析、feed 已存档故事被跳过（本 bug 的回归测试）、feed 漏掉的照常补、URL 归一化（尾斜杠/query）、`findNewsIdByUrl`、最早到达者优先
- `pnpm test` 121 files / 1085 tests 全绿；`pnpm typecheck` 全绿
- 未部署到 VM——delta-pm 当前跑的是本 PR 之前的 main（含 #124）