### PR TITLE
Clarify Meta capex forecast priorities and replace the calculator

### DIFF
--- a/apps/web/lib/world-cup/messages/en.json
+++ b/apps/web/lib/world-cup/messages/en.json
@@ -289,10 +289,10 @@
   "iaGoogleFrameTitle": "Full Demis Hassabis and Alphabet investment analysis report in Chinese",
   "iaMetaCapexCompany": "Meta Platforms · Capital expenditure",
   "iaMetaCapexTitle": "Will Meta formally lower its capex plan within six months?",
-  "iaMetaCapexSummary": "A Chinese-language report examining servers, data centers and networks, with official disclosures, video transcripts, social research and an interactive spending calculator.",
+  "iaMetaCapexSummary": "A Chinese-language report connecting asset purchases, prices and payment timing to Meta’s total capex plan, with official disclosures, video transcripts, social research and four interactive scenarios.",
   "iaMetaCapexSignalLabel": "Formal cut probability · 6 months",
   "iaMetaCapexSignal": "32% · NO 68%",
   "iaMetaCapexMetaTitle": "Meta six-month capex forecast — Predict Raven",
-  "iaMetaCapexMetaDescription": "A six-month forecast as of September 6, 2026: YES 32%, subjective range 20–45%, with an asset breakdown, component forecasts and an interactive spending calculator.",
+  "iaMetaCapexMetaDescription": "A six-month forecast as of September 6, 2026: YES 32%, subjective range 20–45%, with research priorities, asset forecasts and four interactive scenario explanations.",
   "iaMetaCapexFrameTitle": "Full Meta six-month capital expenditure report in Chinese"
 }

--- a/apps/web/lib/world-cup/messages/zh-CN.json
+++ b/apps/web/lib/world-cup/messages/zh-CN.json
@@ -289,10 +289,10 @@
   "iaGoogleFrameTitle": "Demis Hassabis 与 Alphabet 完整投资分析报告",
   "iaMetaCapexCompany": "Meta Platforms · 资本开支",
   "iaMetaCapexTitle": "Meta 会在半年内正式下调资本开支计划吗？",
-  "iaMetaCapexSummary": "按服务器、数据中心、网络等资产拆分预算方向与下修风险，结合原始披露、视频字幕及社交研究，并提供交互式金额演算。",
+  "iaMetaCapexSummary": "沿服务器、数据中心、网络等资产判断数量、价格与付款时点，综合原始披露、视频字幕及社交研究，用四种情形解释何时会下调总计划。",
   "iaMetaCapexSignalLabel": "半年内正式下调概率",
   "iaMetaCapexSignal": "32% · NO 68%",
   "iaMetaCapexMetaTitle": "Meta 半年资本开支预测｜Predict Raven",
-  "iaMetaCapexMetaDescription": "以 2026-09-06 为基线的 Meta 六个月资本开支预测：YES 32%，合理范围 20–45%，含资产拆分、分项判断和交互式金额演算。",
+  "iaMetaCapexMetaDescription": "以 2026-09-06 为基线的 Meta 六个月资本开支预测：YES 32%，合理范围 20–45%，含预测主线、资产分项判断与交互情形对照。",
   "iaMetaCapexFrameTitle": "Meta 六个月资本开支完整投资分析报告"
 }

--- a/apps/web/lib/world-cup/messages/zh-TW.generated.json
+++ b/apps/web/lib/world-cup/messages/zh-TW.generated.json
@@ -289,10 +289,10 @@
   "iaGoogleFrameTitle": "Demis Hassabis 與 Alphabet 完整投資分析報告",
   "iaMetaCapexCompany": "Meta Platforms · 資本開支",
   "iaMetaCapexTitle": "Meta 會在半年內正式下調資本開支計劃嗎？",
-  "iaMetaCapexSummary": "按服務器、數據中心、網絡等資產拆分預算方向與下修風險，結合原始披露、視頻字幕及社交研究，並提供交互式金額演算。",
+  "iaMetaCapexSummary": "沿服務器、數據中心、網絡等資產判斷數量、價格與付款時點，綜合原始披露、視頻字幕及社交研究，用四種情形解釋何時會下調總計劃。",
   "iaMetaCapexSignalLabel": "半年內正式下調概率",
   "iaMetaCapexSignal": "32% · NO 68%",
   "iaMetaCapexMetaTitle": "Meta 半年資本開支預測｜Predict Raven",
-  "iaMetaCapexMetaDescription": "以 2026-09-06 為基線的 Meta 六個月資本開支預測：YES 32%，合理範圍 20–45%，含資產拆分、分項判斷和交互式金額演算。",
+  "iaMetaCapexMetaDescription": "以 2026-09-06 為基線的 Meta 六個月資本開支預測：YES 32%，合理範圍 20–45%，含預測主線、資產分項判斷與交互情形對照。",
   "iaMetaCapexFrameTitle": "Meta 六個月資本開支完整投資分析報告"
 }

--- a/apps/web/public/investment-analysis/reports/meta-capex-6m-assets/capex-structure/index.html
+++ b/apps/web/public/investment-analysis/reports/meta-capex-6m-assets/capex-structure/index.html
@@ -52,7 +52,7 @@ main u.minor{text-decoration:underline dotted;text-decoration-color:#9aa39d;text
 <a href="#_3">如何展示分项预测</a>
 <a href="#_4">概率与回放</a>
 <a href="#_5">文件</a>
-<a href="#_6">完成与验收</a></nav><main><div class="legend"><p>公开附件：保留来源链接、获取状态与研究归纳。完整字幕及内部工作文件保存在本地；请通过节目或原帖链接阅读原文。</p></div><h1 id="_1">第三版结构核对与判断边界</h1>
+<a href="#_6">完成与验收</a></nav><main><div class="legend"><p>公开附件：保留来源链接、获取状态与研究归纳。完整字幕及内部工作文件保存在本地；请通过节目或原帖链接阅读原文。</p></div><div class="legend"><p>第三版结构研究归档。资产分类与分项判断继续沿用；第四版已撤下金额计算器，改为<a href="/investment-analysis/reports/meta-capex-6m.html#capex-scenarios">四种情形对照</a>。本页提及的演算与检查属于第三版记录。</p></div><h1 id="_1">第三版结构核对与判断边界</h1>
 <p>本轮是按资产结构修订预测报告，沿用第二轮原始字幕、社交与论坛研究。不计为新一轮全网补搜，不改变其覆盖计数。信息截点仍为 2026-09-06。</p>
 <h2 id="_2">核验的原始文件</h2>
 <ul>

--- a/apps/web/public/investment-analysis/reports/meta-capex-6m-assets/publication-manifest.json
+++ b/apps/web/public/investment-analysis/reports/meta-capex-6m-assets/publication-manifest.json
@@ -1,18 +1,19 @@
 {
-  "publishedReportVersion": "v3",
+  "publishedReportVersion": "v4",
   "researchCutoff": "2026-09-06",
-  "canonicalHtmlSha256": "0f467f8458140e45ad3e78dad1295986e6a17992d39365d75b3d23d2de5295e6",
+  "canonicalHtmlSha256": "cbe2ce46a00e2429d0d9cd8aa87019c69e5677aa1e198f836eb973c78773312a",
   "reportTextAndNumbersPreserved": true,
   "stylesAndScriptsPreserved": true,
   "fullTranscriptsPublished": false,
   "files": {
-    "meta-capex-6m.html": "5af17fb9a588daa4afb437f1135fbd2517be02bd1a6f1f9052e4ea6362c00997",
-    "meta-capex-6m-assets/capex-structure/index.html": "c078cf6377a2881ba0473ea3e74d41457bd8925d060bcfc4fc410a46cfba0149",
+    "meta-capex-6m.html": "2042bfcc2d7794ed3ec49e65bcaad5ce3a403d30de2d7f013b836a0d8408f709",
+    "meta-capex-6m-assets/readability-v4/index.html": "83d7b6ad46c77d07ffbd6cb036e7a51ac3246ef1e4ab55a14c42ca4216151374",
+    "meta-capex-6m-assets/capex-structure/index.html": "7acaf61ef017094331b8c74c878274fdce22a5024e38a35d95eacfd53303b0a6",
     "meta-capex-6m-assets/capex-structure/components.json": "67c246b98fce6c82bce83fab278f1b0146217ff3f444d25bf2d587617cf761c2",
     "meta-capex-6m-assets/media-social/index.html": "42745f83b3b07620847653484525bbb435b6be079e0bdcdfa5340e2313334131",
     "meta-capex-6m-assets/source-coverage.html": "2bf2fc0be139522cd2581349709048a9ee14f1610dda491926f43aa32304cf72",
     "meta-capex-6m-assets/history.csv": "cc2dedc3c0fdc08ac299cbf9ffd905277c73dd807c7e279f0013c35b74387efb",
     "meta-capex-6m-assets/forecast-audit-v2.json": "133d23770067dbf9b2ee9f9c96b99a2e2ca124944da9130fe0a6a6647ff87adf",
-    "meta-capex-6m-assets/qa-results-v3.json": "5b7b69dccf9971c61076822eadba72a082ca06cf2508ae38c7466f22b620c8bb"
+    "meta-capex-6m-assets/qa-results-v4.json": "9b2dd4c60eff32305e77c76e36b5d1203f8fdda7c0765bed2d63995cff873955"
   }
 }

--- a/apps/web/public/investment-analysis/reports/meta-capex-6m-assets/qa-results-v4.json
+++ b/apps/web/public/investment-analysis/reports/meta-capex-6m-assets/qa-results-v4.json
@@ -1,0 +1,658 @@
+{
+  "checks": [
+    {
+      "name": "frozen_question_verbatim",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "original_question_verbatim",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "main_sections",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "appendices",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "five_insights",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "source_refs_resolve",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "all_reference_ids_defined",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "rendered_percentages_and_dates_match",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "headline_matches_engine",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "headline_sections_match",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "yes_no_total",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "yes_paths_match",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "path_values_appear_in_html",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "probability_recomputed",
+      "status": "PASS",
+      "detail": {
+        "llr": -1.15,
+        "probability": 0.322013284782553
+      }
+    },
+    {
+      "name": "same_cluster_discount",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "round_count",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "source_provenance",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "no_post_cutoff_counted_source",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "input_hash",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "replay_transparency",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "historical_record_count",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "historical_counts",
+      "status": "PASS",
+      "detail": {
+        "首次": 9,
+        "上调": 13,
+        "维持": 10,
+        "下调": 11
+      }
+    },
+    {
+      "name": "historical_arithmetic",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "historical_windows",
+      "status": "PASS",
+      "detail": [
+        {
+          "start_year": 2018,
+          "yes": true,
+          "events": [
+            "2018-10-30"
+          ]
+        },
+        {
+          "start_year": 2019,
+          "yes": true,
+          "events": [
+            "2019-10-30"
+          ]
+        },
+        {
+          "start_year": 2020,
+          "yes": false,
+          "events": []
+        },
+        {
+          "start_year": 2021,
+          "yes": true,
+          "events": [
+            "2021-10-25"
+          ]
+        },
+        {
+          "start_year": 2022,
+          "yes": true,
+          "events": [
+            "2022-11-09",
+            "2023-02-01"
+          ]
+        },
+        {
+          "start_year": 2023,
+          "yes": true,
+          "events": [
+            "2023-10-25"
+          ]
+        },
+        {
+          "start_year": 2024,
+          "yes": false,
+          "events": []
+        },
+        {
+          "start_year": 2025,
+          "yes": false,
+          "events": []
+        }
+      ]
+    },
+    {
+      "name": "cash_lease_bridge",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "h2_cash_bounds",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "fcf_bridge",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "all_tables_wrapped",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "evidence_table_20_rows",
+      "status": "PASS",
+      "detail": 20
+    },
+    {
+      "name": "asset_structure_replaces_attention_root",
+      "status": "PASS",
+      "detail": []
+    },
+    {
+      "name": "substantial_cut_overlap",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "sensitivity_math",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "local_artifact_links",
+      "status": "PASS",
+      "detail": []
+    },
+    {
+      "name": "toc_targets",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "probability_location_review",
+      "status": "PASS",
+      "detail": [
+        {
+          "line": 185,
+          "section": "2",
+          "text": "| 顶层治理 | 🏛️ 2026-04-16 代理声明显示，4 月 1 日 Zuckerberg 拥有 **60.8%** 总投票权；公司已设置风险与战略委员会、审计与隐私委员会。[来源][proxy] | 委员会重组发生在 2025 年六月，属于本次十二个月窗口之前；本期文件确认新结构延续。旧“审计与风险监督委员会”名称不再照搬。 |"
+        },
+        {
+          "line": 286,
+          "section": "4",
+          "text": "“至少减少 5%”只属于敏感性口径。它比较**同一未来十二个月**与基线版本的计划，不能用 2026 全年中点直接替代跨年的十二个月基准。基线日没有公开的完整滚动十二个月预算，因此这项判断的证据要求更高、置信度更低。"
+        }
+      ]
+    },
+    {
+      "name": "repository_linter",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "browser_review_recorded",
+      "status": "PASS",
+      "detail": {
+        "url": "http://127.0.0.1:3109/meta-capex-6m-report-v4.html",
+        "phase": "local",
+        "interaction_tests": {
+          "checks": [
+            {
+              "name": "HTTP 200",
+              "pass": true
+            },
+            {
+              "name": "No sandbox",
+              "pass": true
+            },
+            {
+              "name": "No customer brand",
+              "pass": true
+            },
+            {
+              "name": "Fourth edition",
+              "pass": true
+            },
+            {
+              "name": "Default timing case",
+              "pass": true
+            },
+            {
+              "name": "Select timing",
+              "pass": true
+            },
+            {
+              "name": "Old chart explanation timing",
+              "pass": true
+            },
+            {
+              "name": "Select demand",
+              "pass": true
+            },
+            {
+              "name": "Old chart explanation demand",
+              "pass": true
+            },
+            {
+              "name": "Select price",
+              "pass": true
+            },
+            {
+              "name": "Old chart explanation price",
+              "pass": true
+            },
+            {
+              "name": "Select reallocate",
+              "pass": true
+            },
+            {
+              "name": "Old chart explanation reallocate",
+              "pass": true
+            },
+            {
+              "name": "Keyboard selection",
+              "pass": true
+            },
+            {
+              "name": "Asset evidence opens",
+              "pass": true
+            },
+            {
+              "name": "Mobile selection",
+              "pass": true
+            },
+            {
+              "name": "No fabricated calculator",
+              "pass": true
+            },
+            {
+              "name": "All anchors resolve",
+              "pass": true
+            },
+            {
+              "name": "No console errors",
+              "pass": true,
+              "detail": []
+            },
+            {
+              "name": "Responsive fit",
+              "pass": true
+            }
+          ],
+          "all_passed": true
+        },
+        "viewports": [
+          {
+            "innerWidth": 1440,
+            "docWidth": 1425,
+            "figures": [
+              {
+                "id": "forecast-priorities",
+                "width": 1005,
+                "scroll": 1005
+              },
+              {
+                "id": "capex-structure",
+                "width": 1005,
+                "scroll": 1005
+              },
+              {
+                "id": "capex-forecast",
+                "width": 1005,
+                "scroll": 1005
+              },
+              {
+                "id": "capex-scenarios",
+                "width": 1005,
+                "scroll": 1005
+              }
+            ]
+          },
+          {
+            "innerWidth": 390,
+            "docWidth": 375,
+            "figures": [
+              {
+                "id": "forecast-priorities",
+                "width": 313,
+                "scroll": 313
+              },
+              {
+                "id": "capex-structure",
+                "width": 313,
+                "scroll": 313
+              },
+              {
+                "id": "capex-forecast",
+                "width": 313,
+                "scroll": 313
+              },
+              {
+                "id": "capex-scenarios",
+                "width": 313,
+                "scroll": 313
+              }
+            ]
+          },
+          {
+            "innerWidth": 360,
+            "docWidth": 345,
+            "figures": [
+              {
+                "id": "forecast-priorities",
+                "width": 283,
+                "scroll": 283
+              },
+              {
+                "id": "capex-structure",
+                "width": 283,
+                "scroll": 283
+              },
+              {
+                "id": "capex-forecast",
+                "width": 283,
+                "scroll": 283
+              },
+              {
+                "id": "capex-scenarios",
+                "width": 283,
+                "scroll": 283
+              }
+            ]
+          }
+        ],
+        "errors": [],
+        "visual_review": "PASS",
+        "visual_review_notes": "Viewed desktop priorities, scenario comparison and Insights, plus mobile comparison. Clear hierarchy; no overlapping text or horizontal overflow. Interactive cases and evidence expand correctly."
+      }
+    },
+    {
+      "name": "eight_caption_programs",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "caption_files_and_hashes",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "caption_metadata_before_cutoff",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "six_recent_caption_programs",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "caption_duration_report",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "caption_end_coverage_review",
+      "status": "PASS",
+      "detail": "Dwarkesh publisher captions end at the spoken closing thanks (01:15:18.762); video duration 01:15:49. Remaining tail not transcribed. Other tracks end within 25 seconds of video end."
+    },
+    {
+      "name": "candidate_program_count",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "two_additional_full_texts",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "social_original_count",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "x_gap_disclosed",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "forum_bodies_and_comments",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "six_new_zero_weight_records",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "v1_probabilities_and_paths_preserved",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "original_eight_weights_preserved",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "insights_connected_paragraphs",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "each_insight_load_bearing_evidence",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "generic_market_strawman_removed",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "three_figures",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "four_assets_one_cash_bridge",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "five_component_forecasts",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "complete_component_reasoning",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "component_sources_resolve",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "undisclosed_allocations_not_fabricated",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "unknown_category_preserved",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "cash_chart_reconciles",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "no_stock_flow_confusion",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "cloud_opex_correction",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "historical_share_scope",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "four_explanatory_cases",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "calculator_retired",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "case_sources_resolve",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "nonprobabilistic_case_scope",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "forecast_framework_present",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "all_case_panels_readable_without_js",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "all_local_anchor_targets",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "no_duplicate_ids",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "probability_reuse_transparent",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "history_sensitivity_calendar_unchanged",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "browser_interaction_suite",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "desktop_mobile_no_overflow",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "resolution_and_outcome_paths_unchanged",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "five_asset_forecasts_unchanged",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "no_new_research_claim",
+      "status": "PASS",
+      "detail": null
+    }
+  ],
+  "pass": 80,
+  "fail": 0,
+  "html_sha256": "cbe2ce46a00e2429d0d9cd8aa87019c69e5677aa1e198f836eb973c78773312a",
+  "markdown_sha256": "f0c681f40b44e7fa8e7f01886906f2dc76a6e26fd12efaff43f3f0c633b35885",
+  "unique_external_urls": 95,
+  "notes": [
+    "Source-date checks cover weighted evidence; citation dates and future planned dates were separately reviewed.",
+    "Local links and reference resolution are checked; this is not a blanket network availability test.",
+    "All financial/factual percentages outside conclusion and appendices are listed for review."
+  ],
+  "publicExportNote": "Checks and hashes refer to the canonical local v4 report. The public copy changes link destinations and new-tab attributes only; its hash is in publication-manifest.json."
+}

--- a/apps/web/public/investment-analysis/reports/meta-capex-6m-assets/readability-v4/index.html
+++ b/apps/web/public/investment-analysis/reports/meta-capex-6m-assets/readability-v4/index.html
@@ -1,0 +1,71 @@
+<!doctype html><html lang="zh-CN"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Meta 第四版：预测主线与可读性修订</title><link rel="icon" href="data:,">
+<style>
+:root{--ink:#18201d;--muted:#657069;--paper:#fffdf8;--canvas:#eeeae1;--line:#d9d4c8;--accent:#9d3f25;--accent-soft:#f5e7df;--shadow:0 18px 55px rgba(47,42,31,.10)}
+*{box-sizing:border-box}html{scroll-behavior:smooth}
+body{margin:0;color:var(--ink);background:var(--canvas);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei",sans-serif;line-height:1.72}
+.topbar{position:sticky;top:0;z-index:10;background:rgba(255,253,248,.94);backdrop-filter:blur(12px);border-bottom:1px solid var(--line)}
+.topbar-inner{max-width:1480px;margin:auto;padding:10px 24px;display:flex;align-items:center;justify-content:space-between;gap:16px}
+.brand{font-weight:750;letter-spacing:.02em}.brand span{color:var(--accent)}
+.meta{font-size:13px;color:var(--muted)}
+.layout{max-width:1480px;margin:28px auto 64px;padding:0 24px;display:grid;grid-template-columns:250px minmax(0,1fr);gap:24px}
+.toc{position:sticky;top:72px;align-self:start;max-height:calc(100vh - 96px);overflow:auto;padding:18px 14px;border:1px solid var(--line);border-radius:14px;background:rgba(255,253,248,.72)}
+.toc-title{font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin-bottom:10px}
+.toc a{display:block;color:var(--ink);text-decoration:none;font-size:13.5px;padding:4px 8px;border-radius:8px;margin:1px 0}
+.toc a:hover{background:var(--accent-soft);color:var(--accent)}
+main{background:var(--paper);border:1px solid var(--line);border-radius:18px;box-shadow:var(--shadow);padding:40px 48px 56px;min-width:0}
+main h1{font-size:26px;line-height:1.35;margin:.2em 0 .6em;letter-spacing:.01em}
+main h2{font-size:21px;margin:2.2em 0 .7em;padding-top:.6em;border-top:1px solid var(--line)}
+main h3{font-size:17px;margin:1.6em 0 .5em;line-height:1.5}
+main h2:first-of-type{border-top:none;padding-top:0;margin-top:1em}
+main a{color:var(--accent)}
+main blockquote{margin:1.2em 0;padding:12px 18px;border-left:4px solid var(--accent);background:var(--accent-soft);border-radius:0 10px 10px 0}
+main blockquote p{margin:.3em 0}
+.tablewrap{overflow-x:auto;margin:1.1em 0}
+main table{border-collapse:collapse;font-size:14px;min-width:60%}
+main th{background:var(--accent-soft);color:var(--ink);text-align:left;font-weight:650}
+main th,main td{border:1px solid var(--line);padding:8px 12px;vertical-align:top;line-height:1.65}
+main tr:nth-child(even) td{background:rgba(238,234,225,.35)}
+main code{background:var(--canvas);border:1px solid var(--line);border-radius:6px;padding:1px 6px;font-size:.9em}
+main hr{border:none;border-top:1px solid var(--line);margin:2em 0}
+main li{margin:.25em 0}
+main ul ul,main ol ul{margin-top:.2em}
+main strong{color:#111}
+main u.key{text-decoration:underline;text-decoration-color:var(--accent);text-decoration-thickness:2px;text-underline-offset:4px}
+main u.minor{text-decoration:underline dotted;text-decoration-color:#9aa39d;text-decoration-thickness:1.5px;text-underline-offset:4px}
+.tag{display:inline-block;font-size:11.5px;line-height:1;padding:3px 6px;border-radius:5px;background:var(--canvas);border:1px solid var(--line);color:var(--muted);margin-right:5px;vertical-align:1px;white-space:nowrap}
+.note{display:block;font-size:12.5px;color:var(--muted);margin-top:5px;line-height:1.55;font-weight:400}
+.legend{font-size:13.5px;color:#4d5651;background:rgba(238,234,225,.5);border:1px dashed var(--line);border-radius:10px;padding:10px 14px;margin:.6em 0 1.2em;line-height:1.75}
+.legend p{margin:.2em 0}
+.formula{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,"PingFang SC","Hiragino Sans GB",monospace;background:var(--canvas);border:1px solid var(--line);border-radius:10px;padding:14px 18px;margin:1em 0;line-height:2;font-size:13.5px;overflow-x:auto;white-space:nowrap}
+.formula b{color:var(--accent)}
+.org td:first-child,.tight1 td:first-child{white-space:nowrap}
+.org td:first-child{font-weight:650}
+.org td:nth-child(2){width:58%}
+.org td:nth-child(3){min-width:260px}
+@media(max-width:960px){.layout{grid-template-columns:1fr}.toc{position:static;max-height:none}main{padding:24px 20px}}
+</style></head><body>
+<div class="topbar"><div class="topbar-inner"><div class="brand">Predict-Raven</div><div class="meta">Meta 第四版：预测主线与可读性修订｜生成 2026-09-06｜research-only / market-blind</div></div></div>
+<div class="layout"><nav class="toc"><div class="toc-title">目录</div><a href="#meta">Meta 第四版：预测主线与可读性修订</a>
+<a href="#_1">修改了什么</a>
+<a href="#insights">前次信息更新有没有进入 Insights</a>
+<a href="#_2">保持不变</a>
+<a href="#_3">研究边界</a></nav><main><div class="legend"><p>公开附件：保留来源链接、获取状态与研究归纳。完整字幕及内部工作文件保存在本地；请通过节目或原帖链接阅读原文。</p></div><h1 id="meta">Meta 第四版：预测主线与可读性修订</h1>
+<p>信息截点仍为 2026-09-06。此次为已有研究的综合与表达修订，未新增采集轮次或重新计权。</p>
+<h2 id="_1">修改了什么</h2>
+<ul>
+<li>阅读结论先解释预测任务：资产数量、单价、现金支付年度、跨项目抵消，最后核验正式计划。</li>
+<li>优先跟踪年末交付与付款，其次验证需求变化是否导致净订单减少；价格、承诺、意愿和融资作为具体约束。</li>
+<li>撤下第三版的假设金额计算器。以工程与交付延期、需求减少、设备降价、预算转投四种情形解释总额变化的条件，每种保留证据边界和下一步核验方向。</li>
+<li>四种情形是可能并存的机制，不是第 5 节互斥结果路径；不赋予情形概率或虚构分项金额。</li>
+<li>五条 Insights 改为完整段落，按预测优先级重排。保留判断、关键依据、影响与边界，但不再机械重复四层标签。</li>
+</ul>
+<h2 id="insights">前次信息更新有没有进入 Insights</h2>
+<p>第二版已据视频字幕、访谈和社交材料重写全部五条。第三版改写机房先建、设备后决的机制，并补充外购与自研并存、资本与运营现金边界。问题在于缺少总领与优先级，而非完全没有更新。本版将这些信息连接到预测任务，并突出既有 Q1 组件价格证据。</p>
+<h2 id="_2">保持不变</h2>
+<p>主概率 YES 32%、NO 68%，主观合理范围 20–45%。冻结题、官方财务基线、分项定性数据、计权输入、历史记录、六条互斥路径及敏感性分析沿用前版。新增文字中的价格下降等均为条件推演，未声称已发生。</p>
+<p>第三版及其图表、验证记录完整保留。第四版的源稿为 <span>Markdown（本地研究归档）</span>，阅读版为 <a href="/investment-analysis/reports/meta-capex-6m.html" target="_blank" rel="noopener noreferrer">HTML</a>，校验记录见 <a href="/investment-analysis/reports/meta-capex-6m-assets/qa-results-v4.json" target="_blank" rel="noopener noreferrer">第四版验收</a>。</p>
+<h2 id="_3">研究边界</h2>
+<p>继续沿用第二轮媒体与社交台账。X 原帖正文缺口未补齐，字幕也未逐秒听校；本次编辑没有被计为新的联网研究或新一轮模型预测。</p></main></div>
+</body></html>

--- a/apps/web/public/investment-analysis/reports/meta-capex-6m.html
+++ b/apps/web/public/investment-analysis/reports/meta-capex-6m.html
@@ -1,6 +1,6 @@
 <!doctype html><html lang="zh-CN"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Meta 半年内下调资本开支的概率 · 第三版</title><link rel="icon" href="data:,">
+<title>Meta 半年内下调资本开支的概率 · 第四版</title><link rel="icon" href="data:,">
 <style>
 :root{--ink:#18201d;--muted:#657069;--paper:#fffdf8;--canvas:#eeeae1;--line:#d9d4c8;--accent:#9d3f25;--accent-soft:#f5e7df;--shadow:0 18px 55px rgba(47,42,31,.10)}
 *{box-sizing:border-box}html{scroll-behavior:smooth}
@@ -46,11 +46,11 @@ main u.minor{text-decoration:underline dotted;text-decoration-color:#9aa39d;text
 .org td:nth-child(3){min-width:260px}
 @media(max-width:960px){.layout{grid-template-columns:1fr}.toc{position:static;max-height:none}main{padding:24px 20px}}
 </style></head><body>
-<div class="topbar"><div class="topbar-inner"><div class="brand">Predict-Raven</div><div class="meta">Meta 半年内下调资本开支的概率 · 第三版｜生成 2026-09-06｜research-only / market-blind</div></div></div>
+<div class="topbar"><div class="topbar-inner"><div class="brand">Predict-Raven</div><div class="meta">Meta 半年内下调资本开支的概率 · 第四版｜生成 2026-09-06｜research-only / market-blind</div></div></div>
 <div class="layout"><nav class="toc"><div class="toc-title">目录</div><a href="#meta">Meta 会在半年内下调资本开支吗？</a>
 <a href="#1">1. 阅读结论</a>
 <a href="#2">2. 资本开支结构与分项预测</a>
-<a href="#3-insight-summary">3. Insight Summary</a>
+<a href="#3-insight-summary">3. Insight Summary：哪些变化最值得跟踪？</a>
 <a href="#4">4. 结算口径</a>
 <a href="#5">5. 情景与路径</a>
 <a href="#6">6. 关键证据表</a>
@@ -62,7 +62,7 @@ main u.minor{text-decoration:underline dotted;text-decoration-color:#9aa39d;text
 <a href="#a2">A2. 基准率与可比案例</a>
 <a href="#a3">A3. 口径敏感性</a>
 <a href="#a4">A4. 下一次更新清单</a></nav><main><h1 id="meta">Meta 会在半年内下调资本开支吗？</h1>
-<p class="report-kicker">Predict-Raven · 深度研究 · 2026-09-06 · 第三版 · 资本开支结构与分项预测</p>
+<p class="report-kicker">Predict-Raven · 深度研究 · 2026-09-06 · 第四版 · 预测主线与情形解释</p>
 <p class="note">窄屏阅读时，表格可以左右滑动。</p>
 
 <style>
@@ -108,34 +108,28 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 .cx-detail summary{cursor:pointer;font-weight:650;line-height:1.7;padding:5px 3px}
 .cx-detail summary span{font-size:12px;font-weight:400;color:var(--muted);margin-left:10px}
 .cx-detail div{padding:5px 3px 8px}.cx-detail p{margin:12px 0;line-height:1.9}
-.cx-presets{display:flex;gap:8px;flex-wrap:wrap;margin:12px 0}
-.cx-presets button{border:1px solid var(--line);background:transparent;color:var(--ink);padding:9px 13px;border-radius:3px;cursor:pointer;font:inherit;font-size:13px;min-height:40px}
-.cx-presets button[aria-pressed=true]{border-color:var(--accent);background:var(--accent-soft);color:var(--accent)}
 .cx-figure :focus-visible{outline:2px solid var(--accent);outline-offset:3px}
-.cx-scenario-note{font-size:13px;line-height:1.8;min-height:47px;padding:10px 0;color:var(--muted)}
-.cx-sim-grid{display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1fr);gap:30px}
-.cx-input-row{padding:12px 0;border-top:1px solid var(--line)}
-.cx-input-label{display:flex;align-items:center;justify-content:space-between;gap:12px;font-size:14px}
-.cx-input-row input[type=range]{display:block;width:100%;margin:13px 0 5px;accent-color:var(--accent);min-height:24px;cursor:pointer}
-.cx-input-row output{font-variant-numeric:tabular-nums;font-weight:700;color:var(--accent)}
-.cx-axis{display:grid;grid-template-columns:1fr 1fr;color:var(--muted);font-size:12px;padding-bottom:12px}.cx-axis span:last-child{text-align:right}
-.cx-delta-line{display:grid;grid-template-columns:76px minmax(0,1fr) 44px;gap:8px;align-items:center;padding:14px 0;font-size:12px}
-.cx-delta-track{height:17px;position:relative;background:#f0eee7}
-.cx-delta-track::before{content:"";position:absolute;top:-5px;bottom:-5px;left:50%;width:1px;background:var(--muted);z-index:1}
-.cx-delta-bar{position:absolute;height:100%;background:var(--accent);right:50%;width:0}
-.cx-delta-bar.cx-positive{background:#44604b;left:50%;right:auto}
-.cx-delta-line output{text-align:right;font-variant-numeric:tabular-nums}
-.cx-summary{display:grid;grid-template-columns:1fr 1fr;gap:18px;margin-top:18px;padding-top:18px;border-top:2px solid var(--ink)}
-.cx-summary span{display:block;font-size:12px;color:var(--muted)}
-.cx-summary output{font-size:31px;font-weight:700;font-variant-numeric:tabular-nums;line-height:1.6}
-.cx-formality{display:flex;gap:10px;align-items:flex-start;font-size:13px;line-height:1.8;margin:20px 0 8px}
-.cx-formality input{margin-top:5px;min-width:17px;min-height:17px;accent-color:var(--accent)}
-.cx-result{font-size:14px;line-height:1.9;padding:12px 14px;background:#e7ece6;border-left:3px solid #44604b}
-.cx-result[data-negative=true]{background:var(--accent-soft);border-color:var(--accent)}
-.cx-static{font-size:13px;color:var(--muted);margin-top:18px;padding-top:12px;border-top:1px dashed var(--line)}
 @media(max-width:1000px){.cx-row{gap:10px;grid-template-columns:1.15fr 1.65fr .7fr .7fr .6fr}.cx-sim-grid{gap:22px}.cx-delta-line{grid-template-columns:65px minmax(0,1fr) 37px;gap:5px}}
 @media(max-width:780px){.cx-cash{grid-template-columns:1fr}.cx-asset-list{grid-template-columns:repeat(2,minmax(0,1fr))}.cx-row{grid-template-columns:1fr 1fr;gap:10px 16px;padding:18px 0}.cx-header{display:none}.cx-row .cx-name{grid-column:1/-1}.cx-direction{grid-column:1/-1}.cx-confidence{grid-column:1/-1}.cx-mobile-label{display:block;font-size:12px;color:var(--muted);margin:0 0 5px}.cx-confidence .cx-mobile-label{display:inline;margin-right:8px}.cx-sim-grid{grid-template-columns:1fr;gap:24px}.cx-total{align-items:flex-start}.cx-total b{font-size:28px}.cx-title{font-size:17px}.cx-detail summary span{display:block;margin-left:0}.cx-presets button{min-height:44px}.cx-formality{padding:6px 0}.cx-delta-line{grid-template-columns:76px minmax(0,1fr) 42px}.cx-scenario-note{min-height:0}}
 @media print{.cx-sim-controls,.cx-presets,.cx-formality{display:none}.cx-figure,.cx-detail{break-inside:avoid}.cx-detail:not([open])>div{display:block}.cx-static{display:block!important}}
+.rv-priorities{border-top:1px solid var(--line);margin:20px 0}
+.rv-priority{display:grid;grid-template-columns:minmax(180px,.9fr) minmax(0,1.3fr);gap:8px 28px;padding:18px 0;margin:0!important;border-bottom:1px solid var(--line)}
+.rv-priority strong{grid-row:span 2;line-height:1.75}.rv-priority span{line-height:1.85}.rv-priority a{font-size:13px;width:fit-content}
+.rv-tabs{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:0;margin:22px 0 0;border-bottom:1px solid var(--line)}
+.rv-tabs button{font:inherit;color:var(--ink);background:transparent;border:0;border-bottom:3px solid transparent;text-align:left;padding:14px 12px;cursor:pointer;line-height:1.6;min-height:90px}
+.rv-tabs button strong{display:block;font-size:14px}.rv-tabs button span{display:block;color:var(--muted);font-size:12px;margin-top:6px}
+.rv-tabs button[aria-pressed=true]{border-bottom-color:var(--accent);background:var(--accent-soft)}
+.rv-panel{padding:20px 0 0}.rv-panel[hidden]{display:none}.rv-panel h4{font-size:19px;margin:0 0 14px!important;line-height:1.6}
+.rv-chain{margin:0!important}.rv-chain>div{display:grid;grid-template-columns:100px minmax(0,1fr);gap:20px;padding:12px 0;border-bottom:1px solid var(--line)}
+.rv-chain dt{font-size:13px;color:var(--muted);line-height:1.8}.rv-chain dd{margin:0;line-height:1.85}
+.rv-chain>div:last-child{border-left:3px solid var(--accent);padding-left:12px;background:var(--accent-soft)}
+.rv-watch{padding:12px 0;line-height:1.85!important}.rv-watch strong{display:block;font-size:13px;color:var(--accent)}
+.rv-panel details{font-size:13px;color:var(--muted);border-top:1px dashed var(--line);padding:12px 0}.rv-panel summary{cursor:pointer;min-height:30px;line-height:1.8}
+.rv-current{border-top:1px solid var(--line);padding-top:14px;font-size:14px!important;line-height:1.9!important}
+.rv-resolution{border-top:2px solid var(--ink);margin-top:22px!important;padding-top:18px!important;line-height:1.85!important;font-size:14px}
+#insight-timing,#insight-demand,#insight-orders,#insight-intent,#insight-finance{display:block;scroll-margin-top:85px}
+@media(max-width:780px){.rv-priority{grid-template-columns:1fr;gap:8px;padding:18px 0}.rv-priority strong{grid-row:auto}.rv-tabs{grid-template-columns:1fr 1fr}.rv-tabs button{min-height:88px;padding:12px 10px}.rv-chain>div{grid-template-columns:1fr;gap:4px;padding:12px 0}.rv-chain dt{font-size:12px}.rv-chain>div:last-child{padding:12px}.rv-panel h4{font-size:17px}.rv-panel details{padding:16px 0}.rv-panel summary{min-height:44px}}
+@media print{.rv-tabs{display:none!important}.rv-panel[hidden]{display:block!important}.rv-panel{break-inside:avoid}.rv-panel details{display:none}.rv-priority{break-inside:avoid}}
 
 </style>
 
@@ -193,6 +187,17 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 </tbody>
 </table></div>
 <p>主口径允许小幅下修，因此高于“至少减少 5%”的实质削减判断；两者并非严格包含关系，因为后者还接受可靠的内部计划证据。“转鸽但不削减”与主口径互斥，其 NO 也包括正式下调。附录 A3 给出交叉关系，三个 YES 不能相加。</p>
+<h3 id="_1">先把预测任务说清楚</h3>
+<p><strong>要预测资本开支，就要预测各类资产买多少、成交单价多少、何时形成现金支付，再把全部项目加总。</strong> 对本题还要多走一步：这些变化是否让 Meta 在观察窗内正式调低可比计划。业务需求、工程进度和公司公告，因此是三个不同层次的证据。</p>
+<p>服务器主要看采购数量与单价，机房主要看工程规模与付款节点，网络要同时看集群设备和长期建设；最后另加融资租赁本金。某团队少用 GPU、某园区延期、某供应商降价，都只改变其中一环，不能直接当作公司总额下调。</p>
+<div class="rv-priorities" id="forecast-priorities">
+<p class="rv-priority"><strong>最先跟踪：原定今年的钱，能否在今年付出去？</strong><span>年底交付、验收和付款后移，即使扩建意愿不变，也可能压低当年现金计划。要核对延期金额、付款条款，以及能否被其他资本项目补上。</span><a href="#insight-timing">看工程与付款判断 →</a></p>
+<p class="rv-priority"><strong>再看：少用算力，是否真的变成少买设备？</strong><span>广告、推荐和其他模型可能接走空出的容量。只有需求未被接替、后续订单确实减少，且单价等因素没有抵消，才更接近总额下修。</span><a href="#insight-demand">看需求如何传到订单 →</a></p>
+<p class="rv-priority"><strong>持续核对：买得更便宜，还是用同样预算买得更多？</strong><span>设备单价会改变名义支出；采购承诺决定能否调整；主营现金流与融资条件决定管理层能坚持多久。这些因素共同决定节省是否留在公司层面。</span><a href="#insight-orders">看采购、价格与承诺 →</a></p>
+</div>
+
+<p><strong>目前的概括是：继续扩容的意愿仍强，但付款年度有调整风险。</strong> 近期容量目标及八月维持指引的行动支持前半句；下半年待支付金额较大，使交付与付款节点值得优先追踪。后半句是研究判断，现有材料尚未证明已发生足以压低总计划的项目延期。正式披露与计算依据见第 3 节。</p>
+<p>因此，这次预测的重点是核对“哪一笔钱会从当前计划中消失、为何消失、是否转投别处”，而不是只判断 Meta 是否继续看好 AI。窗口还跨过下一年度预算发布期：对首次公布的 2027 年预算，要按第 4 节的可比基准另行判断，不能把上述 2026 年付款逻辑直接套用。</p>
 <p><strong>基线口径卡</strong>（以下金额以十亿美元计；1 十亿美元＝10 亿美元）：</p>
 <div class="tablewrap"><table>
 <thead>
@@ -233,8 +238,8 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 </tbody>
 </table></div>
 <p>信息截点为 2026-09-06 本次检索；第二轮补漏与第三版结构核对仍严格使用该日及以前的材料。尽可能覆盖会改变结论的公开信息；付费墙后全文、未公开预算和未开展的专家访谈不在已掌握证据之内。全文把公告事实、公司判断、媒体消息和我们的推断分开。</p>
-<p><strong>第三版变化：</strong> 第 2 节改为按现有资产投向拆解，加入现金结构图、分项预测图和金额抵消演算。每项分别解释预算方向、主动缩量与付款后移风险；公司未披露的年度分项金额保留未知。主概率仍为 <strong>32%</strong>，合理范围 <strong>20–45%</strong>。此次细分的是已有证据如何作用于各类资产，没有新增独立的削减决定，因而不重复计权。第二版已采集的字幕、原帖、论坛证据继续保留，覆盖与缺口见第 8 节。</p>
-<p>快速阅读：<a href="#capex-structure">资本开支结构</a> · <a href="#capex-forecast">各项预测</a> · <a href="#capex-simulator">金额抵消演算</a>。</p>
+<p><strong>第四版变化：</strong> 补上预测任务与跟踪优先级，重写 Insights，把假设金额演算改为四种情形对照。第二版已据新增视频、访谈与社交材料重写五条 Insights；第三版进一步补充资产决策时序，但此前没有充分概括这些信息如何共同回答预测题。本版修正的是综合与表达，未新增一轮采集或独立计权，主概率及合理范围维持不变。</p>
+<p>快速阅读：<a href="#forecast-priorities">预测任务与重点</a> · <a href="#capex-structure">资本开支结构</a> · <a href="#capex-forecast">各项预测</a> · <a href="#capex-scenarios">四种情形</a> · <a href="#insight-timing">核心判断</a>。</p>
 <h2 id="2">2. 资本开支结构与分项预测</h2>
 <h3 id="21">2.1 先按钱花在哪里拆，再按谁使用拆</h3>
 <p><strong>主结构是服务器与芯片、数据中心建设、网络，以及其他资本化资产。</strong> 前三项沿用 Meta 正式电话会的投向；“其他”用于覆盖其余资本化资产。融资租赁本金单独桥接到公司现金口径。广告、模型训练和产品推理属于用途：它们会共用服务器、网络与机房，不能再与资产类别相加。<a href="https://s21.q4cdn.com/399680738/files/doc_financials/2024/q4/META-Q4-2024-Earnings-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">历史结构说明</a>、<a href="https://s21.q4cdn.com/399680738/files/doc_financials/2024/q4/META-Q4-2024-Follow-Up-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">用途定义</a></p>
@@ -253,7 +258,7 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 <p><strong>会计边界决定这棵树能不能相加。</strong> 已计入服务器的 GPU、内存等部件不再另设一个金额桶；在建工程是资产所处阶段，可能同时包含机房、服务器和网络，不能全部归为土建。季报里的服务器和网络资产原值 119.683、在建工程 80.345，都是六月末存量，不能代替年度支出。新取得租赁资产的非现金入账，也不能再加到融资租赁本金上。<a href="https://www.sec.gov/Archives/edgar/data/1326801/000162828026050705/meta-20260630.htm" target="_blank" rel="noopener noreferrer">Q2 季报 Note 6</a></p>
 <p>普通云服务费、外部模型调用费、电费和研发人员费用通常属于运营费用；股权投资与合资出资需另核会计分类。它们会影响自建需求、现金承受力和经济风险，却不自动成为本题资本开支的一部分。<a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q1/META-Q1-2026-Earnings-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">Q1 电话会</a>、<a href="https://www.sec.gov/Archives/edgar/data/1326801/000162828026050705/meta-20260630.htm" target="_blank" rel="noopener noreferrer">Q2 季报</a></p>
 <h3 id="22">2.2 每个部分，未来半年更可能怎么变？</h3>
-<p><strong>基准判断是：服务器继续买，机房继续建；当年预算最容易出现的裂口在付款时间，其次是设备交付和价格。</strong> 以下考察 2026-09-06 至 2027-03-06 期间可能发生的预算修订，参照同一资产的当前计划，而非简单预测同比增速。2027 年尚无量化分项基线，不能把扩容目标转换为已公布的美元预算。</p>
+<p><strong>基准判断是：服务器继续买，机房继续建；未来半年最值得查的是交付、验收能否按期转为付款，同时核对服务器数量与单价的变化。</strong> 以下考察 2026-09-06 至 2027-03-06 期间可能发生的预算修订，参照同一资产的当前计划，而非简单预测同比增速。2027 年尚无量化分项基线，不能把扩容目标转换为已公布的美元预算。</p>
 <figure class="cx-figure" id="capex-forecast" aria-labelledby="cx-forecast-title">
 <figcaption class="cx-title" id="cx-forecast-title">分项预测：建设意愿与现金时点分开判断</figcaption>
 <p class="cx-sub">未来半年内对当前计划的修订方向。风险是作者的相对判断，颜色不代表数值概率。</p>
@@ -275,24 +280,45 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 <details class="cx-detail" id="detail-lease"><summary>融资租赁本金<span>以现金计划核对 · 展开依据与改判条件</span></summary><div><p><strong>判断：</strong>已经开始的合同通常比未下单设备难以主动压缩；新增租赁开始时间仍可能改变未来本金现金。判断需要逐项合同，不能把全部未来租赁义务当成当年付款。</p><p><strong>依据：</strong>上半年现金本金偿还为 1.805 十亿美元；付款义务与资产非现金入账分开披露。</p><p><strong>什么会让本项下修：</strong>新租赁开始时间后移、合同变更等确实降低可比期间本金现金，并获财务确认。</p><p><strong>什么可能抵消：</strong>已有合同付款延续；新设施开始使用也可能增加本金偿还。</p><p><strong>沿着谁查：</strong>租赁会计与资金负责人：起租日、偿还表、变更条款及经营/融资租赁分类。</p><p><strong>证据边界：</strong>此项不得与同一租赁资产取得时的非现金金额重复相加；未披露全年分项指引。</p><p>原始来源：<a href="https://www.sec.gov/Archives/edgar/data/1326801/000162828026050705/meta-20260630.htm" target="_blank" rel="noopener noreferrer">2026-07-30 季报</a> · <a href="https://investor.atmeta.com/investor-news/press-release-details/2026/Meta-Reports-Second-Quarter-2026-Results/default.aspx" target="_blank" rel="noopener noreferrer">2026-07-29 业绩公告</a></p></div></details>
 
 <p><strong>按用途再看一次：</strong> 核心 AI 的推荐与广告回报，支撑追加服务器和配套网络；生成式 AI 的训练排期、产品调用量，更容易影响服务器批次及型号；非 AI 基础服务仍有容量和更新需求。三者都使用机房与网络。某个模型少训练，只有在释放的容量未被其他用途接走、后续采购因此减少时，才会压低服务器总计划。<a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q1/META-Q1-2026-Earnings-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">Q1 电话会</a>、<a href="https://cheekypint.transistor.fm/2/transcript" target="_blank" rel="noopener noreferrer">Li 访谈</a>、<a href="https://stripe.com/br/sessions/2026/a-conversation-with-daniel" target="_blank" rel="noopener noreferrer">Gross 访谈</a></p>
-<h3 id="23">2.3 分项变动怎样汇成总计划？</h3>
-<p><strong>先加金额，再判断是否正式下调；不要平均分项风险。</strong> 以下用 2026 年指引中点 137.5 十亿美元作演算基准。所有输入均是同一年度、同一现金口径下的假设增减；负数为少花，正数为多花。它们不是公司实际分项预算，也不是本报告的金额预测。</p>
-<figure class="cx-figure" id="capex-simulator" aria-labelledby="cx-sim-title">
-<figcaption class="cx-title" id="cx-sim-title">金额演算：一个部分少花，不一定降低总额</figcaption>
-<p class="cx-sub"><strong>纯假设情景，不是分项金额预测。</strong>基准为 2026 年年度中点 137.5；单位：十亿美元。</p>
-<div class="cx-presets" role="group" aria-label="选择假设场景"><button type="button" data-scenario="offset" aria-pressed="true">一减一增</button><button type="button" data-scenario="delay" aria-pressed="false">付款跨年</button><button type="button" data-scenario="price" aria-pressed="false">设备降价</button><button type="button" data-scenario="network_delay" aria-pressed="false">集群交付后移</button><button type="button" data-scenario="unchanged" aria-pressed="false">全部归零</button></div>
-<p class="cx-scenario-note" id="cx-scenario-note">假设数据中心少付 5、服务器多付 5：单项减少被抵消，总计划中点不变。</p>
-<div class="cx-sim-grid"><div class="cx-sim-controls"><div class="cx-input-row"><div class="cx-input-label"><label for="cx-input-servers">服务器与芯片</label><output id="cx-value-servers" for="cx-input-servers">+5.0</output></div><input type="range" id="cx-input-servers" data-component="servers" min="-20" max="20" step="0.5" value="5" aria-describedby="cx-input-help" aria-valuetext="+5.0 十亿美元"></div><div class="cx-input-row"><div class="cx-input-label"><label for="cx-input-datacenters">数据中心建设</label><output id="cx-value-datacenters" for="cx-input-datacenters">-5.0</output></div><input type="range" id="cx-input-datacenters" data-component="datacenters" min="-20" max="20" step="0.5" value="-5" aria-describedby="cx-input-help" aria-valuetext="-5.0 十亿美元"></div><div class="cx-input-row"><div class="cx-input-label"><label for="cx-input-network">网络基础设施</label><output id="cx-value-network" for="cx-input-network">0.0</output></div><input type="range" id="cx-input-network" data-component="network" min="-10" max="10" step="0.5" value="0" aria-describedby="cx-input-help" aria-valuetext="0.0 十亿美元"></div><div class="cx-input-row"><div class="cx-input-label"><label for="cx-input-other">其他资本化资产</label><output id="cx-value-other" for="cx-input-other">0.0</output></div><input type="range" id="cx-input-other" data-component="other" min="-5" max="5" step="0.5" value="0" aria-describedby="cx-input-help" aria-valuetext="0.0 十亿美元"></div><div class="cx-input-row"><div class="cx-input-label"><label for="cx-input-lease">融资租赁本金</label><output id="cx-value-lease" for="cx-input-lease">0.0</output></div><input type="range" id="cx-input-lease" data-component="lease" min="-2" max="2" step="0.5" value="0" aria-describedby="cx-input-help" aria-valuetext="0.0 十亿美元"></div><p class="cx-sub" id="cx-input-help">拖动可调整；键盘方向键也可操作。输入范围仅供演算，不表示已知预算或可削减额度。</p></div>
-<div><div class="cx-axis"><span>← 少花 · 最左 −20</span><span>多花 → 最右 ＋20</span></div><div class="cx-delta-line"><span>服务器</span><div class="cx-delta-track" aria-hidden="true"><div class="cx-delta-bar cx-positive" id="cx-bar-servers" style="width:12.5%;"></div></div><output id="cx-bar-value-servers">+5.0</output></div><div class="cx-delta-line"><span>数据中心</span><div class="cx-delta-track" aria-hidden="true"><div class="cx-delta-bar " id="cx-bar-datacenters" style="width:12.5%;"></div></div><output id="cx-bar-value-datacenters">-5.0</output></div><div class="cx-delta-line"><span>网络</span><div class="cx-delta-track" aria-hidden="true"><div class="cx-delta-bar " id="cx-bar-network" style="width:0.0%;"></div></div><output id="cx-bar-value-network">0.0</output></div><div class="cx-delta-line"><span>其他资产</span><div class="cx-delta-track" aria-hidden="true"><div class="cx-delta-bar " id="cx-bar-other" style="width:0.0%;"></div></div><output id="cx-bar-value-other">0.0</output></div><div class="cx-delta-line"><span>租赁本金</span><div class="cx-delta-track" aria-hidden="true"><div class="cx-delta-bar " id="cx-bar-lease" style="width:0.0%;"></div></div><output id="cx-bar-value-lease">0.0</output></div>
-<div class="cx-summary" aria-live="polite" aria-atomic="true"><div><span>净变化</span><output id="cx-net">0.0</output></div><div><span>演算后的年度中点</span><output id="cx-midpoint">137.5</output></div></div>
-<label class="cx-formality" for="cx-formal"><input type="checkbox" id="cx-formal">假设 Meta 已在观察窗内正式公布上述同年、同口径修订</label>
-<p class="cx-result" id="cx-result" data-negative="false" role="status">净额不变：本演算没有构成公司总计划下调。</p></div></div>
-<div class="cx-static">预设例：数据中心 −5、服务器 ＋5 → 净额 0；只将数据中心 −5 → 中点 132.5；服务器 −8、数据中心 ＋5 → 中点 134.5。均为假设金额。</div>
-<noscript><p>当前未启用脚本，图示保留“一减一增”的静态情景；预设例与各分项判断仍可阅读。</p></noscript>
+<h3 id="23">2.3 从分项消息到公司总额：四种情形怎么判断？</h3>
+<p>这部分用于判断一条“少花钱”的消息有没有预测价值。关键是分清：钱只是晚付、需求真的减少、采购变便宜，还是换了一个地方花。下面把各自的条件展开，不再用任意金额代替研究判断。</p>
+<figure class="cx-figure" id="capex-scenarios" aria-labelledby="rv-case-title">
+<figcaption class="cx-title" id="rv-case-title">同样是少花，哪些变化会压低总计划？</figcaption>
+<p class="cx-sub">点选情形，沿着“发生什么 → 影响哪类资产 → 是否减少公司总额”阅读。以下是条件推演，不代表事件已经发生，也不提供假设金额或情形概率。</p>
+<div class="rv-tabs" role="group" aria-label="选择资本开支变化情形"><button type="button" data-case="timing" aria-pressed="true" aria-controls="case-timing"><strong>工程与交付延期</strong><span>继续扩建，但付款可能跨年</span></button><button type="button" data-case="demand" aria-pressed="false" aria-controls="case-demand"><strong>需求减少</strong><span>少用算力，是否真的少买设备？</span></button><button type="button" data-case="price" aria-pressed="false" aria-controls="case-price"><strong>设备单价下降</strong><span>买得便宜，也可能买得更多</span></button><button type="button" data-case="reallocate" aria-pressed="false" aria-controls="case-reallocate"><strong>预算转投</strong><span>一个项目少花，另一个多花</span></button></div>
+<div aria-live="polite" aria-atomic="false"><section class="rv-panel" id="case-timing" aria-labelledby="case-title-timing">
+<h4 id="case-title-timing">工程与交付延期：继续扩建，但付款可能跨年</h4>
+<dl class="rv-chain"><div><dt>发生什么</dt><dd>机房验收、供电或集群交付后移。</dd></div><div><dt>影响哪些支出</dt><dd>机房工程款可能后移；服务器与网络的交付和付款也可能一起调整。</dd></div><div><dt>怎样影响总额</dt><dd>若付款跨出原年度，且其他资本项目没有补上，当年总计划才有下修空间。</dd></div></dl>
+<p class="rv-watch"><strong>看到这类消息，接下来查什么？</strong>原定付款节点 → 修订付款年度 → 可抵补的其他支出。三项必须一起查。</p>
+<p class="rv-current"><strong>现有证据支持到哪里：</strong>本报告优先跟踪这条路径。用工约束和下半年付款集中值得关注，但尚未确认足以导致总计划下降的实际延期。</p>
+<p class="cx-sub">依据：<a href="https://investor.atmeta.com/investor-news/press-release-details/2026/Meta-Reports-Second-Quarter-2026-Results/default.aspx" target="_blank" rel="noopener noreferrer">2026-07-29 Q2 公告</a> · <a href="https://www.linkedin.com/posts/sjanardhan_americas-workforce-academy-the-future-is-activity-7469869698331922432-JYIA" target="_blank" rel="noopener noreferrer">2026-06-08 Janardhan 原帖</a></p>
+<details><summary>与旧图的对应关系</summary><p>对应旧图的“付款跨年”和“集群交付后移”；交付晚不一定付款晚，取决于预付款及验收条款。</p></details>
+</section><section class="rv-panel" id="case-demand" aria-labelledby="case-title-demand">
+<h4 id="case-title-demand">需求减少：少用算力，是否真的少买设备？</h4>
+<dl class="rv-chain"><div><dt>发生什么</dt><dd>训练计划收缩、追加回报下降，或效率提高后需要的算力减少。</dd></div><div><dt>影响哪些支出</dt><dd>先影响后续服务器采购，配套网络也可能减少；已启动的机房建设仍可能继续。</dd></div><div><dt>怎样影响总额</dt><dd>只有释放的容量没有被其他业务接走、订单确实减少，且单价或其他项目没有抵消，才会压低总额。</dd></div></dl>
+<p class="rv-watch"><strong>看到这类消息，接下来查什么？</strong>释放容量的去向、后续订单是否取消，以及财务是否收回预算额度。</p>
+<p class="rv-current"><strong>现有证据支持到哪里：</strong>现有访谈证明公司会筛选和重新分配需求，尚未证明这已造成公司整体采购净减少。</p>
+<p class="cx-sub">依据：<a href="https://cheekypint.transistor.fm/2/transcript" target="_blank" rel="noopener noreferrer">2025-06-18 Susan Li 访谈</a> · <a href="https://stripe.com/br/sessions/2026/a-conversation-with-daniel" target="_blank" rel="noopener noreferrer">2026-04-30 Gross 访谈实录</a> · <a href="https://ca.investing.com/news/transcripts/meta-at-morgan-stanley-conference-ai-strategy-and-financial-insights-93CH-4495629" target="_blank" rel="noopener noreferrer">2026-03-04 Susan Li 访谈</a></p>
+<details><summary>与旧图的对应关系</summary><p>旧图没有直接呈现这条需求路径；本版补入，以对应“为什么会主动少买”这一预测问题。</p></details>
+</section><section class="rv-panel" id="case-price" aria-labelledby="case-title-price">
+<h4 id="case-title-price">设备单价下降：买得便宜，也可能买得更多</h4>
+<dl class="rv-chain"><div><dt>发生什么</dt><dd>服务器组件报价下降，或同等任务所需设备更便宜。</dd></div><div><dt>影响哪些支出</dt><dd>相同采购数量下，服务器与芯片支出可能下降；采用新方案也可能带来配套改造支出。</dd></div><div><dt>怎样影响总额</dt><dd>若节省被保留，总额可能下降；若增加数量、升级配置或转投建设，总额可能维持。</dd></div></dl>
+<p class="rv-watch"><strong>看到这类消息，接下来查什么？</strong>同一批设备的数量与单价，并核对省下来的预算如何使用。</p>
+<p class="rv-current"><strong>现有证据支持到哪里：</strong>四月曾因组件涨价上调指引，说明单价确实重要。目前没有足够证据断言本窗口将出现净降价。</p>
+<p class="cx-sub">依据：<a href="https://investor.atmeta.com/investor-news/press-release-details/2026/Meta-Reports-First-Quarter-2026-Results/default.aspx" target="_blank" rel="noopener noreferrer">2026-04-29 Q1 公告</a> · <a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q1/META-Q1-2026-Earnings-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">2026-04-29 Q1 电话会</a></p>
+<details><summary>与旧图的对应关系</summary><p>对应旧图的“设备降价”。旧图预设了部分节省被转投；这只是其中一种可能，不能作为金额预测。</p></details>
+</section><section class="rv-panel" id="case-reallocate" aria-labelledby="case-title-reallocate">
+<h4 id="case-title-reallocate">预算转投：一个项目少花，另一个多花</h4>
+<dl class="rv-chain"><div><dt>发生什么</dt><dd>某个园区、设备批次或业务少花钱，公司把预算转给其他资本项目。</dd></div><div><dt>影响哪些支出</dt><dd>例如机房少付、服务器多买；也可能发生在同一资产类别的不同项目之间。</dd></div><div><dt>怎样影响总额</dt><dd>完全抵补时总额不变；只抵补一部分时才留下净减少，仍需核对同一年度和会计口径。</dd></div></dl>
+<p class="rv-watch"><strong>看到这类消息，接下来查什么？</strong>原项目节省额与全部替代支出，不能只收集“某项减少”的消息。</p>
+<p class="rv-current"><strong>现有证据支持到哪里：</strong>这是抵消机制，不是独立的下调预测。它决定前面几类消息能否真正传到公司总计划。</p>
+<p class="cx-sub">依据：<a href="https://cheekypint.transistor.fm/2/transcript" target="_blank" rel="noopener noreferrer">2025-06-18 Susan Li 访谈</a> · <a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q2/META-Q2-2026-Earnings-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">2026-07-29 Q2 电话会</a></p>
+<details><summary>与旧图的对应关系</summary><p>对应旧图的“一减一增”。“全部归零”只是重置操作，不对应一种经济情形，因此已删除。</p></details>
+</section></div>
+<p class="rv-resolution"><strong>最后还要跨过正式披露这一关。</strong>以上都先解释经济变化。总额确实减少之后，仍须由 Meta 在观察窗内正式公布可比计划下调，才符合本题；项目消息或实际付款减少本身不够。不同年度、租赁分类及首次次年预算，按第 4 节核对。</p>
+<noscript><p>未启用脚本时，四种情形依次展示，全部文字仍可阅读。</p></noscript>
 </figure>
 
-<p>这个演算只覆盖同一年度计划中点修订。它没有假设公司会把区间上下限等额平移，也不能替代 2027 年首次预算与上一年可比基准的比较。单项目改由合作方持有、租赁分类变化或付款转为其他会计类别，先按第 4 节还原，再输入可比净额。</p>
-<p>各部分会相互抵消，也会一起变化：同一集群延期可能同时影响服务器和网络；某项目少花可能被其他项目补上。因而不能把“任意分项减少”的可能性当作公司正式下调的概率。总额减少以后，还要经过财务确认和窗口内的正式公开。</p>
 <h3 id="24">2.4 关键人关系表</h3>
 <p>“穿透”在这里指沿着预算提出、批准和执行的链条找具体负责人。“关键-1”指直接下属，“关键-2”指再下一层。本表的“打灯”衡量<strong>公开证据对关系状态的可见度</strong>：5 分有近期正式资料且能交叉验证，3 分主要依赖报道，1 分仅有零散线索；它不是个人能力、关系好坏或预算否决力的评分。没有依据的审批权不补写。</p>
 <div class="tablewrap"><table>
@@ -423,69 +449,37 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 </tbody>
 </table></div>
 </div>
-<h2 id="3-insight-summary">3. Insight Summary</h2>
-<div class="legend">
-<p>这一节解释五件事：创始人为什么继续买、团队如何分配算力、机房与服务器为何分阶段决定、工程进度怎样进入年度预算、融资如何吸收现金压力。每条保留“判断／依据／为什么重要／最需要弄清楚的事”四层。🏛️ 为正式文件，📰 为新闻或公开原帖，🎙️ 为本人访谈；本次没有自采专家访谈。实线标出支撑判断的关键事实，虚线为补充。判断是我们的推断，管理层的说法不等于已经兑现的结果。</p>
-</div>
-<h3 id="31-zuckerberg">3.1 【本质驱动】Zuckerberg 已经把“买早了”列为可以承担的损失</h3>
-<ul>
-<li><strong>判断：</strong> AI 回报晚两年出现，未必足以让 Zuckerberg 改变投入方向。他把提前建设可能造成的损失，与错过下一代技术的代价放在一起比较，并选择承担前一种风险。这个选择有一个条件：Meta 的主营业务和融资能力足以支持它等下去。因此，真正能迫使他降低总投入的，应是承受损失的能力恶化，或他不再相信提前占有算力有价值。</li>
-<li><strong>依据：</strong><ul>
-<li>🎙️ <span class="tag">来源陈述</span> <a href="https://www.youtube.com/watch?v=23FyskyFoP8" target="_blank" rel="noopener noreferrer">Access 长访谈</a>（2025-09-18，原视频 01:09:10–01:13:55）：Zuckerberg 承认 AI 基建可能出现泡沫；比较三年与五年才实现超级智能的两种情形后，<u class="key">他说即使提前投入造成巨额浪费，建设太慢、到时没有准备好的风险仍更大</u>。他紧接着以 Meta 不至于因此倒闭解释这一选择。已读取完整上下文，未只引用开场剪辑。</li>
-<li>🏛️ <span class="tag">事实</span> <a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q2/META-Q2-2026-Earnings-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">七月业绩会</a>和<a href="https://about.fb.com/news/2026/08/agreement-with-state-attorneys-general-supporting-teens/" target="_blank" rel="noopener noreferrer">八月和解公告</a>（2026-07-29、2026-08-26）分别强调近期容量扩张、维持其余指引区间；<u class="minor">今年的正式行动仍与这项风险取舍一致</u>。</li>
-</ul>
-</li>
-<li><strong>为什么重要：</strong> “AI 可能过度投资”并不是一条他尚未考虑的反对理由。用这个理由预测六个月内削减预算，容易低估其坚持程度。但他的选择也不是无条件的：持续广告恶化与融资收紧若同时发生，就会直接冲击他认为自己能够承担风险的前提。小幅年度付款下修则无需改变这套战略判断。</li>
-<li><strong>最需要弄清楚的事：</strong> 在新年度预算评审中，管理层是否明确设定了最低现金储备或最高负债约束；触及它时，哪一批基础设施投入会被停止？</li>
-</ul>
-<h3 id="32">3.2 【传导路径】团队省下来的算力，要经过第二次决策才会变成少买设备</h3>
-<ul>
-<li><strong>判断：</strong> Meta 已经在讨论哪些 AI 任务不值得花那么多钱。问题在于，停止低价值任务之后，空出的资源可能交给别的团队。要形成公司资本开支下降，还需要财务和基础设施负责人进一步决定：不再把这部分容量用于其他工作，并减少后续采购。这是“效率提高”到“总预算下降”之间最容易被省略的一步。</li>
-<li><strong>依据：</strong><ul>
-<li>🎙️ <span class="tag">来源陈述</span> Gross 在 <a href="https://www.youtube.com/watch?v=l9wzs_QIyp0" target="_blank" rel="noopener noreferrer">Stripe Sessions</a>（会期 2026-04-30，视频 5 月 19 日上传，20:34–22:35）讨论员工调用 AI 的预算：<u class="key">有些任务可以由较小的模型完成，有些生成物本身没有足够的经济价值</u>。他把分配预算类比为评估不同投资策略；<a href="https://stripe.com/br/sessions/2026/a-conversation-with-daniel" target="_blank" rel="noopener noreferrer">发布方实录</a>与字幕可交叉核对。这是正在研究的管理办法，不是已宣布的资本削减制度。</li>
-<li>🎙️ <span class="tag">来源陈述</span> Susan Li 在 <a href="https://cheekypint.transistor.fm/2/transcript" target="_blank" rel="noopener noreferrer">Cheeky Pint</a>（原节目 2025-06-18，24:16 起）说明，<u class="key">GPU 可以被中央重新调配，团队因此不愿轻易拿稳定的人员名额换取未必能一直保有的算力</u>。同一访谈也承认，广告吸收额外算力的能力有上限。</li>
-<li>🎙️ <span class="tag">来源陈述</span> Li 在 <a href="https://ca.investing.com/news/transcripts/meta-at-morgan-stanley-conference-ai-strategy-and-financial-insights-93CH-4495629" target="_blank" rel="noopener noreferrer">Morgan Stanley 访谈</a>（2026-03-04，第三方完整转录）描述核心业务按实验结果申请预算，并评估多个项目叠加后的回报；<u class="minor">财务评估关注的已是追加投入的收益，而非单纯的使用量</u>。</li>
-<li>🎙️ <span class="tag">来源陈述</span> Bosworth 的 <a href="https://www.youtube.com/watch?v=qZhCeV6XATw" target="_blank" rel="noopener noreferrer">Big Technology 原视频</a>（2026-07-08，08:20–11:00；<a href="https://www.bigtechnology.com/p/metas-path-to-ai-relevance-according" target="_blank" rel="noopener noreferrer">编辑实录</a>于 7 月 9 日发布）解释自研模型也有约束外部供应商价格的作用。外购与自研因而可能并存，不能仅凭外部模型合作就断言下一批服务器不买了。</li>
-</ul>
-</li>
-<li><strong>为什么重要：</strong> 节省模型调用费用、缩短训练、减少某团队资源，都可能改善经营效率，却不一定减少设备总订单。更有判断力的信号是：退回的容量长期没有其他用途接手，或者财务主动收回额度。反过来，不能把广告称为无限的“兜底需求”；当核心业务追加算力的收益也下降时，调拨这层缓冲才会失效。</li>
-<li><strong>最需要弄清楚的事：</strong> 最近一次大训练取消或延期后，释放了多少容量、被谁接走、下一批设备采购因此减少了多少？外购模型增加后，被替代的自建服务器采购是否真正取消？</li>
-</ul>
-<h3 id="33">3.3 【本质驱动】先建机房、以后再买服务器，让投资规模仍有调整余地</h3>
-<ul>
-<li><strong>判断：</strong> Meta 对基础设施的承诺分阶段落地。它先投入建设周期长的数据中心和网络，让未来有地方接入更多算力；服务器买多少、何时买，仍可以在后续阶段决定。由此看，远期园区规模很大，不能证明所有配套设备预算都已锁死。但在本题的半年窗口内，公司仍强调尽可能增加近两年的容量，因此更可能先调整采购批次，而不是撤回整个扩建方向。</li>
-<li><strong>依据：</strong><ul>
-<li>🏛️ <span class="tag">来源陈述</span> <a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q2/META-Q2-2026-Earnings-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">Q2 正式电话会</a>（2026-07-29，PDF 第 8 页）明确区分两个时间段：近期争取更多容量；面向 2028 年以后，<u class="key">先建设数据中心和网络基础，以容纳未来的服务器投资决定</u>。公司将长期资产与后续投资选择的灵活性联系起来。</li>
-<li>🎙️ <span class="tag">来源陈述</span> Janardhan 的<a href="https://www.business-standard.com/companies/people/we-want-to-be-part-of-india-s-growth-story-meta-s-santosh-janardhan-126061801239_1.html" target="_blank" rel="noopener noreferrer">本人采访</a>（2026-06-19）介绍先建设基础、保留以后扩容选择；<u class="minor">一个项目的阶段安排与上述资本策略一致</u>，但不提供全公司的可撤销设备金额。</li>
-</ul>
-</li>
-<li><strong>为什么重要：</strong> 对服务器供应商，要查的是后续订单何时转为不可取消；对机房与电力项目，要查的是建设和付款是否继续。两者可以出现不同方向。若 AI 需求转弱，最早的调整可能发生在下一批设备，而已经启动的长期建设仍然继续；仅盯着园区是否停工，会漏掉这一变化。</li>
-<li><strong>最需要弄清楚的事：</strong> 原定 2027 年交付的服务器中，多少已签不可取消订单，多少仍只是容量预留？设备选择推迟时，数据中心和网络的付款计划会不会同步改变？</li>
-</ul>
-<h3 id="34">3.4 【传导路径】最可能造成小幅下修的，是建设现场赶不上财务日历</h3>
-<ul>
-<li><strong>判断：</strong> 管理层可以决定继续扩建，却不能仅靠批准预算让电工、设备和验收同时到位。今年资本付款明显集中在下半年；如果部分关键节点跨到次年，而其他项目又无法补上，这种执行差额就可能进入全年指引。它不要求 Zuckerberg 承认 AI 投资方向错了。</li>
-<li><strong>依据：</strong><ul>
-<li>📰 <span class="tag">来源陈述</span> Janardhan 的<a href="https://www.linkedin.com/posts/sjanardhan_americas-workforce-academy-the-future-is-activity-7469869698331922432-JYIA" target="_blank" rel="noopener noreferrer">本人原帖</a>（2026-06-08）在推出施工人才培训计划时指出，<u class="key">没有足够的熟练工人，再大的基础设施投资也无法落地</u>。这是负责人的公开风险判断；他同时披露了缓解措施，不能据此认定某座 Meta 园区已经延期。</li>
-<li>🏛️ <span class="tag">事实</span> <a href="https://investor.atmeta.com/investor-news/press-release-details/2026/Meta-Reports-Second-Quarter-2026-Results/default.aspx" target="_blank" rel="noopener noreferrer">Q2 公告</a>（2026-07-29）显示，上半年资本现金支付为 50.918 十亿美元。全年区间减去已付金额，<u class="key">下半年需要支付 79.082–94.082 十亿美元</u>。该数值为算术推导，不是公司单独发布的半年指引；六月的用工风险在七月指引形成前已公开，不能当作七月以后突发的坏消息。</li>
-<li>🎙️ <span class="tag">来源陈述</span> Janardhan 在<a href="https://www.business-standard.com/companies/people/we-want-to-be-part-of-india-s-growth-story-meta-s-santosh-janardhan-126061801239_1.html" target="_blank" rel="noopener noreferrer">面对面采访</a>（2026-06-19）解释，Jamnagar 先建设 168MW 基础，扩至 1GW 是后续选择；<u class="minor">十多年寿命的基础设施与后续扩建，可以分阶段决定</u>。这一项目的安排不能直接外推为今年全公司的可取消金额。</li>
-</ul>
-</li>
-<li><strong>为什么重要：</strong> 合同与扩建公告说明公司想获得什么，现金指引还要取决于何时能够交付、验收和付款。预测半年内是否下调，应该把采购与财务之间的进度更新看得比远期总 GW 愿景更重。反向风险同样存在：公司可能通过替代设备采购或提前支付其他资本项目填补差额，最终保持年度区间。普通云服务运营费用不能直接填补资本开支现金缺口；若转向云采购，需另核资本口径与总经济支出的变化。</li>
-<li><strong>最需要弄清楚的事：</strong> 哪些原定今年验收的设备或机房已接近跨年，付款是否随之延后，财务有没有可提前支付的其他项目抵补？</li>
-</ul>
-<h3 id="35">3.5 【传导路径】现金压力先改变融资和股东回报，才可能压到建设预算</h3>
-<ul>
-<li><strong>判断：</strong> Meta 正在增加筹资手段，以维持建设速度。Dina 的职责说明了组织方向，停止回购、发债和合资项目则说明这一方向已经变成行动。只要这些资金来源仍可用，自由现金流变薄就不会立刻迫使资本预算下降；代价可能先体现为股东少收到现金，以及公司承担更多未来付款责任。</li>
-<li><strong>依据：</strong><ul>
-<li>📰 <span class="tag">来源陈述</span> Dina 的 <a href="https://www.linkedin.com/posts/dina-powell-mccormick_with-meta-compute-were-uniting-capital-activity-7448071525326401536-Mzeh" target="_blank" rel="noopener noreferrer">FII 本人原帖及视频转录</a>（2026-04-09）将 Meta Compute 描述为财务、基础设施与人才的协作，<u class="key">明确提到用公司资产负债表、主权基金、机构投资者和能源伙伴共同支持建设</u>。这证明她公开阐述的工作方向，不证明每个资金来源均已落实。</li>
-<li>🏛️ <span class="tag">事实</span> <a href="https://www.sec.gov/Archives/edgar/data/1326801/000162828026050705/meta-20260630.htm" target="_blank" rel="noopener noreferrer">Q2 季报</a>（2026-07-30）显示上半年没有回购、五月发行 25 十亿美元债券；<a href="https://investor.atmeta.com/investor-news/press-release-details/2026/Meta-Announces-New-Strategic-Venture-with-BlackRock-to-Develop-Data-Center-in-El-Paso/default.aspx" target="_blank" rel="noopener noreferrer">El Paso 公告</a>（2026-07-28）宣布合作开发约 14 十亿美元长期资产。<u class="key">公司已实际使用回购之外的现金安排和外部融资渠道</u>；合资安排仍附带 Meta 的租赁及担保责任。</li>
-<li>🏛️ <span class="tag">事实</span> <a href="https://about.fb.com/news/2026/08/agreement-with-state-attorneys-general-supporting-teens/" target="_blank" rel="noopener noreferrer">八月和解公告</a>与<a href="https://s21.q4cdn.com/399680738/files/doc_events/META-Conference-Call-on-Agreement-with-Bipartisan-Attorneys-General-Transcript.pdf" target="_blank" rel="noopener noreferrer">电话会</a>说明多年付款，并维持七月其余指引区间；<u class="minor">这次可分期的冲击被吸收后，资本计划仍保留</u>。</li>
-</ul>
-</li>
-<li><strong>为什么重要：</strong> 对本题，这些措施延后了“缺钱所以必须砍”的时点。对股东，资本预算维持却未必是好消息：投入回报仍待兑现，未来租金、担保和债务并未消失。真正需要提高警惕的是融资条件与主营业务同时转差，使继续建设的代价超过管理层愿意接受的范围。</li>
-<li><strong>最需要弄清楚的事：</strong> 下一批项目融资若达不到原定成本或担保条件，公司会提高自有资金投入，还是先缩减已批准的项目规模？</li>
-</ul>
+<h2 id="3-insight-summary">3. Insight Summary：哪些变化最值得跟踪？</h2>
+<p><strong>最值得优先验证的下调路径，是“工程与交付后移 → 当年付款减少 → 其他项目补不上”。</strong> 它无需管理层改变 AI 战略。更深一层的削减则需要“需求或回报下降 → 空余算力无人接手 → 后续采购减少”。设备价格、已签承诺与融资能力，会加强或阻断这两条路径。下面按这些问题展开；优先级是研究判断，不是已确认事件。</p>
+<p class="note">本节已重新综合前两轮材料。🏛️ 为正式文件，🎙️ 为本人访谈，📰 为新闻或本人原帖；下划线标出关键依据。来源所述事实与我们的推断分别表述。</p>
+
+<p><span id="insight-timing"></span></p>
+<h3 id="31">3.1 【传导路径】半年内的小幅下修，最值得查的是年底付款能否落地</h3>
+<p><strong>Meta 可以继续批准扩建，却仍然下修当年现金预算。</strong> 工程晚完工、设备晚交付，只有在相应付款也顺延、其他资本支出没有补上时，才会把项目延误传到公司总额。这是本次最优先核验的路径，因为它不需要先发生一次战略转向。</p>
+<p>🏛️ <a href="https://investor.atmeta.com/investor-news/press-release-details/2026/Meta-Reports-Second-Quarter-2026-Results/default.aspx" target="_blank" rel="noopener noreferrer">Q2 公告</a>（2026-07-29）披露上半年资本现金支付 50.918 十亿美元。用全年区间扣除已付金额，<u class="key">下半年仍需支付 79.082–94.082 十亿美元</u>；这是算术推导，不是公司单独发布的半年指引。📰 Janardhan 在<a href="https://www.linkedin.com/posts/sjanardhan_americas-workforce-academy-the-future-is-activity-7469869698331922432-JYIA" target="_blank" rel="noopener noreferrer">本人原帖</a>（2026-06-08）提到熟练施工人员不足，并公布培训措施，说明执行能力是负责人关注的约束。</p>
+<p>但付款集中在下半年，本身不能证明延期；用工风险也早于七月指引，可能已被公司考虑。<strong>能改变判断的，是指引发布后的具体进度变化。</strong> 下一步应核对原定年内验收的项目、相应付款节点及替代支出。公司若提前采购别的设备，仍可能维持总预算。普通云服务运营费用不能直接填补资本开支现金缺口。</p>
+<p><span id="insight-demand"></span></p>
+<h3 id="32">3.2 【传导路径】需求变弱以后，还要看空出的算力有没有人接走</h3>
+<p><strong>某个模型少训练，并不直接意味着下一批服务器少买。</strong> Meta 可以把空出的容量调给广告、推荐或其他模型。只有这些用途也不需要新增容量，财务与基础设施团队才有理由收回采购额度。因此，应追踪公司整体的追加需求，而不是用一个产品的成败代替资本预算判断。</p>
+<p>🎙️ Susan Li 在 <a href="https://cheekypint.transistor.fm/2/transcript" target="_blank" rel="noopener noreferrer">Cheeky Pint</a>（2025-06-18，24:16 起）解释，<u class="key">GPU 可以由中央重新分配</u>，同时承认广告吸收额外算力的能力也有上限。🎙️ Gross 在 <a href="https://www.youtube.com/watch?v=l9wzs_QIyp0" target="_blank" rel="noopener noreferrer">Stripe Sessions 原视频</a>（会期 2026-04-30，5 月 19 日上传，20:34–22:35）讨论用小模型完成部分任务、按生成物的经济价值分配预算；<a href="https://stripe.com/br/sessions/2026/a-conversation-with-daniel" target="_blank" rel="noopener noreferrer">发布方实录</a>可交叉核对。这些材料说明如何筛选需求，尚不能证明筛选已经减少公司设备订单。</p>
+<p>新增访谈让这一步更清楚：🎙️ Li 在 <a href="https://ca.investing.com/news/transcripts/meta-at-morgan-stanley-conference-ai-strategy-and-financial-insights-93CH-4495629" target="_blank" rel="noopener noreferrer">Morgan Stanley 访谈</a>（2026-03-04，第三方完整转录）描述按实验和追加回报评估预算；Bosworth 在 <a href="https://www.youtube.com/watch?v=qZhCeV6XATw" target="_blank" rel="noopener noreferrer">Big Technology</a>（2026-07-08，08:20–11:00；<a href="https://www.bigtechnology.com/p/metas-path-to-ai-relevance-according" target="_blank" rel="noopener noreferrer">编辑实录</a>7 月 9 日发布）说明自研也有约束外部模型价格的作用。所以外购增加与自研继续投入可以并存。</p>
+<p><strong>最有用的新证据，是取消训练之后的容量去向和采购变更。</strong> 如果资源很快被别的业务接走，削减信号就弱；若持续闲置并导致后续订单取消，信号才强。节省调用费、使用小模型或外购合作，都需要补齐这一步。</p>
+<p><span id="insight-orders"></span></p>
+<h3 id="33">3.3 【本质驱动】园区开工没有锁死全部设备预算，服务器数量和单价仍要分别预测</h3>
+<p><strong>机房先建、服务器后买，意味着“继续建园区”与“调整下一批设备”可以同时发生。</strong> 对已经进入建设阶段的长期资产，要查工程和付款承诺；对尚未下单的服务器，要查数量、采购价格和交付批次。不能用远期园区规模，推定全部设备支出已经不可调整。</p>
+<p>🏛️ <a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q2/META-Q2-2026-Earnings-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">Q2 正式电话会</a>（2026-07-29，PDF 第 8 页）区分了近期扩容与远期选择：面向 2028 年以后，<u class="key">先建设数据中心和网络基础，为后续服务器投资保留空间</u>。🎙️ Janardhan 的<a href="https://www.business-standard.com/companies/people/we-want-to-be-part-of-india-s-growth-story-meta-s-santosh-janardhan-126061801239_1.html" target="_blank" rel="noopener noreferrer">本人采访</a>（2026-06-19）也介绍分阶段建设、保留以后扩容选择。两者支持投资分阶段决定，均未披露半年内可撤销的设备金额。</p>
+<p>价格是另一条独立的金额通道。🏛️ <a href="https://investor.atmeta.com/investor-news/press-release-details/2026/Meta-Reports-First-Quarter-2026-Results/default.aspx" target="_blank" rel="noopener noreferrer">Q1 公告</a>（2026-04-29）把当次资本指引上调主要归因于组件价格上涨，另有部分未来容量投入。<strong>既然单价上涨能推高名义预算，单价回落也可能在需求不变时降低预算；但这是条件推演，尚不是已经发生的价格下行。</strong> 如果公司把便宜下来的预算用于多买设备，总额仍可不变。</p>
+<p>下一步应拿到后续服务器批次的数量、报价、取消条款和付款年度，再核对节省是否转投。公司仍强调尽可能增加近期容量，因此目前更应留意批次与单价调整；远期建设的灵活性，不能直接当作本窗口内必然削减的证据。</p>
+<p><span id="insight-intent"></span></p>
+<h3 id="34-ai">3.4 【本质驱动】仅有“AI 回报来得慢”，还不足以推翻继续扩容的判断</h3>
+<p><strong>Zuckerberg 已经把提前投入可能造成的损失纳入选择。</strong> 如果预测依赖“管理层发现 AI 有泡沫，所以马上少花”，就需要证明他对错过算力的担忧减弱了，或公司已承受不起等待成本。单纯重复过度投资的风险，不能完成这一步。</p>
+<p>🎙️ <a href="https://www.youtube.com/watch?v=23FyskyFoP8" target="_blank" rel="noopener noreferrer">Access 长访谈</a>（2025-09-18，01:09:10–01:13:55）中，他承认基础设施可能出现泡沫，但<u class="key">仍认为建设太慢、到时没有准备好的风险更大</u>，并以 Meta 能承受损失解释取舍。这是历史上的本人陈述；🏛️ <a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q2/META-Q2-2026-Earnings-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">七月业绩会</a>（2026-07-29）强调近期容量扩张，<a href="https://about.fb.com/news/2026/08/agreement-with-state-attorneys-general-supporting-teens/" target="_blank" rel="noopener noreferrer">八月和解公告</a>（2026-08-26）维持其余指引，提供了更近的行动依据。</p>
+<p>这支持继续投入的基准判断，却没有排除前述付款下修。<strong>真正会动摇战略投入的，是追加算力不再有吸引力，或主营业务与融资能力同时恶化。</strong> 需要查新年度预算评审是否出现明确的现金、负债或回报约束，以及触及约束后哪批项目先被停止。</p>
+<p><span id="insight-finance"></span></p>
+<h3 id="35">3.5 【传导路径】现金吃紧是否会变成少建项目，取决于融资缓冲还能用多久</h3>
+<p><strong>自由现金流变薄之后，公司仍可以调整回购、借款或引入合作方，继续支付建设费用。</strong> 这些选择延后了被迫削减的时点，也增加未来偿付责任。因此，资本预算保持不变，并不能说明投入已经产生足够回报。</p>
+<p>🏛️ <a href="https://www.sec.gov/Archives/edgar/data/1326801/000162828026050705/meta-20260630.htm" target="_blank" rel="noopener noreferrer">Q2 季报</a>（2026-07-30）显示<u class="key">上半年没有回购，五月发行了 25 十亿美元债券</u>；<a href="https://investor.atmeta.com/investor-news/press-release-details/2026/Meta-Announces-New-Strategic-Venture-with-BlackRock-to-Develop-Data-Center-in-El-Paso/default.aspx" target="_blank" rel="noopener noreferrer">El Paso 公告</a>（2026-07-28）宣布合作开发约 14 十亿美元长期资产。📰 Dina 的 <a href="https://www.linkedin.com/posts/dina-powell-mccormick_with-meta-compute-were-uniting-capital-activity-7448071525326401536-Mzeh" target="_blank" rel="noopener noreferrer">FII 本人原帖及视频转录</a>（2026-04-09）介绍资产负债表、主权基金、机构和能源伙伴等融资方向；季报和项目公告说明部分安排已经落地，原帖本身不证明所有资金均已落实。</p>
+<p>🏛️ <a href="https://about.fb.com/news/2026/08/agreement-with-state-attorneys-general-supporting-teens/" target="_blank" rel="noopener noreferrer">八月和解公告</a>及<a href="https://s21.q4cdn.com/399680738/files/doc_events/META-Conference-Call-on-Agreement-with-Bipartisan-Attorneys-General-Transcript.pdf" target="_blank" rel="noopener noreferrer">电话会</a>将付款分布在多年，同时保留七月其余指引。这次冲击被吸收，是当前预算韧性的证据，不能外推为任何冲击都能承受。<strong>最值得跟踪的是下一批融资的成本与条件，以及融资不及预期时公司是否削减已批准项目。</strong> 合作持有也可能改变报表分类；必须核对可比资本现金与租赁、担保责任，不能把融资安排直接算成经济投入下降。</p>
 <h2 id="4">4. 结算口径</h2>
 <h3 id="41-yes">4.1 什么算 YES？</h3>
 <p>观察窗按美国东部时间从 <strong>2026-09-06 00:00</strong> 到 <strong>2027-03-06 23:59</strong>。任一合格下调一经正式公开，即锁定 YES，之后再上调也不撤销。只考察名义美元计划，不做通胀调整。</p>
@@ -852,6 +846,7 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 <p><strong>能改变什么：</strong> 改变“执行调整进入正式指引”和“外部冲击迫使总预算变化”，幅度中；难以独立证明公司整体预算。</p>
 <p><strong>好不好约：</strong> 中高。公开项目多，但要防止把单个环节的信息误当全局。</p>
 <h2 id="8">8. 信源梯度反馈</h2>
+<p><strong>第四版综合说明：</strong> 本次按付款时点、需求转订单、采购价格与承诺、投入意愿及融资能力重写 Insights，使用已归档且截点内的材料。没有把编辑重组算作新增搜索，也没有声称填补 X 原帖正文缺口。<a href="/investment-analysis/reports/meta-capex-6m-assets/readability-v4/index.html" target="_blank" rel="noopener noreferrer">版本改写与检查记录</a>。</p>
 <p><strong>第三版结构核对：</strong> 回到 2024 Q4 与 2026 Q1/Q2 正式电话会及 Q2 季报，核对资产类别、现金与存量、组件价格及长期建设与服务器决策的时序。核验记录及分项判断见<a href="/investment-analysis/reports/meta-capex-6m-assets/capex-structure/index.html" target="_blank" rel="noopener noreferrer">结构研究台账</a>与<a href="/investment-analysis/reports/meta-capex-6m-assets/capex-structure/components.json" target="_blank" rel="noopener noreferrer">结构数据</a>。这次是有针对性的原文核对，未把它计作新一轮视频或社交采集。</p>
 <p><strong>第二轮补上了第一版明显不足的视频与社交覆盖，但仍不能称为穷尽。</strong> 第一版有 Susan Li 的文字访谈及正式电话会，却没有保存视频字幕，没有读取 X 原帖，也没有实际展开 Reddit 评论。本版把候选、正文、字幕和访问失败分别登记。</p>
 <div class="tablewrap"><table>
@@ -975,7 +970,7 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 <tr>
 <td>概率位置</td>
 <td>PASS</td>
-<td>概率只在第 1 节与附录；依模板要求第 10 节重复主结论。正文财务百分比和股权比例不属于事件概率；分项风险采用定性判断，演算金额不构成预测。</td>
+<td>概率只在第 1 节与附录；依模板要求第 10 节重复主结论。正文财务百分比和股权比例不属于事件概率；分项风险采用定性判断，四种情形用于解释因果条件，不构成独立概率输入。</td>
 </tr>
 <tr>
 <td>精度与范围</td>
@@ -1003,9 +998,9 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 <td>官方现金桥接与主要投向已核验；年度分项金额未披露，不以资产存量或研究注意力分摊预算。</td>
 </tr>
 <tr>
-<td>分项与演算</td>
+<td>分项与情形</td>
 <td>PASS / LIMITED</td>
-<td>每项方向、触发与反证均可展开；抵消演算明确为假设，不参与总概率计算。</td>
+<td>保留分项方向、触发与反证；四种情形列明总额下降条件，不使用任意演算金额，不参与概率计算。</td>
 </tr>
 <tr>
 <td>文稿与视觉</td>
@@ -1014,12 +1009,12 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 </tr>
 </tbody>
 </table></div>
-<p>研究文件：<a href="/investment-analysis/reports/meta-capex-6m-assets/history.csv" target="_blank" rel="noopener noreferrer">历史明细</a>、<a href="/investment-analysis/reports/meta-capex-6m-assets/source-coverage.html" target="_blank" rel="noopener noreferrer">来源与覆盖记录</a>、<a href="/investment-analysis/reports/meta-capex-6m-assets/forecast-audit-v2.json" target="_blank" rel="noopener noreferrer">计算审计</a>、<a href="/investment-analysis/reports/meta-capex-6m-assets/qa-results-v3.json" target="_blank" rel="noopener noreferrer">验收记录</a>。正文能独立阅读，附属文件用于复核计算及访问边界。</p>
+<p>研究文件：<a href="/investment-analysis/reports/meta-capex-6m-assets/history.csv" target="_blank" rel="noopener noreferrer">历史明细</a>、<a href="/investment-analysis/reports/meta-capex-6m-assets/source-coverage.html" target="_blank" rel="noopener noreferrer">来源与覆盖记录</a>、<a href="/investment-analysis/reports/meta-capex-6m-assets/forecast-audit-v2.json" target="_blank" rel="noopener noreferrer">计算审计</a>、<a href="/investment-analysis/reports/meta-capex-6m-assets/qa-results-v4.json" target="_blank" rel="noopener noreferrer">验收记录</a>。正文能独立阅读，附属文件用于复核计算及访问边界。</p>
 <h2 id="10">10. 最终预测声明</h2>
 <p><strong>Meta 在 2027-03-06 23:59（美国东部时间）前正式下调可比口径名义资本开支计划的概率：32%；合理范围 20–45%；倾向 NO；主观置信度中低。</strong></p>
 <p>最可能看到的现实是，Meta 继续争取近两年的计算资源，同时在部分项目上调整节奏、融资结构或交付安排。正式削减仍是值得认真对待的少数情景，其中最现实的是年度付款和工程进度导致指引下修；即使发生，也需要再判断是否代表长期需求减少。不构成投资建议。</p>
 <h2 id="a1">A1. 概率模型与数值代入</h2>
-<p><strong>第三版说明：</strong> 主模型继续使用第二版四轮证据回放。第 2 节按资产拆开同一决策链，未形成新的独立概率输入；分项风险不能平均或相乘得到总概率。交互金额仅展示净额抵消。所有原计权、历史窗口与六条结果路径均维持。</p>
+<p><strong>第三版说明：</strong> 主模型继续使用第二版四轮证据回放。第 2 节按资产拆开同一决策链，未形成新的独立概率输入；分项风险不能平均或相乘得到总概率。第四版以四种情形说明净额变化的条件，已撤下假设金额演算。所有原计权、历史窗口与六条结果路径均维持。</p>
 <h3 id="a11">A1.1 从经验频率到本次判断</h3>
 <div class="tablewrap"><table>
 <thead>
@@ -2029,57 +2024,19 @@ P（正式下调）＝更新后几率 ÷ (1＋更新后几率) ≈ <b>32%</b><br
 </tbody>
 </table></div>
 <script>
-(function(){
+(function () {
   'use strict';
-  const state = {"midpoint":137.5,"components":[{"id":"servers","short":"服务器"},{"id":"datacenters","short":"数据中心"},{"id":"network","short":"网络"},{"id":"other","short":"其他资产"},{"id":"lease","short":"租赁本金"}],"scenarios":[{"id":"offset","name":"一减一增","deltas":{"servers":5,"datacenters":-5,"network":0,"other":0,"lease":0},"explanation":"假设数据中心少付 5、服务器多付 5：单项减少被抵消，总计划中点不变。"},{"id":"delay","name":"付款跨年","deltas":{"servers":0,"datacenters":-5,"network":0,"other":0,"lease":0},"explanation":"假设数据中心的 5 顺延到下一年，且没有其他项目补上：当前年度中点减少 5。长期建设规模可以不变。"},{"id":"price","name":"设备降价","deltas":{"servers":-8,"datacenters":5,"network":0,"other":0,"lease":0},"explanation":"假设服务器少花 8、数据中心多花 5：净额减少 3；即使算力不减少，也可能形成名义计划下调。"},{"id":"network_delay","name":"集群交付后移","deltas":{"servers":-5,"datacenters":2,"network":-1,"other":0,"lease":0},"explanation":"假设服务器与配套网络合计少付 6、建设多付 2：同一交付原因产生两项变化，净额减少 4。"},{"id":"unchanged","name":"全部归零","deltas":{"servers":0,"datacenters":0,"network":0,"other":0,"lease":0},"explanation":"所有输入归零。金额输入只用于理解同一年度预算加总，不代表已知的分项预算或可削减额度。"}]};
-  const root = document.getElementById('capex-simulator');
+  const root = document.getElementById('capex-scenarios');
   if (!root) return;
-  const byId = id => document.getElementById(id);
-  const inputs = state.components.map(c => byId('cx-input-' + c.id));
-  const buttons = Array.from(root.querySelectorAll('button[data-scenario]'));
-  const signed = value => (value > 0 ? '+' : '') + value.toFixed(1);
-  function update(){
-    let net = 0;
-    state.components.forEach((c, index) => {
-      const value = Number(inputs[index].value);
-      net += value;
-      inputs[index].setAttribute('aria-valuetext', signed(value) + ' 十亿美元');
-      byId('cx-value-' + c.id).textContent = signed(value);
-      byId('cx-bar-value-' + c.id).textContent = signed(value);
-      const bar = byId('cx-bar-' + c.id);
-      bar.style.width = (Math.abs(value) / 20 * 50) + '%';
-      bar.classList.toggle('cx-positive', value > 0);
-    });
-    net = Math.round(net * 10) / 10;
-    byId('cx-net').textContent = signed(net);
-    byId('cx-midpoint').textContent = (state.midpoint + net).toFixed(1);
-    const formal = byId('cx-formal').checked;
-    const result = byId('cx-result');
-    result.dataset.negative = String(net < 0);
-    if (net < 0) {
-      result.textContent = formal ? '在这些假设下，符合主口径 YES：公司在窗口内正式下调同年可比计划。' : '净额减少，金额条件满足；仍需 Meta 在观察窗内正式公布这项可比修订，才构成 YES。';
-    } else if (net > 0) {
-      result.textContent = '净额增加：本次假设修订属于上调，不能凭其中某一项减少结算 YES。';
-    } else {
-      result.textContent = '净额不变：本演算没有构成公司总计划下调。';
-    }
+  const buttons = Array.from(root.querySelectorAll('button[data-case]'));
+  const panels = Array.from(root.querySelectorAll('.rv-panel'));
+  function select(id) {
+    buttons.forEach(button => button.setAttribute('aria-pressed', String(button.dataset.case === id)));
+    panels.forEach(panel => { panel.hidden = panel.id !== 'case-' + id; });
   }
-  buttons.forEach(button => button.addEventListener('click', () => {
-    const scenario = state.scenarios.find(s => s.id === button.dataset.scenario);
-    state.components.forEach((c, index) => { inputs[index].value = scenario.deltas[c.id]; });
-    buttons.forEach(b => b.setAttribute('aria-pressed', String(b === button)));
-    byId('cx-scenario-note').textContent = scenario.explanation;
-    byId('cx-formal').checked = false;
-    update();
-  }));
-  inputs.forEach(input => input.addEventListener('input', () => {
-    buttons.forEach(b => b.setAttribute('aria-pressed', 'false'));
-    byId('cx-scenario-note').textContent = '自定义假设：请确保所有增减都属于同一年度、同一现金口径，没有重复计入同一资产。';
-    byId('cx-formal').checked = false;
-    update();
-  }));
-  byId('cx-formal').addEventListener('change', update);
-  update();
+  buttons.forEach(button => button.addEventListener('click', () => select(button.dataset.case)));
+  select('timing');
 })();
+
 </script></main></div>
 </body></html>

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -28,10 +28,10 @@
 | Delta PM | `services/delta-pm`、`apps/delta-pm-console`、`/live-delta-pm` | 新闻→重要性→priced-in→纸面决策审计链 |
 | Raven Delta | `apps/raven-delta`、`/delta` | 美股新闻影响分析、邮件 / WebSocket 推送 |
 | World Cup blind forecast | `scripts/world-cup`、`apps/web/app/world-cup` | 预测生成严禁读取市场价格；事后评分可使用市场基准 |
-| AI 投研系统案例 | `apps/web/app/[locale]/investment-analysis`、`/investment-analysis` | 三份公开案例：腾讯混元 × WorkBuddy、Hassabis × Alphabet、[Meta 半年资本开支](https://forecasting-agent.com/investment-analysis/meta-capex-6m)（v3，截点 2026-09-06） |
+| AI 投研系统案例 | `apps/web/app/[locale]/investment-analysis`、`/investment-analysis` | 三份公开案例：腾讯混元 × WorkBuddy、Hassabis × Alphabet、[Meta 半年资本开支](https://forecasting-agent.com/investment-analysis/meta-capex-6m)（v4，截点 2026-09-06） |
 | Polymarket live pipeline | `services/orchestrator`、`services/executor` | 真钱路径；任何 live 命令、风控调整或订单测试都需要用户明确确认 |
 
-后续投资资料统一去除客户品牌标签。Meta v3 公开经过复核的来源摘要与审计附件，完整字幕留在本地；按用户要求，本站报告 iframe 统一不设置 `sandbox`，脚本交互与附件下载正常启用；新报告沿用同一容器，不再按公司单独放行。
+后续投资资料统一去除客户品牌标签。Meta v4 公开经过复核的来源摘要与审计附件，完整字幕留在本地；第四版用四种条件情形替代假设金额演算，先概括付款、需求转订单、价格、承诺与融资，再展开 Insights；按用户要求，本站报告 iframe 统一不设置 `sandbox`，脚本交互与附件下载正常启用；新报告沿用同一容器，不再按公司单独放行。
 
 ## 3. 当前最主要的技术 WIP：GPT Pro v2 harness
 

--- a/docs/en/agent-handoff.md
+++ b/docs/en/agent-handoff.md
@@ -28,10 +28,10 @@
 | Delta PM | `services/delta-pm`, `apps/delta-pm-console`, `/live-delta-pm` | News → importance → priced-in → paper-decision audit chain |
 | Raven Delta | `apps/raven-delta`, `/delta` | US-equity news-impact analysis with email / WebSocket delivery |
 | World Cup blind forecast | `scripts/world-cup`, `apps/web/app/world-cup` | Generation may not read prices; post-hoc scoring may use a market benchmark |
-| AI investment research cases | `apps/web/app/[locale]/investment-analysis`, `/investment-analysis` | Three public cases: Tencent Hunyuan × WorkBuddy, Hassabis × Alphabet, and [Meta six-month capex](https://forecasting-agent.com/investment-analysis/meta-capex-6m) (v3, as of 2026-09-06) |
+| AI investment research cases | `apps/web/app/[locale]/investment-analysis`, `/investment-analysis` | Three public cases: Tencent Hunyuan × WorkBuddy, Hassabis × Alphabet, and [Meta six-month capex](https://forecasting-agent.com/investment-analysis/meta-capex-6m) (v4, as of 2026-09-06) |
 | Polymarket live pipeline | `services/orchestrator`, `services/executor` | Real-money path; live runs, risk changes, and order probes require explicit user approval |
 
-Investment reports omit customer branding from now on. Meta v3 publishes reviewed source summaries and audit attachments; full transcripts remain local. Per the user request, first-party report iframes omit `sandbox`, so scripts and attachment downloads work normally. Future reports use the same container without company-specific exceptions.
+Investment reports omit customer branding from now on. Meta v4 publishes reviewed source summaries and audit attachments; full transcripts remain local. Version 4 replaces the arbitrary-dollar calculator with four conditional scenarios and prioritizes payment timing, demand-to-order conversion, prices, commitments and financing. Per the user request, first-party report iframes omit `sandbox`, so scripts and attachment downloads work normally. Future reports use the same container without company-specific exceptions.
 
 ## 3. Primary technical WIP: GPT Pro v2 harness
 


### PR DESCRIPTION
The Meta report’s arbitrary-dollar calculator looked like a component forecast and did not explain which real events would lower consolidated capex. Version 4 replaces it with four conditional scenarios, adds the forecast tasks and research priorities up front, and rewrites Insights around payment timing, demand-to-order conversion, procurement prices and commitments, management intent, and financing.

The frozen question, 32% probability, source cutoff, asset judgments, model weights and historical/outcome-path analysis remain unchanged. The revision adds no new research-round claim. Published attachment links and English/Simplified/Traditional Chinese case descriptions are updated; first-party report containers remain unrestricted as requested.

Validation: `pnpm --filter @autopoly/web build` passed; 80 report checks passed. Real-browser scenario switching, keyboard selection, evidence expansion, public attachments and iframe scripting passed at 1440, 390 and 360 pixels, with zero console errors or horizontal overflow. Desktop and mobile screenshots were inspected. Only report content, related message resources and bilingual handoff notes change.
