### PR TITLE
feat(forecast-engine): add Exa web-search backend

### DIFF
--- a/packages/forecast-engine/src/web-search.test.ts
+++ b/packages/forecast-engine/src/web-search.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { fetchPageText, parseDuckDuckGoHtml, stripTags } from "./web-search";
+import { fetchPageText, parseDuckDuckGoHtml, stripTags, webSearch } from "./web-search";
 import { webSearchEnabled } from "./deepseek-agent";
 
 const DDG_FIXTURE = `
@@ -25,6 +25,57 @@ describe("parseDuckDuckGoHtml", () => {
       snippet: "BTC fell below $60,000 amid ETF outflows …"
     });
     expect(hits[1]?.url).toBe("https://coindesk.com/direct-link");
+  });
+});
+
+describe("exa backend", () => {
+  const prevPin = process.env.FORECAST_WEB_SEARCH;
+  const prevKey = process.env.EXA_API_KEY;
+  afterEach(() => {
+    if (prevPin === undefined) delete process.env.FORECAST_WEB_SEARCH;
+    else process.env.FORECAST_WEB_SEARCH = prevPin;
+    if (prevKey === undefined) delete process.env.EXA_API_KEY;
+    else process.env.EXA_API_KEY = prevKey;
+  });
+
+  it("maps exa results to SearchHit and sends the api key header", async () => {
+    process.env.FORECAST_WEB_SEARCH = "exa";
+    process.env.EXA_API_KEY = "test-key";
+    let captured: { url: string; init?: RequestInit } | null = null;
+    const fake = (async (url: string, init?: RequestInit) => {
+      captured = { url, init };
+      return {
+        ok: true,
+        json: async () => ({
+          results: [
+            { title: "Hunyuan Hy4 preview", url: "https://example.com/hy4", text: "Tencent released…" },
+            { title: "", url: "", text: "dropped: no url" }
+          ]
+        })
+      };
+    }) as unknown as typeof fetch;
+    const hits = await webSearch("tencent hy4", fake);
+    expect(hits).toEqual([
+      { title: "Hunyuan Hy4 preview", url: "https://example.com/hy4", snippet: "Tencent released…" }
+    ]);
+    expect(captured!.url).toBe("https://api.exa.ai/search");
+    const headers = captured!.init?.headers as Record<string, string>;
+    expect(headers["x-api-key"]).toBe("test-key");
+    expect(JSON.parse(String(captured!.init?.body)).numResults).toBeGreaterThan(0);
+  });
+
+  it("prefers exa over tavily when both keys are set and no pin is given", async () => {
+    delete process.env.FORECAST_WEB_SEARCH;
+    process.env.EXA_API_KEY = "test-key";
+    process.env.TAVILY_API_KEY = "tavily-key";
+    let calledUrl = "";
+    const fake = (async (url: string) => {
+      calledUrl = url;
+      return { ok: true, json: async () => ({ results: [] }) };
+    }) as unknown as typeof fetch;
+    await webSearch("q", fake);
+    expect(calledUrl).toBe("https://api.exa.ai/search");
+    delete process.env.TAVILY_API_KEY;
   });
 });
 

--- a/packages/forecast-engine/src/web-search.ts
+++ b/packages/forecast-engine/src/web-search.ts
@@ -2,9 +2,10 @@
 // (DeepSeek/Kimi), used by the tool loop in deepseek-agent.ts.
 //
 // Backends, in preference order:
+//   - exa         when EXA_API_KEY is set (neural + keyword search, paid)
 //   - tavily      when TAVILY_API_KEY is set (reliable, 1k free credits/mo)
 //   - duckduckgo  keyless default (HTML endpoint; fine at this call volume)
-// The backend can be pinned via FORECAST_WEB_SEARCH=tavily|duckduckgo.
+// The backend can be pinned via FORECAST_WEB_SEARCH=exa|tavily|duckduckgo.
 
 export interface SearchHit {
   title: string;
@@ -18,11 +19,32 @@ const PAGE_TIMEOUT_MS = 12_000;
 const PAGE_TEXT_CAP = 6_000;
 const UA = "Mozilla/5.0 (X11; Linux x86_64) raven-forecast-research/1.0";
 
-function backendName(): "tavily" | "duckduckgo" {
+function backendName(): "exa" | "tavily" | "duckduckgo" {
   const pin = (process.env.FORECAST_WEB_SEARCH ?? "").trim().toLowerCase();
+  if (pin === "exa") return "exa";
   if (pin === "tavily") return "tavily";
   if (pin === "duckduckgo") return "duckduckgo";
+  if (process.env.EXA_API_KEY) return "exa";
   return process.env.TAVILY_API_KEY ? "tavily" : "duckduckgo";
+}
+
+async function exaSearch(query: string, fetchFn: typeof fetch): Promise<SearchHit[]> {
+  const res = await fetchFn("https://api.exa.ai/search", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-api-key": process.env.EXA_API_KEY ?? "" },
+    body: JSON.stringify({
+      query,
+      numResults: MAX_HITS,
+      contents: { text: { maxCharacters: 300 } }
+    }),
+    signal: AbortSignal.timeout(SEARCH_TIMEOUT_MS)
+  });
+  if (!res.ok) throw new Error(`exa search ${res.status}`);
+  const data = (await res.json()) as { results?: Array<{ title?: string; url?: string; text?: string }> };
+  return (data.results ?? [])
+    .filter((r) => r.url)
+    .slice(0, MAX_HITS)
+    .map((r) => ({ title: r.title ?? "", url: r.url!, snippet: (r.text ?? "").slice(0, 300) }));
 }
 
 async function tavilySearch(query: string, fetchFn: typeof fetch): Promise<SearchHit[]> {
@@ -78,7 +100,9 @@ async function duckDuckGoSearch(query: string, fetchFn: typeof fetch): Promise<S
 }
 
 export async function webSearch(query: string, fetchFn: typeof fetch = fetch): Promise<SearchHit[]> {
-  return backendName() === "tavily" ? tavilySearch(query, fetchFn) : duckDuckGoSearch(query, fetchFn);
+  const backend = backendName();
+  if (backend === "exa") return exaSearch(query, fetchFn);
+  return backend === "tavily" ? tavilySearch(query, fetchFn) : duckDuckGoSearch(query, fetchFn);
 }
 
 export function stripTags(html: string): string {


### PR DESCRIPTION
## Summary
- Add `exa` as a web-search backend for the OpenAI-compatible provider tool loop, preferred when `EXA_API_KEY` is set; pinnable via `FORECAST_WEB_SEARCH=exa`.
- Env-gated and additive: without `EXA_API_KEY`, behavior is byte-for-byte unchanged (tavily/duckduckgo order intact).

## Verification
- `vitest`: 6/6 pass (new tests: exa result mapping + header, preference order over tavily)
- `tsc --noEmit` for the package: pass
- `pnpm --filter @autopoly/web build`: pass (no UI changes, screenshot review n/a)
- Live check: exa returned 8 high-quality hits (tencent.com official / HuggingFace / GitHub / Reuters) for a query where duckduckgo yielded 1 weak source in an engine smoke run

🤖 Generated with [Claude Code](https://claude.com/claude-code)