### PR TITLE
Allow readers to download Meta report history CSV

### DIFF
--- a/apps/web/app/[locale]/investment-analysis/[slug]/page.tsx
+++ b/apps/web/app/[locale]/investment-analysis/[slug]/page.tsx
@@ -98,7 +98,7 @@ export default async function InvestmentReportPage({
         src={report.src}
         title={t(locale, report.iframeTitleKey)}
         sandbox={report.interactive
-          ? "allow-scripts allow-popups allow-popups-to-escape-sandbox"
+          ? "allow-scripts allow-downloads allow-popups allow-popups-to-escape-sandbox"
           : "allow-popups allow-popups-to-escape-sandbox"}
       />
     </main>

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -31,7 +31,7 @@
 | AI 投研系统案例 | `apps/web/app/[locale]/investment-analysis`、`/investment-analysis` | 三份公开案例：腾讯混元 × WorkBuddy、Hassabis × Alphabet、[Meta 半年资本开支](https://forecasting-agent.com/investment-analysis/meta-capex-6m)（v3，截点 2026-09-06） |
 | Polymarket live pipeline | `services/orchestrator`、`services/executor` | 真钱路径；任何 live 命令、风控调整或订单测试都需要用户明确确认 |
 
-后续投资资料统一去除客户品牌标签。Meta v3 公开经过复核的来源摘要与审计附件，完整字幕留在本地；仅该报告 iframe 开放脚本用于金额演算，仍不授予 `allow-same-origin`。
+后续投资资料统一去除客户品牌标签。Meta v3 公开经过复核的来源摘要与审计附件，完整字幕留在本地；仅该报告 iframe 开放脚本用于金额演算，并允许用户下载历史 CSV，仍不授予 `allow-same-origin`。
 
 ## 3. 当前最主要的技术 WIP：GPT Pro v2 harness
 
@@ -96,6 +96,8 @@
 - [ ] 对 FutureX、LongPort MCP、Time Machine 三项分别做 go / archive 产品判断；任何一项获批后都从最新 `main` 建独立小 PR。
 
 ### P2 — 已知但不阻塞
+
+- [ ] `paper-agent` 的 `market-scan.test.ts` 有两项固定日期测试于 2026-09-01 过期，当前 CI 因此失败；测试和实现与发布前主线一致。后续应固定测试时钟，勿修改实际到期过滤规则来迎合测试。
 
 - [ ] 东京 VM 根盘使用率 82%（约 8.6 GiB 可用）；继续监控，并在部署新镜像前先做可恢复的缓存 / 旧镜像清理。
 - [ ] 将 live Pulse 的结算回填 / 离线评分按当前 ledger 重新设计；不要直接搬 PR #77 的旧实现。

--- a/docs/en/agent-handoff.md
+++ b/docs/en/agent-handoff.md
@@ -31,7 +31,7 @@
 | AI investment research cases | `apps/web/app/[locale]/investment-analysis`, `/investment-analysis` | Three public cases: Tencent Hunyuan × WorkBuddy, Hassabis × Alphabet, and [Meta six-month capex](https://forecasting-agent.com/investment-analysis/meta-capex-6m) (v3, as of 2026-09-06) |
 | Polymarket live pipeline | `services/orchestrator`, `services/executor` | Real-money path; live runs, risk changes, and order probes require explicit user approval |
 
-Investment reports omit customer branding from now on. Meta v3 publishes reviewed source summaries and audit attachments; full transcripts remain local. Only its iframe permits scripts, without `allow-same-origin`, for the spending calculator.
+Investment reports omit customer branding from now on. Meta v3 publishes reviewed source summaries and audit attachments; full transcripts remain local. Only its iframe permits scripts, without `allow-same-origin`, for the spending calculator and permits user-initiated historical CSV downloads.
 
 ## 3. Primary technical WIP: GPT Pro v2 harness
 
@@ -96,6 +96,8 @@ These are independent products. Do not bundle them into the GPT Pro provider PR 
 - [ ] Make independent go/archive decisions for FutureX, LongPort MCP, and Time Machine. Any approved direction starts as its own small PR from current `main`.
 
 ### P2 — Known, non-blocking
+
+- [ ] Two fixed-date `paper-agent` tests in `market-scan.test.ts` expired on 2026-09-01 and now fail CI; both the tests and implementation match the pre-publication baseline. Pin the test clock in a follow-up without changing the actual expiry filter to satisfy fixtures.
 
 - [ ] The Tokyo VM root disk is 82% used (about 8.6 GiB free). Keep monitoring it and perform recoverable cache / old-image cleanup before the next image deployment.
 - [ ] Redesign live Pulse settlement backfill / offline scoring against the current ledger; do not raw-port PR #77.


### PR DESCRIPTION
The Meta report's historical CSV link was blocked by the browser's iframe download sandbox. Permit downloads only for the interactive Meta report so a reader can click the CSV link and receive `history.csv`. The iframe still omits `allow-same-origin`; the other reports retain their existing sandbox.

Validation: the web production build passed. Real browser clicks passed for all three case links, all three language options and the CSV download from inside the Meta iframe, with no console errors. Desktop and mobile layouts were inspected during the publication checks. The bilingual handoff also records the pre-existing two expired-date paper-agent tests reported in PR #146; production filtering is unchanged.
