### PR TITLE
Remove sandbox restrictions from investment report containers

### DIFF
--- a/apps/web/app/[locale]/investment-analysis/[slug]/page.tsx
+++ b/apps/web/app/[locale]/investment-analysis/[slug]/page.tsx
@@ -13,7 +13,7 @@ const ORIGIN = "https://forecasting-agent.com";
 
 const REPORTS: Record<
   InvestmentCaseSlug,
-  { titleKey: StrKey; descriptionKey: StrKey; iframeTitleKey: StrKey; src: string; interactive?: boolean }
+  { titleKey: StrKey; descriptionKey: StrKey; iframeTitleKey: StrKey; src: string }
 > = {
   "tencent-hunyuan-workbuddy": {
     titleKey: "iaTencentMetaTitle",
@@ -31,8 +31,7 @@ const REPORTS: Record<
     titleKey: "iaMetaCapexMetaTitle",
     descriptionKey: "iaMetaCapexMetaDescription",
     iframeTitleKey: "iaMetaCapexFrameTitle",
-    src: "/investment-analysis/reports/meta-capex-6m.html",
-    interactive: true
+    src: "/investment-analysis/reports/meta-capex-6m.html"
   }
 };
 
@@ -97,9 +96,6 @@ export default async function InvestmentReportPage({
         className={styles.reportFrame}
         src={report.src}
         title={t(locale, report.iframeTitleKey)}
-        sandbox={report.interactive
-          ? "allow-scripts allow-downloads allow-popups allow-popups-to-escape-sandbox"
-          : "allow-popups allow-popups-to-escape-sandbox"}
       />
     </main>
   );

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -31,7 +31,7 @@
 | AI 投研系统案例 | `apps/web/app/[locale]/investment-analysis`、`/investment-analysis` | 三份公开案例：腾讯混元 × WorkBuddy、Hassabis × Alphabet、[Meta 半年资本开支](https://forecasting-agent.com/investment-analysis/meta-capex-6m)（v3，截点 2026-09-06） |
 | Polymarket live pipeline | `services/orchestrator`、`services/executor` | 真钱路径；任何 live 命令、风控调整或订单测试都需要用户明确确认 |
 
-后续投资资料统一去除客户品牌标签。Meta v3 公开经过复核的来源摘要与审计附件，完整字幕留在本地；仅该报告 iframe 开放脚本用于金额演算，并允许用户下载历史 CSV，仍不授予 `allow-same-origin`。
+后续投资资料统一去除客户品牌标签。Meta v3 公开经过复核的来源摘要与审计附件，完整字幕留在本地；按用户要求，本站报告 iframe 统一不设置 `sandbox`，脚本交互与附件下载正常启用；新报告沿用同一容器，不再按公司单独放行。
 
 ## 3. 当前最主要的技术 WIP：GPT Pro v2 harness
 

--- a/docs/en/agent-handoff.md
+++ b/docs/en/agent-handoff.md
@@ -31,7 +31,7 @@
 | AI investment research cases | `apps/web/app/[locale]/investment-analysis`, `/investment-analysis` | Three public cases: Tencent Hunyuan × WorkBuddy, Hassabis × Alphabet, and [Meta six-month capex](https://forecasting-agent.com/investment-analysis/meta-capex-6m) (v3, as of 2026-09-06) |
 | Polymarket live pipeline | `services/orchestrator`, `services/executor` | Real-money path; live runs, risk changes, and order probes require explicit user approval |
 
-Investment reports omit customer branding from now on. Meta v3 publishes reviewed source summaries and audit attachments; full transcripts remain local. Only its iframe permits scripts, without `allow-same-origin`, for the spending calculator and permits user-initiated historical CSV downloads.
+Investment reports omit customer branding from now on. Meta v3 publishes reviewed source summaries and audit attachments; full transcripts remain local. Per the user request, first-party report iframes omit `sandbox`, so scripts and attachment downloads work normally. Future reports use the same container without company-specific exceptions.
 
 ## 3. Primary technical WIP: GPT Pro v2 harness
 


### PR DESCRIPTION
All first-party investment reports now use normal HTML browser behavior for scripts and attachment downloads. Remove the iframe sandbox and the Meta-only `interactive` flag, so Tencent, Google, Meta and future entries share the same container. The report catalog continues to select fixed, first-party HTML files. The bilingual handoff records this default.

Validation: the web production build passed. Real browser probes executed scripts inside all three reports and confirmed that each iframe has no sandbox attribute. Meta scenario controls and the historical CSV download passed on desktop and mobile, with no console errors or horizontal overflow; both screenshots were inspected. Report contents and attachment URLs are unchanged. The unrelated expired-date paper-agent CI tests remain documented in the handoff.
