### PR TITLE
fix: show Claude burn as tokens only

### DIFF
--- a/scripts/fleet/quota-monitor.test.ts
+++ b/scripts/fleet/quota-monitor.test.ts
@@ -3,6 +3,7 @@ import {
   aggregateBurn,
   bar,
   burnCeilingAlertEnabled,
+  burnStatsTokenOnly,
   buildDailyCard,
   digestDue,
   extractLatestRateLimits,
@@ -83,6 +84,19 @@ describe("burn ceiling alert configuration", () => {
   it("accepts a comma-separated list and defaults to enabled", () => {
     expect(burnCeilingAlertEnabled("claudeBurn", "")).toBe(true);
     expect(burnCeilingAlertEnabled("kimiBurn", " claudeBurn, kimiBurn ")).toBe(false);
+  });
+});
+
+describe("burn statistics presentation", () => {
+  it("can reduce Claude to raw token counts without changing Kimi", () => {
+    const tokenOnly = "claudeBurn";
+    expect(burnStatsTokenOnly("claudeBurn", tokenOnly)).toBe(true);
+    expect(burnStatsTokenOnly("kimiBurn", tokenOnly)).toBe(false);
+  });
+
+  it("accepts a comma-separated list and defaults to detailed output", () => {
+    expect(burnStatsTokenOnly("claudeBurn", "")).toBe(false);
+    expect(burnStatsTokenOnly("kimiBurn", " claudeBurn, kimiBurn ")).toBe(true);
   });
 });
 
@@ -231,11 +245,18 @@ describe("transcript burn accounting", () => {
     expect(fmtTokens(5_320_000)).toBe("5.3M");
   });
 
-  it("burn stats render into the card when the official endpoint is silent", () => {
+  it("Claude burn stats render as token counts only", () => {
     const card = buildDailyCard(
       {
-        claude: { status: "rate-limited" },
-        claudeBurn: { fiveHourTokens: 1_200_000, fiveHourCalls: 40, sevenDayTokens: 9_800_000, sevenDayCalls: 300 },
+        claude: { fields: [{ label: "five_hour", percent: 94 }] },
+        claudeBurn: {
+          fiveHourTokens: 1_200_000,
+          fiveHourCalls: 40,
+          sevenDayTokens: 9_800_000,
+          sevenDayCalls: 300,
+          ceilingTokens: 1_276_596,
+          usedPercent: 94
+        },
         kimiBurn: { fiveHourTokens: 0, fiveHourCalls: 0, sevenDayTokens: 350_000, sevenDayCalls: 12 },
         books: []
       },
@@ -244,7 +265,10 @@ describe("transcript burn accounting", () => {
     );
     const blob = JSON.stringify(card);
     expect(blob).toContain("按本机实测消耗");
-    expect(blob).toContain("近 5 小时 1.2M tokens（40 条消息）");
+    expect(blob).toContain("近 5 小时 1.2M tokens · 近 7 天 9.8M tokens");
+    expect(blob).not.toContain("40 条消息");
+    expect(blob).not.toContain("撞限水位");
+    expect(blob).not.toContain("94%");
     expect(blob).toContain("Kimi Code（kimi-k3 书）");
     expect(blob).toContain("近 7 天 350k tokens");
   });

--- a/scripts/fleet/quota-monitor.ts
+++ b/scripts/fleet/quota-monitor.ts
@@ -118,6 +118,16 @@ export function burnCeilingAlertEnabled(
   return !disabled.has(key);
 }
 
+export function burnStatsTokenOnly(
+  key: "claudeBurn" | "kimiBurn",
+  tokenOnlyRaw = process.env.MONITOR_TOKEN_ONLY_BURN_BUCKETS || ""
+): boolean {
+  const tokenOnly = new Set(
+    tokenOnlyRaw.split(",").map((item) => item.trim()).filter(Boolean)
+  );
+  return tokenOnly.has(key);
+}
+
 // ---- Codex subscription waterline -----------------------------------------
 // Every persisted codex session rollout records rate_limits snapshots:
 //   {"rate_limits":{"primary":{"used_percent":1.0,"window_minutes":10080,
@@ -277,16 +287,12 @@ export function buildDailyCard(summary: MonitorSummary, findings: Finding[], now
   } else {
     md.push("Codex（GPT-5.6 两本书）：暂无快照");
   }
-  if (summary.claude && "fields" in summary.claude && summary.claude.fields.length) {
+  if (summary.claudeBurn) {
+    const cb = summary.claudeBurn;
+    md.push(`Claude 订阅（按本机实测消耗，含 fleet 外任务）\n近 5 小时 ${fmtTokens(cb.fiveHourTokens)} tokens · 近 7 天 ${fmtTokens(cb.sevenDayTokens)} tokens`);
+  } else if (summary.claude && "fields" in summary.claude && summary.claude.fields.length) {
     for (const f of summary.claude.fields) {
       md.push(`Claude 订阅（三本书 + 本机其他任务）\n\`${bar(f.percent)}\` ${f.label} 已用 ${f.percent.toFixed(0)}%`);
-    }
-  } else if (summary.claudeBurn) {
-    const cb = summary.claudeBurn;
-    if (cb.usedPercent !== undefined) {
-      md.push(`Claude 订阅（按本机实测消耗）\n\`${bar(cb.usedPercent)}\` 5 小时窗已用约 ${cb.usedPercent.toFixed(0)}%（对照上次撞限水位）· 近 7 天 ${fmtTokens(cb.sevenDayTokens)} tokens`);
-    } else {
-      md.push(`Claude 订阅（按本机实测消耗，含 fleet 外任务）\n近 5 小时 ${fmtTokens(cb.fiveHourTokens)} tokens（${cb.fiveHourCalls} 条消息）· 近 7 天 ${fmtTokens(cb.sevenDayTokens)} tokens · 尚未撞过限，暂无百分比基准`);
     }
   } else {
     md.push("Claude 订阅：本机暂无消耗记录");
@@ -586,13 +592,15 @@ function checkTranscriptBurn(findings: Finding[], lines: string[], summary: Moni
   for (const b of buckets) {
     const stats = aggregateBurn(entries, now.getTime(), b.match);
     const ceiling = ceilings[b.key];
-    if (ceiling && ceiling > 0) {
+    const tokenOnly = burnStatsTokenOnly(b.key);
+    if (ceiling && ceiling > 0 && !tokenOnly) {
       stats.ceilingTokens = ceiling;
       stats.usedPercent = Math.min(100, (stats.fiveHourTokens / ceiling) * 100);
     }
     summary[b.key] = stats;
     const pct = stats.usedPercent !== undefined ? ` | ~${stats.usedPercent.toFixed(0)}% of observed 5h ceiling` : "";
-    lines.push(`${b.label.padEnd(12)} | 5h ${fmtTokens(stats.fiveHourTokens)} tok / ${stats.fiveHourCalls} msg | 7d ${fmtTokens(stats.sevenDayTokens)} tok${pct}`);
+    const calls = tokenOnly ? "" : ` / ${stats.fiveHourCalls} msg`;
+    lines.push(`${b.label.padEnd(12)} | 5h ${fmtTokens(stats.fiveHourTokens)} tok${calls} | 7d ${fmtTokens(stats.sevenDayTokens)} tok${pct}`);
     if (stats.usedPercent !== undefined && burnCeilingAlertEnabled(b.key)) {
       if (stats.usedPercent >= SUB_USED_CRIT_PCT) findings.push({ topic: `${b.key}-ceiling`, severity: "critical", message: `${b.label} 5 小时窗消耗已达上次撞限水位的 ${stats.usedPercent.toFixed(0)}%。` });
       else if (stats.usedPercent >= SUB_USED_WARN_PCT) findings.push({ topic: `${b.key}-ceiling`, severity: "warn", message: `${b.label} 5 小时窗消耗达上次撞限水位的 ${stats.usedPercent.toFixed(0)}%。` });


### PR DESCRIPTION
## Summary
- render Claude daily usage as raw 5-hour and 7-day token counts only
- suppress empirical ceiling percentages, bars, and message counts for configured token-only buckets
- preserve real provider failure and rate-limit alerts

## Test
- pnpm exec vitest run scripts/fleet/quota-monitor.test.ts (22/22)