### PR TITLE
Keep investment language links on public report URLs

### DIFF
--- a/apps/web/lib/investment-analysis/routes.test.ts
+++ b/apps/web/lib/investment-analysis/routes.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { investmentHref, stripInvestmentLocale } from "./routes";
+
+describe("investment report language navigation", () => {
+  it.each([
+    "/investment-analysis/meta-capex-6m",
+    "/investment-analysis/meta-capex-6m/en",
+    "/investment-analysis/meta-capex-6m/zh-TW/",
+    "/zh-CN/investment-analysis/meta-capex-6m",
+    "/apps/web/zh-CN/investment-analysis/meta-capex-6m",
+    "/apps/web/en/investment-analysis/meta-capex-6m",
+    "/apps/web/zh-TW/investment-analysis/meta-capex-6m"
+  ])("keeps language links public when the current path is %s", (pathname) => {
+    const current = stripInvestmentLocale(pathname);
+    expect(investmentHref(current, "en")).toBe("/investment-analysis/meta-capex-6m/en");
+    expect(investmentHref(current, "zh-CN")).toBe("/investment-analysis/meta-capex-6m");
+    expect(investmentHref(current, "zh-TW")).toBe("/investment-analysis/meta-capex-6m/zh-TW");
+  });
+
+  it("switches the collection language without leaking the deployment path", () => {
+    expect(investmentHref(stripInvestmentLocale("/apps/web/zh-CN/investment-analysis"), "en"))
+      .toBe("/investment-analysis/en");
+  });
+});

--- a/apps/web/lib/investment-analysis/routes.ts
+++ b/apps/web/lib/investment-analysis/routes.ts
@@ -14,6 +14,7 @@ export function investmentHref(path: string, locale: Locale): string {
 }
 
 export function stripInvestmentLocale(pathname: string): string {
-  const withoutTrailingLocale = pathname.replace(/\/(en|zh-CN|zh-TW)\/?$/, "");
+  const withoutAppPrefix = pathname.replace(/^\/apps\/web(?=\/|$)/, "");
+  const withoutTrailingLocale = withoutAppPrefix.replace(/\/(en|zh-CN|zh-TW)\/?$/, "");
   return withoutTrailingLocale.replace(/^\/(en|zh-CN|zh-TW)(?=\/)/, "") || "/investment-analysis";
 }


### PR DESCRIPTION
On the production report page, clicking English produced `/apps/web/zh-CN/investment-analysis/meta-capex-6m/en` because `usePathname()` exposed Vercel's internal deployment prefix. Strip that prefix before normalizing the locale, so language links consistently use `/investment-analysis/meta-capex-6m/en` and retain the current report.

Eight route regression cases pass, including the exact production path, all three locales, public paths and the collection. The web production build passes. This preserves the existing report content, appearance, scripts and download permissions. Full browser publication checks cover desktop/mobile layout and actual navigation; the known unrelated expired-date paper-agent tests are documented in the handoff.
