### PR TITLE
fix: stop Claude ceiling calibration in token-only mode

### DIFF
--- a/scripts/fleet/quota-monitor.ts
+++ b/scripts/fleet/quota-monitor.ts
@@ -616,6 +616,7 @@ function checkTranscriptBurn(findings: Finding[], lines: string[], summary: Moni
     const book = m[1]!;
     const key = claudeBooks.includes(book) ? "claudeBurn" : book.includes("kimi") ? "kimiBurn" : null;
     if (!key) continue;
+    if (burnStatsTokenOnly(key)) continue;
     const current = (summary[key as "claudeBurn" | "kimiBurn"])?.fiveHourTokens ?? 0;
     if (current > (ceilings[key] ?? 0)) {
       ceilings[key] = current;


### PR DESCRIPTION
## Summary
- skip historical ceiling calibration for token-only burn buckets
- remove the final Claude ceiling-related terminal message

## Test
- pnpm exec vitest run scripts/fleet/quota-monitor.test.ts (22/22)