### PR TITLE
Meta 报告：明确立场、补齐预算逻辑并纠正跨年规则

### DIFF
--- a/apps/web/lib/world-cup/messages/en.json
+++ b/apps/web/lib/world-cup/messages/en.json
@@ -289,10 +289,10 @@
   "iaGoogleFrameTitle": "Full Demis Hassabis and Alphabet investment analysis report in Chinese",
   "iaMetaCapexCompany": "Meta Platforms · Capital expenditure",
   "iaMetaCapexTitle": "Will Meta formally lower its capex plan within six months?",
-  "iaMetaCapexSummary": "A Chinese-language report connecting asset purchases, prices and payment timing to Meta’s total capex plan, with official disclosures, video transcripts, social research and four interactive scenarios.",
+  "iaMetaCapexSummary": "Our judgment: Meta is more likely to maintain or raise capex. The report connects business demand, resource reallocation and financing to the budget, with product evidence and explanations of year-end delivery and payment shifts.",
   "iaMetaCapexSignalLabel": "Formal cut probability · 6 months",
-  "iaMetaCapexSignal": "32% · NO 68%",
+  "iaMetaCapexSignal": "34% · NO 66%",
   "iaMetaCapexMetaTitle": "Meta six-month capex forecast — Predict Raven",
-  "iaMetaCapexMetaDescription": "A six-month forecast as of September 6, 2026: YES 32%, subjective range 20–45%, with research priorities, asset forecasts and four interactive scenario explanations.",
+  "iaMetaCapexMetaDescription": "Meta six-month capex forecast as of September 6, 2026: YES 34%, subjective range 20–45%. Explicit stance, business evidence, asset forecasts and delivery/payment scenarios.",
   "iaMetaCapexFrameTitle": "Full Meta six-month capital expenditure report in Chinese"
 }

--- a/apps/web/lib/world-cup/messages/zh-CN.json
+++ b/apps/web/lib/world-cup/messages/zh-CN.json
@@ -289,10 +289,10 @@
   "iaGoogleFrameTitle": "Demis Hassabis 与 Alphabet 完整投资分析报告",
   "iaMetaCapexCompany": "Meta Platforms · 资本开支",
   "iaMetaCapexTitle": "Meta 会在半年内正式下调资本开支计划吗？",
-  "iaMetaCapexSummary": "沿服务器、数据中心、网络等资产判断数量、价格与付款时点，综合原始披露、视频字幕及社交研究，用四种情形解释何时会下调总计划。",
+  "iaMetaCapexSummary": "我们判断，Meta 更可能维持或上调资本开支。报告以多个内部业务需求、资源重配与融资缓冲解释预算支撑，逐项列出业务产出，并说明交付与付款跨年如何导致下调。",
   "iaMetaCapexSignalLabel": "半年内正式下调概率",
-  "iaMetaCapexSignal": "32% · NO 68%",
+  "iaMetaCapexSignal": "34% · NO 66%",
   "iaMetaCapexMetaTitle": "Meta 半年资本开支预测｜Predict Raven",
-  "iaMetaCapexMetaDescription": "以 2026-09-06 为基线的 Meta 六个月资本开支预测：YES 32%，合理范围 20–45%，含预测主线、资产分项判断与交互情形对照。",
+  "iaMetaCapexMetaDescription": "以 2026-09-06 为基线的 Meta 半年资本开支预测：YES 34%，合理范围 20–45%。含明确立场、业务产出与预算申请、资产分项及交付付款情形。",
   "iaMetaCapexFrameTitle": "Meta 六个月资本开支完整投资分析报告"
 }

--- a/apps/web/lib/world-cup/messages/zh-TW.generated.json
+++ b/apps/web/lib/world-cup/messages/zh-TW.generated.json
@@ -289,10 +289,10 @@
   "iaGoogleFrameTitle": "Demis Hassabis 與 Alphabet 完整投資分析報告",
   "iaMetaCapexCompany": "Meta Platforms · 資本開支",
   "iaMetaCapexTitle": "Meta 會在半年內正式下調資本開支計劃嗎？",
-  "iaMetaCapexSummary": "沿服務器、數據中心、網絡等資產判斷數量、價格與付款時點，綜合原始披露、視頻字幕及社交研究，用四種情形解釋何時會下調總計劃。",
+  "iaMetaCapexSummary": "我們判斷，Meta 更可能維持或上調資本開支。報告以多個內部業務需求、資源重配與融資緩衝解釋預算支撐，逐項列出業務產出，並說明交付與付款跨年如何導致下調。",
   "iaMetaCapexSignalLabel": "半年內正式下調概率",
-  "iaMetaCapexSignal": "32% · NO 68%",
+  "iaMetaCapexSignal": "34% · NO 66%",
   "iaMetaCapexMetaTitle": "Meta 半年資本開支預測｜Predict Raven",
-  "iaMetaCapexMetaDescription": "以 2026-09-06 為基線的 Meta 六個月資本開支預測：YES 32%，合理範圍 20–45%，含預測主線、資產分項判斷與交互情形對照。",
+  "iaMetaCapexMetaDescription": "以 2026-09-06 為基線的 Meta 半年資本開支預測：YES 34%，合理範圍 20–45%。含明確立場、業務產出與預算申請、資產分項及交付付款情形。",
   "iaMetaCapexFrameTitle": "Meta 六個月資本開支完整投資分析報告"
 }

--- a/apps/web/public/investment-analysis/reports/meta-capex-6m-assets/publication-manifest.json
+++ b/apps/web/public/investment-analysis/reports/meta-capex-6m-assets/publication-manifest.json
@@ -1,19 +1,24 @@
 {
-  "publishedReportVersion": "v4",
+  "publishedReportVersion": "v5",
   "researchCutoff": "2026-09-06",
-  "canonicalHtmlSha256": "cbe2ce46a00e2429d0d9cd8aa87019c69e5677aa1e198f836eb973c78773312a",
+  "canonicalHtmlSha256": "3d205061cdc8c476090b77a37523796c7e431802ee15e75042ae1dc10305a720",
   "reportTextAndNumbersPreserved": true,
   "stylesAndScriptsPreserved": true,
   "fullTranscriptsPublished": false,
   "files": {
-    "meta-capex-6m.html": "2042bfcc2d7794ed3ec49e65bcaad5ce3a403d30de2d7f013b836a0d8408f709",
-    "meta-capex-6m-assets/readability-v4/index.html": "83d7b6ad46c77d07ffbd6cb036e7a51ac3246ef1e4ab55a14c42ca4216151374",
+    "meta-capex-6m.html": "b5cbead1a09757c8d23b68b5f02c6f66a8d66347a08946fecb518c971ec09eb7",
+    "meta-capex-6m-assets/thesis-v5/index.html": "dae4a5a7055ef6ef72dd7c42b1d2d33a6051b6347935c236b01233fb8795a91d",
+    "meta-capex-6m-assets/thesis-v5/business-evidence.html": "d9b48112f360f0a975ce8f0641930f44663e65bf5efd6d53e5d9f50bc3050fe7",
+    "meta-capex-6m-assets/thesis-v5/resolution-review.html": "0eb2eef354d748792d0b6fb39877150f5ef2553699f876018395bc7b5cb16349",
+    "meta-capex-6m-assets/thesis-v5/forecast-audit-v5.json": "5645c12b0fadff92e67c6e427322a1d1dc548309869447e5cb5eaa31147d24bc",
+    "meta-capex-6m-assets/thesis-v5/resolution-cases.json": "cbaead483f71c246a32ed2fcae6e8c2f4c459df99b89cbab1759297ad1ff32ac",
+    "meta-capex-6m-assets/readability-v4/index.html": "e899daf7644552b6d601a6c269418e32e1284a6fe2f3873f2be6be1d7d425286",
     "meta-capex-6m-assets/capex-structure/index.html": "7acaf61ef017094331b8c74c878274fdce22a5024e38a35d95eacfd53303b0a6",
     "meta-capex-6m-assets/capex-structure/components.json": "67c246b98fce6c82bce83fab278f1b0146217ff3f444d25bf2d587617cf761c2",
     "meta-capex-6m-assets/media-social/index.html": "42745f83b3b07620847653484525bbb435b6be079e0bdcdfa5340e2313334131",
     "meta-capex-6m-assets/source-coverage.html": "2bf2fc0be139522cd2581349709048a9ee14f1610dda491926f43aa32304cf72",
     "meta-capex-6m-assets/history.csv": "cc2dedc3c0fdc08ac299cbf9ffd905277c73dd807c7e279f0013c35b74387efb",
     "meta-capex-6m-assets/forecast-audit-v2.json": "133d23770067dbf9b2ee9f9c96b99a2e2ca124944da9130fe0a6a6647ff87adf",
-    "meta-capex-6m-assets/qa-results-v4.json": "9b2dd4c60eff32305e77c76e36b5d1203f8fdda7c0765bed2d63995cff873955"
+    "meta-capex-6m-assets/qa-results-v5.json": "b0d8769fb311b30cd4019a0d7c2263fcfd7752eee8fea4d1d56493b301922d8e"
   }
 }

--- a/apps/web/public/investment-analysis/reports/meta-capex-6m-assets/qa-results-v5.json
+++ b/apps/web/public/investment-analysis/reports/meta-capex-6m-assets/qa-results-v5.json
@@ -1,0 +1,769 @@
+{
+  "checks": [
+    {
+      "name": "frozen_question_verbatim",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "original_question_verbatim",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "main_sections",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "appendices",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "five_insights",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "source_refs_resolve",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "all_reference_ids_defined",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "rendered_percentages_and_dates_match",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "headline_matches_replay_plus_rule_delta",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "headline_sections_match",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "yes_no_total",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "yes_paths_match",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "path_values_appear_in_html",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "probability_recomputed",
+      "status": "PASS",
+      "detail": {
+        "llr": -1.15,
+        "probability": 0.322013284782553
+      }
+    },
+    {
+      "name": "same_cluster_discount",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "round_count",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "source_provenance",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "no_post_cutoff_counted_source",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "input_hash",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "replay_transparency",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "historical_record_count",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "historical_counts",
+      "status": "PASS",
+      "detail": {
+        "首次": 9,
+        "上调": 13,
+        "维持": 10,
+        "下调": 11
+      }
+    },
+    {
+      "name": "historical_arithmetic",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "historical_windows",
+      "status": "PASS",
+      "detail": [
+        {
+          "start_year": 2018,
+          "yes": true,
+          "events": [
+            "2018-10-30"
+          ]
+        },
+        {
+          "start_year": 2019,
+          "yes": true,
+          "events": [
+            "2019-10-30"
+          ]
+        },
+        {
+          "start_year": 2020,
+          "yes": false,
+          "events": []
+        },
+        {
+          "start_year": 2021,
+          "yes": true,
+          "events": [
+            "2021-10-25"
+          ]
+        },
+        {
+          "start_year": 2022,
+          "yes": true,
+          "events": [
+            "2022-11-09",
+            "2023-02-01"
+          ]
+        },
+        {
+          "start_year": 2023,
+          "yes": true,
+          "events": [
+            "2023-10-25"
+          ]
+        },
+        {
+          "start_year": 2024,
+          "yes": false,
+          "events": []
+        },
+        {
+          "start_year": 2025,
+          "yes": false,
+          "events": []
+        }
+      ]
+    },
+    {
+      "name": "cash_lease_bridge",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "h2_cash_bounds",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "fcf_bridge",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "all_tables_wrapped",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "evidence_table_20_rows",
+      "status": "PASS",
+      "detail": 20
+    },
+    {
+      "name": "asset_structure_replaces_attention_root",
+      "status": "PASS",
+      "detail": []
+    },
+    {
+      "name": "substantial_cut_overlap",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "sensitivity_math",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "local_artifact_links",
+      "status": "PASS",
+      "detail": []
+    },
+    {
+      "name": "toc_targets",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "probability_location_review",
+      "status": "PASS",
+      "detail": [
+        {
+          "line": 130,
+          "section": "2",
+          "text": "内容推荐已披露产出与证明限度管理层称 Q1 排序改进使 Instagram Reels 观看时长提升 10%。管理层对改进效果的归因，不是全部时长的同比增长，也不是利润增长。Q1 第 5 页 · 2026-04-29可支持的预算申请可支持继续优化推荐模型、申请训练与推理资源。扩大设备预算还要证明新增参与度能变现，追加收益高于计算成本。"
+        },
+        {
+          "line": 131,
+          "section": "2",
+          "text": "广告创意工具已披露产出与证明限度超过 900 万家小企业使用至少一种 AI 创意工具；另有 Q1 视频生成测试，广告主转化率相对提升超过 3%。采用规模与测试效果来自不同人群，不能相乘；超过 3% 不是增加 3 个百分点。Q2 第 7 页；测试见 Q1 第 7 页 · 2026-07-29 · Q1 测试原文可支持的预算申请采用数据支持服务容量，测试结果支持扩大试验。新增设备申请仍需持续调用量、增量广告收益与单位生成成本。"
+        },
+        {
+          "line": 132,
+          "section": "2",
+          "text": "企业代理已披露产出与证明限度Meta 转述 Movida 个案：一个月观察期内，WhatsApp 日均预订同比增加 44%，85% 对话由 AI 独立处理。单一客户、单一渠道的效果，不是 Meta 收入，也不证明全体客户可复制。Q2 第 8 页 · 2026-07-29可支持的预算申请可支持试点扩展、客户接入和稳定服务。大规模商业容量申请还需多个客户复现、持续付费及正毛利。"
+        },
+        {
+          "line": 133,
+          "section": "2",
+          "text": "Meta AI 助手已披露产出与证明限度管理层称重建助手并整合 Muse Spark 后，每日互动人数增加 60%。用量变化；该段未给精确对照日期和绝对人数，不能解释为付费用户或收入增长。Q2 第 2 页 · 2026-07-29可支持的预算申请可支持满足真实推理需求、改善响应。能否增加自有设备，取决于留存、服务成本及现有或外部容量是否足够。"
+        },
+        {
+          "line": 205,
+          "section": "2",
+          "text": "| 顶层治理 | 🏛️ 2026-04-16 代理声明显示，4 月 1 日 Zuckerberg 拥有 **60.8%** 总投票权；公司已设置风险与战略委员会、审计与隐私委员会。[来源][proxy] | 委员会重组发生在 2025 年六月，属于本次十二个月窗口之前；本期文件确认新结构延续。旧“审计与风险监督委员会”名称不再照搬。 |"
+        },
+        {
+          "line": 317,
+          "section": "4",
+          "text": "“至少减少 5%”只属于敏感性口径。它比较**同一未来十二个月**与基线版本的计划，不能用 2026 全年中点直接替代跨年的十二个月基准。基线日没有公开的完整滚动十二个月预算，因此这项判断的证据要求更高、置信度更低。"
+        }
+      ]
+    },
+    {
+      "name": "repository_linter",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "browser_review_recorded",
+      "status": "PASS",
+      "detail": {
+        "url": "http://127.0.0.1:3109/meta-capex-6m-report-v5.html",
+        "phase": "local-v5",
+        "interaction_tests": {
+          "checks": [
+            {
+              "name": "HTTP 200",
+              "pass": true
+            },
+            {
+              "name": "No sandbox",
+              "pass": true
+            },
+            {
+              "name": "No customer brand",
+              "pass": true
+            },
+            {
+              "name": "Fifth edition",
+              "pass": true
+            },
+            {
+              "name": "Explicit stance",
+              "pass": true
+            },
+            {
+              "name": "Current probability",
+              "pass": true
+            },
+            {
+              "name": "Six business rows",
+              "pass": true
+            },
+            {
+              "name": "Delivery payment steps",
+              "pass": true
+            },
+            {
+              "name": "Default timing case",
+              "pass": true
+            },
+            {
+              "name": "Select timing",
+              "pass": true
+            },
+            {
+              "name": "Old chart explanation timing",
+              "pass": true
+            },
+            {
+              "name": "Select demand",
+              "pass": true
+            },
+            {
+              "name": "Old chart explanation demand",
+              "pass": true
+            },
+            {
+              "name": "Select price",
+              "pass": true
+            },
+            {
+              "name": "Old chart explanation price",
+              "pass": true
+            },
+            {
+              "name": "Select reallocate",
+              "pass": true
+            },
+            {
+              "name": "Old chart explanation reallocate",
+              "pass": true
+            },
+            {
+              "name": "Keyboard selection",
+              "pass": true
+            },
+            {
+              "name": "Asset evidence opens",
+              "pass": true
+            },
+            {
+              "name": "Mobile selection",
+              "pass": true
+            },
+            {
+              "name": "No fabricated calculator",
+              "pass": true
+            },
+            {
+              "name": "All anchors resolve",
+              "pass": true
+            },
+            {
+              "name": "No console errors",
+              "pass": true,
+              "detail": []
+            },
+            {
+              "name": "Responsive fit",
+              "pass": true
+            }
+          ],
+          "all_passed": true
+        },
+        "viewports": [
+          {
+            "innerWidth": 1440,
+            "docWidth": 1425,
+            "figures": [
+              {
+                "id": "forecast-priorities",
+                "width": 1005,
+                "scroll": 1005
+              },
+              {
+                "id": "capex-structure",
+                "width": 1005,
+                "scroll": 1005
+              },
+              {
+                "id": "capex-forecast",
+                "width": 1005,
+                "scroll": 1005
+              },
+              {
+                "id": "business-evidence",
+                "width": 1005,
+                "scroll": 1005
+              },
+              {
+                "id": "capex-scenarios",
+                "width": 1005,
+                "scroll": 1005
+              },
+              {
+                "id": "delivery-payment",
+                "width": 1005,
+                "scroll": 1005
+              }
+            ]
+          },
+          {
+            "innerWidth": 390,
+            "docWidth": 375,
+            "figures": [
+              {
+                "id": "forecast-priorities",
+                "width": 313,
+                "scroll": 313
+              },
+              {
+                "id": "capex-structure",
+                "width": 313,
+                "scroll": 313
+              },
+              {
+                "id": "capex-forecast",
+                "width": 313,
+                "scroll": 313
+              },
+              {
+                "id": "business-evidence",
+                "width": 313,
+                "scroll": 313
+              },
+              {
+                "id": "capex-scenarios",
+                "width": 313,
+                "scroll": 313
+              },
+              {
+                "id": "delivery-payment",
+                "width": 313,
+                "scroll": 313
+              }
+            ]
+          },
+          {
+            "innerWidth": 360,
+            "docWidth": 345,
+            "figures": [
+              {
+                "id": "forecast-priorities",
+                "width": 283,
+                "scroll": 283
+              },
+              {
+                "id": "capex-structure",
+                "width": 283,
+                "scroll": 283
+              },
+              {
+                "id": "capex-forecast",
+                "width": 283,
+                "scroll": 283
+              },
+              {
+                "id": "business-evidence",
+                "width": 283,
+                "scroll": 283
+              },
+              {
+                "id": "capex-scenarios",
+                "width": 283,
+                "scroll": 283
+              },
+              {
+                "id": "delivery-payment",
+                "width": 283,
+                "scroll": 283
+              }
+            ]
+          }
+        ],
+        "errors": [],
+        "visual_review": "PASS",
+        "visual_notes": "Viewed desktop business matrix and delivery chain plus 390px business and financing views. Text is readable, rows stack with labels, no clipping or overflow."
+      }
+    },
+    {
+      "name": "eight_caption_programs",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "caption_files_and_hashes",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "caption_metadata_before_cutoff",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "six_recent_caption_programs",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "caption_duration_report",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "caption_end_coverage_review",
+      "status": "PASS",
+      "detail": "Dwarkesh publisher captions end at the spoken closing thanks (01:15:18.762); video duration 01:15:49. Remaining tail not transcribed. Other tracks end within 25 seconds of video end."
+    },
+    {
+      "name": "candidate_program_count",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "two_additional_full_texts",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "social_original_count",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "x_gap_disclosed",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "forum_bodies_and_comments",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "six_new_zero_weight_records",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "v1_probabilities_and_paths_preserved",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "original_eight_weights_preserved",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "insights_connected_paragraphs",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "each_insight_load_bearing_evidence",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "generic_market_strawman_removed",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "three_figures",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "four_assets_one_cash_bridge",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "five_component_forecasts",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "complete_component_reasoning",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "component_sources_resolve",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "undisclosed_allocations_not_fabricated",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "unknown_category_preserved",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "cash_chart_reconciles",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "no_stock_flow_confusion",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "cloud_opex_correction",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "historical_share_scope",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "four_explanatory_cases",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "calculator_retired",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "case_sources_resolve",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "nonprobabilistic_case_scope",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "forecast_framework_present",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "all_case_panels_readable_without_js",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "all_local_anchor_targets",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "no_duplicate_ids",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "probability_reuse_transparent",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "historical_appendix_unchanged",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "browser_interaction_suite",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "desktop_mobile_no_overflow",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "restored_original_or_rule",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "five_asset_forecasts_unchanged",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "no_new_research_claim",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "explicit_stance",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "six_business_evidence_rows",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "business_budget_chain",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "financing_not_roi",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "delivery_payment_distinction",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "four_cash_transmission_steps",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "rule_delta_transparent",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "exclusive_paths_include_boundary",
+      "status": "PASS",
+      "detail": null
+    },
+    {
+      "name": "no_client_brand",
+      "status": "PASS",
+      "detail": null
+    }
+  ],
+  "pass": 89,
+  "fail": 0,
+  "html_sha256": "3d205061cdc8c476090b77a37523796c7e431802ee15e75042ae1dc10305a720",
+  "markdown_sha256": "cda7b531a83d312abcaa5764d98c0062d205a5b43b359f91c23fb7a1b8fe883a",
+  "unique_external_urls": 95,
+  "notes": [
+    "Source-date checks cover weighted evidence; citation dates and future planned dates were separately reviewed.",
+    "Local links and reference resolution are checked; this is not a blanket network availability test.",
+    "All financial/factual percentages outside conclusion and appendices are listed for review."
+  ],
+  "publicExportNote": "Checks and hashes refer to the canonical local v5 report. The public copy changes link destinations and new-tab attributes only; its hash is in publication-manifest.json."
+}

--- a/apps/web/public/investment-analysis/reports/meta-capex-6m-assets/thesis-v5/business-evidence.html
+++ b/apps/web/public/investment-analysis/reports/meta-capex-6m-assets/thesis-v5/business-evidence.html
@@ -1,0 +1,123 @@
+<!doctype html><html lang="zh-CN"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Meta v5：业务产出证据核验</title><link rel="icon" href="data:,">
+<style>
+:root{--ink:#18201d;--muted:#657069;--paper:#fffdf8;--canvas:#eeeae1;--line:#d9d4c8;--accent:#9d3f25;--accent-soft:#f5e7df;--shadow:0 18px 55px rgba(47,42,31,.10)}
+*{box-sizing:border-box}html{scroll-behavior:smooth}
+body{margin:0;color:var(--ink);background:var(--canvas);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei",sans-serif;line-height:1.72}
+.topbar{position:sticky;top:0;z-index:10;background:rgba(255,253,248,.94);backdrop-filter:blur(12px);border-bottom:1px solid var(--line)}
+.topbar-inner{max-width:1480px;margin:auto;padding:10px 24px;display:flex;align-items:center;justify-content:space-between;gap:16px}
+.brand{font-weight:750;letter-spacing:.02em}.brand span{color:var(--accent)}
+.meta{font-size:13px;color:var(--muted)}
+.layout{max-width:1480px;margin:28px auto 64px;padding:0 24px;display:grid;grid-template-columns:250px minmax(0,1fr);gap:24px}
+.toc{position:sticky;top:72px;align-self:start;max-height:calc(100vh - 96px);overflow:auto;padding:18px 14px;border:1px solid var(--line);border-radius:14px;background:rgba(255,253,248,.72)}
+.toc-title{font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin-bottom:10px}
+.toc a{display:block;color:var(--ink);text-decoration:none;font-size:13.5px;padding:4px 8px;border-radius:8px;margin:1px 0}
+.toc a:hover{background:var(--accent-soft);color:var(--accent)}
+main{background:var(--paper);border:1px solid var(--line);border-radius:18px;box-shadow:var(--shadow);padding:40px 48px 56px;min-width:0}
+main h1{font-size:26px;line-height:1.35;margin:.2em 0 .6em;letter-spacing:.01em}
+main h2{font-size:21px;margin:2.2em 0 .7em;padding-top:.6em;border-top:1px solid var(--line)}
+main h3{font-size:17px;margin:1.6em 0 .5em;line-height:1.5}
+main h2:first-of-type{border-top:none;padding-top:0;margin-top:1em}
+main a{color:var(--accent)}
+main blockquote{margin:1.2em 0;padding:12px 18px;border-left:4px solid var(--accent);background:var(--accent-soft);border-radius:0 10px 10px 0}
+main blockquote p{margin:.3em 0}
+.tablewrap{overflow-x:auto;margin:1.1em 0}
+main table{border-collapse:collapse;font-size:14px;min-width:60%}
+main th{background:var(--accent-soft);color:var(--ink);text-align:left;font-weight:650}
+main th,main td{border:1px solid var(--line);padding:8px 12px;vertical-align:top;line-height:1.65}
+main tr:nth-child(even) td{background:rgba(238,234,225,.35)}
+main code{background:var(--canvas);border:1px solid var(--line);border-radius:6px;padding:1px 6px;font-size:.9em}
+main hr{border:none;border-top:1px solid var(--line);margin:2em 0}
+main li{margin:.25em 0}
+main ul ul,main ol ul{margin-top:.2em}
+main strong{color:#111}
+main u.key{text-decoration:underline;text-decoration-color:var(--accent);text-decoration-thickness:2px;text-underline-offset:4px}
+main u.minor{text-decoration:underline dotted;text-decoration-color:#9aa39d;text-decoration-thickness:1.5px;text-underline-offset:4px}
+.tag{display:inline-block;font-size:11.5px;line-height:1;padding:3px 6px;border-radius:5px;background:var(--canvas);border:1px solid var(--line);color:var(--muted);margin-right:5px;vertical-align:1px;white-space:nowrap}
+.note{display:block;font-size:12.5px;color:var(--muted);margin-top:5px;line-height:1.55;font-weight:400}
+.legend{font-size:13.5px;color:#4d5651;background:rgba(238,234,225,.5);border:1px dashed var(--line);border-radius:10px;padding:10px 14px;margin:.6em 0 1.2em;line-height:1.75}
+.legend p{margin:.2em 0}
+.formula{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,"PingFang SC","Hiragino Sans GB",monospace;background:var(--canvas);border:1px solid var(--line);border-radius:10px;padding:14px 18px;margin:1em 0;line-height:2;font-size:13.5px;overflow-x:auto;white-space:nowrap}
+.formula b{color:var(--accent)}
+.org td:first-child,.tight1 td:first-child{white-space:nowrap}
+.org td:first-child{font-weight:650}
+.org td:nth-child(2){width:58%}
+.org td:nth-child(3){min-width:260px}
+@media(max-width:960px){.layout{grid-template-columns:1fr}.toc{position:static;max-height:none}main{padding:24px 20px}}
+</style></head><body>
+<div class="topbar"><div class="topbar-inner"><div class="brand">Predict-Raven</div><div class="meta">Meta v5：业务产出证据核验｜生成 2026-09-06｜research-only / market-blind</div></div></div>
+<div class="layout"><nav class="toc"><div class="toc-title">目录</div><a href="#meta-v5">Meta v5：业务产出证据核验</a>
+<a href="#_1">一、逐项核验及预算含义</a>
+<a href="#_2">二、怎样把“多个内部买方”讲清楚</a>
+<a href="#_3">三、表格之外必须说明的预算链条</a>
+<a href="#_4">四、本轮边界与纠错清单</a></nav><main><div class="legend"><p>公开附件：保留来源链接、获取状态与研究归纳。完整字幕及内部工作文件保存在本地；请通过节目或原帖链接阅读原文。</p></div><h1 id="meta-v5">Meta v5：业务产出证据核验</h1>
+<p>核验日期：2026-09-06。截止日：2026-09-06。仅核验官方 2026 年 Q1、Q2 财报电话会；Word 文件仅提供待核对线索，没有作为事实来源。已联网打开两份官方 PDF 并核对相关正文。以下页码是 PDF 印刷页码，从 1 开始；行号为本次网页解析定位，长期定位以页码和段落主题为准。</p>
+<p><strong>结论：Word 所列的六项具体业务数字与官方电话会相符，但它们处于不同的证据层级。它们说明多项业务有理由争取计算资源，不能相加成“AI 收入”，也不能直接换算成获批资本开支。</strong></p>
+<h2 id="_1">一、逐项核验及预算含义</h2>
+<div class="tablewrap"><table>
+<thead>
+<tr>
+<th>业务与证据</th>
+<th>来源与定位</th>
+<th>能支持到哪一步预算申请（研究判断）</th>
+<th>不能据此推出什么</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>广告优化：Q2 管理层称 Advantage+ 端到端方案的收入年化运行率超过 <strong>750 亿美元</strong>。</td>
+<td><a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q2/META-Q2-2026-Earnings-Call-Transcript.pdf#page=7" target="_blank" rel="noopener noreferrer">2026-07-29 Q2 官方电话会</a>，第 7 页，Susan Li 关于广告工具的段落；解析行 247–249。性质：公司披露的产品收入指标，非独立核验的 AI 因果收益。</td>
+<td>产品已被用于大规模商业活动，使广告团队申请模型实验和线上推理资源时，有成熟收入渠道可承接结果。若额外计算确实提高扣除服务成本后的广告利润，申请新增设备的理由才进一步成立。</td>
+<td>不是 AI 额外创造了 750 亿美元收入，不是已实现全年收入，更不是 Meta AI／模型 API 收入。原有广告预算可能迁入这些方案；该数字没有披露边际利润或新增算力回报。</td>
+</tr>
+<tr>
+<td>内容推荐：管理层称 Q1 的排序改进使 Instagram Reels 观看时长提升 <strong>10%</strong>。</td>
+<td><a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q1/META-Q1-2026-Earnings-Call-Transcript.pdf#page=5" target="_blank" rel="noopener noreferrer">2026-04-29 Q1 官方电话会</a>，第 5 页，推荐效果段落；解析行 157–188。性质：管理层对产品效果的归因。</td>
+<td>可以支持继续验证推荐模型，并争取相应训练和推理资源。若增加的参与度能转成广告收入且覆盖计算成本，才更有理由扩大容量。</td>
+<td>不是 Reels 全部观看时长的同比增长口径，不是收入或利润同步增加 10%。单次改进不能证明今后每批算力都有相同收益。</td>
+</tr>
+<tr>
+<td>生成式广告创意：Q2 称超过 <strong>900 万家小企业</strong>使用至少一种 AI 创意工具；Q1 称使用视频生成功能的广告主在测试中转化率提高 <strong>超过 3%</strong>。</td>
+<td><a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q2/META-Q2-2026-Earnings-Call-Transcript.pdf#page=7" target="_blank" rel="noopener noreferrer">Q2 电话会第 7 页</a>，解析行 255–264；<a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q1/META-Q1-2026-Earnings-Call-Transcript.pdf#page=7" target="_blank" rel="noopener noreferrer">Q1 电话会第 7 页</a>，解析行 233–235。性质：公司披露的使用覆盖及测试效果，二者人群与观察期不同。</td>
+<td>使用覆盖可支持服务容量和继续产品投入；测试结果可支持下一轮扩大试验。增加设备还需确认持续调用量、增量付费或广告收益，以及生成内容的单位计算成本。</td>
+<td>不能把两项数字相乘；900 万用户并非都使用视频生成功能。超过 3% 是相对提升，并非增加 3 个百分点，也不代表所有广告主的可复制收益。Q1 的超过 800 万“广告主”与 Q2 的超过 900 万“小企业”口径不同，不能机械计算采用人数增长率。</td>
+</tr>
+<tr>
+<td>企业代理：Meta 转述租车公司 Movida 的个案，在一个月观察期内，WhatsApp 渠道日均预订较上年同期增加 <strong>44%</strong>；该渠道 <strong>85%</strong> 的对话由 AI 独立处理。</td>
+<td><a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q2/META-Q2-2026-Earnings-Call-Transcript.pdf#page=8" target="_blank" rel="noopener noreferrer">Q2 电话会第 8 页</a>，解析行 272–277。性质：公司转述客户个案，不是 Meta 整体业务的独立因果实验。</td>
+<td>可以支持企业代理产品试点、客户接入和稳定服务容量。若更多客户重复出现效果、愿意持续付费，且服务毛利为正，才支持更广的商业部署和相应设备申请。</td>
+<td>不是 Meta 企业代理收入增长 44%，也不是全体客户都能自动处理 85% 对话；预订变化还可能受到渠道迁移、促销和其他因素影响。没有披露该个案给 Meta 带来多少利润。</td>
+</tr>
+<tr>
+<td>Meta AI：Q2 管理层称重建助手并整合 Muse Spark 后，每天与助手互动的人数增加 <strong>60%</strong>。</td>
+<td><a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q2/META-Q2-2026-Earnings-Call-Transcript.pdf#page=2" target="_blank" rel="noopener noreferrer">Q2 电话会第 2 页</a>，解析行 69–77。性质：公司披露的使用变化；未在该段给出精确对照日期和绝对人数。</td>
+<td>可以支持满足正在增长的推理服务需求、改善响应速度，并继续验证留存和付费。它为消化部分可兼容容量提供了用途线索。</td>
+<td>不是付费用户或收入增长 60%，也不能推断未来用量会一直同速增加。满足需求可能依靠现有设备、效率优化或外部服务，未必立即增加自有资本开支。</td>
+</tr>
+<tr>
+<td>模型 API：Q2 确认 Muse Spark 1.1 已通过公开 API 提供，并提到向美国开发者扩展 OpenRouter 分发。</td>
+<td><a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q2/META-Q2-2026-Earnings-Call-Transcript.pdf#page=2" target="_blank" rel="noopener noreferrer">Q2 电话会第 2 页</a>，解析行 73–77；<a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q2/META-Q2-2026-Earnings-Call-Transcript.pdf#page=8" target="_blank" rel="noopener noreferrer">第 8 页</a>，解析行 278–288。性质：公司确认的上线与渠道进展。</td>
+<td>可以支持接口运维、开发者接入和按真实请求量扩展服务；若有持续付费使用、续用和正毛利，再支持更大商业容量。</td>
+<td>上线不等于已取得规模收入。Q1/Q2 原文没有提供可单独核验的该 API 收入、利润或付费留存，不能写成它已经填补广告以外的大额资本回报。</td>
+</tr>
+</tbody>
+</table></div>
+<h2 id="_2">二、怎样把“多个内部买方”讲清楚</h2>
+<p><strong>“内部买方”是一个解释资源申请的比喻：广告、推荐、助手和企业产品团队都可能向公司争取算力，并非这些团队各自拥有独立采购合同或能够单独批准公司资本预算。</strong></p>
+<p>上表说明，不同业务手里有不同成熟度的申请依据。广告有商业规模，推荐有产品效果，创意工具有采用和试验结果，企业代理有客户个案，助手有用量变化，API 有上线进展。多个用途并存，意味着某项模型或产品效果不佳时，公司未必需要放弃全部对应容量，可以先评估是否转给其他需求。</p>
+<p>这项推论还要经过两道检验：第一，设备、网络和工作负载是否兼容，转用需要多少时间和改造成本；第二，承接方的净需求是否足够，转用后是否真的减少或替代下一批采购。现有设备调拨本身既不会产生新的资本开支，也不必然保住原计划中的每一笔新采购。不能把“存在其他用途”写成“任何算力都可无成本转用”。</p>
+<p>Q2 第 8 页的资本规划段落支持这种多用途解释：管理层把现有产品、基础模型和其他产品机会放在共同容量规划下，并将 2026、2027 年的容量作为近期重点。这属于正式意向，仍需后续订单、交付和预算检验，不能视为不会下调的保证。<a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q2/META-Q2-2026-Earnings-Call-Transcript.pdf#page=8" target="_blank" rel="noopener noreferrer">官方原文，2026-07-29，第 8 页</a></p>
+<h2 id="_3">三、表格之外必须说明的预算链条</h2>
+<p>业务出现产出，只是申请资源的第一步。较完整的推理应当是：<strong>产品效果或客户使用增加 → 证明额外计算值得投入 → 判断现有设备与效率优化是否足够 → 出现仍未被满足的净容量需求 → 决定购置或采用外部服务 → 把设备和项目的现金付款列入年度计划。</strong> 任何一环发生变化，都可能让“产品很好”与“公司 capex 增长”脱钩。</p>
+<p>融资缓冲解决的是这条链末端的资金安排，不能替代前面的回报证明。Q2 第 9 页称外部资本可补充经营现金流；这种选择减少了短期现金压力直接迫使项目取消的可能性。但是借款有偿付成本，合资和租赁可能改变付款方、现金流分类和时点，均需与报告采用的资本开支口径对齐。<a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q2/META-Q2-2026-Earnings-Call-Transcript.pdf#page=9" target="_blank" rel="noopener noreferrer">官方原文，2026-07-29，第 9 页</a></p>
+<h2 id="_4">四、本轮边界与纠错清单</h2>
+<ul>
+<li>未发现上述六项指定数字与官方正文直接冲突；需要纠正的是概念外推与口径混用。</li>
+<li>业务效果均明确标为公司披露、管理层归因或客户个案转述，不升级为独立验证的投资回报。</li>
+<li>“预算能支持到哪一步”全部是研究分析，官方没有逐项公开内部投资门槛和实际审批结果。</li>
+<li>不新增概率权重，不把同一财报的多个业务指标重复计为相互独立的证据。</li>
+<li>本任务限定 Q1/Q2 正式来源，因此未使用 2026-09-02 Muse Spark 1.3 发布稿；不代表其内容已经在本轮复核。</li>
+<li>仅写入本说明和配套 JSON；未修改报告正文、网站或概率。</li>
+</ul></main></div>
+</body></html>

--- a/apps/web/public/investment-analysis/reports/meta-capex-6m-assets/thesis-v5/forecast-audit-v5.json
+++ b/apps/web/public/investment-analysis/reports/meta-capex-6m-assets/thesis-v5/forecast-audit-v5.json
@@ -1,0 +1,77 @@
+{
+  "version": "v5",
+  "cutoff": "2026-09-06",
+  "question": "从 2026-09-06 起至 2027-03-06 23:59（美国东部时间）止，Meta Platforms, Inc. 是否会通过正式公开渠道，明确下调其可比口径下的名义资本开支计划？",
+  "originalReplayProbability": 0.3220132847825528,
+  "originalReplayInputSha256": "a6bce3edee250ba057b6989979ec4f78f7b64158fbf84d495b5ce0cc61abbce3",
+  "originalReplayRounds": 4,
+  "newIndependentModelRun": false,
+  "newEvidenceLikelihoodWeights": false,
+  "resolutionRule": "The first next-year midpoint is lower than either the comparable prior-year final guidance midpoint or officially disclosed actual. Preserve public timestamps and compare available official information within the window.",
+  "addedSet": "G > A and A <= N < G, with no other YES under the previous rule anywhere in the observation window",
+  "subjectiveAddedProbability": 0.02,
+  "addedProbabilitySensitivity": [
+    0,
+    0.04
+  ],
+  "unroundedProbability": 0.34201328478255283,
+  "headlineYes": 34,
+  "headlineNo": 66,
+  "subjectiveRange": [
+    20,
+    45
+  ],
+  "historicalWindowsYes": 5,
+  "historicalWindowsCount": 8,
+  "paths": [
+    {
+      "label": "主动战略削减",
+      "result": "YES",
+      "percent": 6
+    },
+    {
+      "label": "需求或财务压力",
+      "result": "YES",
+      "percent": 6
+    },
+    {
+      "label": "供给施工付款跨期",
+      "result": "YES",
+      "percent": 20
+    },
+    {
+      "label": "仅恢复的跨年边界",
+      "result": "YES",
+      "percent": 2
+    },
+    {
+      "label": "转鸽但不削减",
+      "result": "NO",
+      "percent": 28
+    },
+    {
+      "label": "维持",
+      "result": "NO",
+      "percent": 14
+    },
+    {
+      "label": "上调或更高次年预算且无边界触发",
+      "result": "NO",
+      "percent": 24
+    }
+  ],
+  "pathReallocationNote": "Two subjective points are moved from the previous higher-next-year-budget NO row to a new exclusive cross-year boundary row. No cause is assigned; not independently estimated from order data.",
+  "overlap": {
+    "formalAndSubstantial": 14,
+    "formalOnly": 20,
+    "substantialOnly": 4,
+    "neither": 62
+  },
+  "sourceGrouping": "Verified Q1/Q2 business metrics describe the existing capacity-demand cluster; no repeated likelihood update.",
+  "proProbabilityUsedAsInput": false,
+  "limitations": [
+    "Rule delta is subjective, not sample-calibrated.",
+    "The 20–45 range is not a statistical confidence interval.",
+    "Existing v2 replay remains an archive of the narrower rule, not a current valid settlement specification."
+  ]
+}

--- a/apps/web/public/investment-analysis/reports/meta-capex-6m-assets/thesis-v5/index.html
+++ b/apps/web/public/investment-analysis/reports/meta-capex-6m-assets/thesis-v5/index.html
@@ -1,6 +1,6 @@
 <!doctype html><html lang="zh-CN"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Meta 第四版：预测主线与可读性修订</title><link rel="icon" href="data:,">
+<title>Meta 第五版：立场、业务产出与预算支撑</title><link rel="icon" href="data:,">
 <style>
 :root{--ink:#18201d;--muted:#657069;--paper:#fffdf8;--canvas:#eeeae1;--line:#d9d4c8;--accent:#9d3f25;--accent-soft:#f5e7df;--shadow:0 18px 55px rgba(47,42,31,.10)}
 *{box-sizing:border-box}html{scroll-behavior:smooth}
@@ -46,26 +46,31 @@ main u.minor{text-decoration:underline dotted;text-decoration-color:#9aa39d;text
 .org td:nth-child(3){min-width:260px}
 @media(max-width:960px){.layout{grid-template-columns:1fr}.toc{position:static;max-height:none}main{padding:24px 20px}}
 </style></head><body>
-<div class="topbar"><div class="topbar-inner"><div class="brand">Predict-Raven</div><div class="meta">Meta 第四版：预测主线与可读性修订｜生成 2026-09-06｜research-only / market-blind</div></div></div>
-<div class="layout"><nav class="toc"><div class="toc-title">目录</div><a href="#meta">Meta 第四版：预测主线与可读性修订</a>
-<a href="#_1">修改了什么</a>
-<a href="#insights">前次信息更新有没有进入 Insights</a>
-<a href="#_2">保持不变</a>
-<a href="#_3">研究边界</a></nav><main><div class="legend"><p>公开附件：保留来源链接、获取状态与研究归纳。完整字幕及内部工作文件保存在本地；请通过节目或原帖链接阅读原文。</p></div><h1 id="meta">Meta 第四版：预测主线与可读性修订</h1>
-<p>信息截点仍为 2026-09-06。此次为已有研究的综合与表达修订，未新增采集轮次或重新计权。</p>
-<h2 id="_1">修改了什么</h2>
+<div class="topbar"><div class="topbar-inner"><div class="brand">Predict-Raven</div><div class="meta">Meta 第五版：立场、业务产出与预算支撑｜生成 2026-09-06｜research-only / market-blind</div></div></div>
+<div class="layout"><nav class="toc"><div class="toc-title">目录</div><a href="#meta">Meta 第五版：立场、业务产出与预算支撑</a>
+<a href="#_1">正文改变了什么</a>
+<a href="#32-34">概率为什么从 32% 调到 34%</a>
+<a href="#_2">获取和发布边界</a></nav><main><div class="legend"><p>公开附件：保留来源链接、获取状态与研究归纳。完整字幕及内部工作文件保存在本地；请通过节目或原帖链接阅读原文。</p></div><h1 id="meta">Meta 第五版：立场、业务产出与预算支撑</h1>
+<p>信息截点：2026-09-06。预测窗口：2026-09-06 至 2027-03-06 23:59，美国东部时间。</p>
+<p><strong>当前判断：正式下调的概率约 34%，NO 约 66%，主观合理范围 20–45%。</strong> 本版吸收 Word 在总论和业务产出证据上的长处，保留按资产拆解资本开支的结构。Word 用于发现线索，业务事实回到 Meta 官方 Q1/Q2 电话会核验，其预测概率未作为输入。</p>
+<h2 id="_1">正文改变了什么</h2>
 <ul>
-<li>阅读结论先解释预测任务：资产数量、单价、现金支付年度、跨项目抵消，最后核验正式计划。</li>
-<li>优先跟踪年末交付与付款，其次验证需求变化是否导致净订单减少；价格、承诺、意愿和融资作为具体约束。</li>
-<li>撤下第三版的假设金额计算器。以工程与交付延期、需求减少、设备降价、预算转投四种情形解释总额变化的条件，每种保留证据边界和下一步核验方向。</li>
-<li>四种情形是可能并存的机制，不是第 5 节互斥结果路径；不赋予情形概率或虚构分项金额。</li>
-<li>五条 Insights 改为完整段落，按预测优先级重排。保留判断、关键依据、影响与边界，但不再机械重复四层标签。</li>
+<li>开头增加“我们判断”的一句话立场，明确下调是较小概率结果，其中交付和付款时点是主要条件路径。</li>
+<li>总论与五条核心判断围绕多个内部业务申请方、资源重配、融资缓冲展开，说明每一层的作用和失效条件。</li>
+<li>单列广告优化、推荐、广告创意、企业代理、Meta AI 和模型 API 六项证据，分别说明其证明力与能支持的预算申请阶段。</li>
+<li>解释交付跨年与付款跨年的差别，展示“晚交付—付款也晚—其他资本支出未补上—正式下修”的条件链。</li>
+<li>融资缓冲区分现金储备、发债、合作方资本与减少回购；保留利息、租赁及担保责任，不把融资当作项目回报。</li>
 </ul>
-<h2 id="insights">前次信息更新有没有进入 Insights</h2>
-<p>第二版已据视频字幕、访谈和社交材料重写全部五条。第三版改写机房先建、设备后决的机制，并补充外购与自研并存、资本与运营现金边界。问题在于缺少总领与优先级，而非完全没有更新。本版将这些信息连接到预测任务，并突出既有 Q1 组件价格证据。</p>
-<h2 id="_2">保持不变</h2>
-<p>主概率 YES 32%、NO 68%，主观合理范围 20–45%。冻结题、官方财务基线、分项定性数据、计权输入、历史记录、六条互斥路径及敏感性分析沿用前版。新增文字中的价格下降等均为条件推演，未声称已发生。</p>
-<p>第三版及其图表、验证记录完整保留。第四版的源稿为 <span>Markdown（本地研究归档）</span>，阅读版为 <span>HTML（本地研究归档）</span>，校验记录见 <span>第四版验收（本地研究归档）</span>。</p>
-<h2 id="_3">研究边界</h2>
-<p>继续沿用第二轮媒体与社交台账。X 原帖正文缺口未补齐，字幕也未逐秒听校；本次编辑没有被计为新的联网研究或新一轮模型预测。</p></main></div>
+<h2 id="32-34">概率为什么从 32% 调到 34%</h2>
+<p>此前正文把跨年规则误写为优先比较实际值。原题要求与上年最终指引中点或实际值分别比较，任一可比下调即可成立。本版恢复该规则。旧版原件保留，不能再作为当前结算说明。</p>
+<p>原证据四轮回放约为 32.2%，本次为新增且不重叠的跨年情形主观留量约 2 个百分点，整数报告为 34%。这不是一条新证据的权重，也不是第五轮独立模型研究。八个历史窗口复核后仍为 5/8；合理范围不变。新增情形另占一行，工程支付类没有自动吸收该增量。</p>
+<ul>
+<li><a href="/investment-analysis/reports/meta-capex-6m-assets/thesis-v5/forecast-audit-v5.json" target="_blank" rel="noopener noreferrer">当前概率与路径审计</a></li>
+<li><a href="/investment-analysis/reports/meta-capex-6m-assets/thesis-v5/resolution-review.html" target="_blank" rel="noopener noreferrer">结算规则、案例与历史复核</a></li>
+<li><a href="/investment-analysis/reports/meta-capex-6m-assets/thesis-v5/business-evidence.html" target="_blank" rel="noopener noreferrer">业务证据与预算申请边界</a></li>
+<li><a href="/investment-analysis/reports/meta-capex-6m-assets/qa-results-v5.json" target="_blank" rel="noopener noreferrer">当前报告验收记录</a></li>
+</ul>
+<h2 id="_2">获取和发布边界</h2>
+<p>本版针对官方原文和规则作复核，没有重新完成一整轮视频、播客或社交搜索。沿用已存的八场英文字幕、两个额外节目全文和社交台账；X 原帖正文仍为零，未公开内部预算仍不可观察。</p>
+<p>公开附件提供来源链接、核验摘要、概率审计与验收记录，完整第三方字幕不上传。主报告保持脚本可运行；网站报告容器不设置 sandbox。桌面、390 与 360 像素窄屏均通过实际浏览器检查后发布。</p></main></div>
 </body></html>

--- a/apps/web/public/investment-analysis/reports/meta-capex-6m-assets/thesis-v5/resolution-cases.json
+++ b/apps/web/public/investment-analysis/reports/meta-capex-6m-assets/thesis-v5/resolution-cases.json
@@ -1,0 +1,565 @@
+{
+  "purpose": "Read-only rule correction audit; no new research round or independent empirical model.",
+  "history_input_sha256": "0a52758421fbcbaa518c7625467bcdd46707659f8c38fb141aae0011c6d322bf",
+  "units": "USD billion for hypothetical and historical amounts",
+  "frozen_or_rule": "First next-fiscal-year midpoint below comparable prior-fiscal-year final guidance midpoint OR actual; either satisfied comparison is sufficient.",
+  "arithmetic_domain": "Formal in-window next-year first plan; comparable reference values known for settlement. Incomparable or missing evidence is unresolved, not automatically NO.",
+  "historical_windows": [
+    {
+      "start": "2018-09-06",
+      "end": "2019-03-06",
+      "same_fy_cut_dates": [
+        "2018-10-30"
+      ],
+      "same_fy_cut_fiscal_years": [
+        2018
+      ],
+      "prior_fy_final_guidance_midpoint": 14.25,
+      "prior_fy_final_guidance_url": "https://investor.atmeta.com/files/doc_financials/2018/Q3/Earnings-call-prepared-remarks.pdf",
+      "prior_fy_actual": 13.92,
+      "actual_publication_date": "2019-01-30",
+      "next_fy_first_midpoint": 19,
+      "first_date": "2018-10-30",
+      "first_source_url": "https://investor.atmeta.com/files/doc_financials/2018/Q3/Earnings-call-prepared-remarks.pdf",
+      "actual_known_on_first_date": false,
+      "first_below_guidance": false,
+      "first_below_eventual_actual": false,
+      "old_cross_year_result": false,
+      "or_cross_year_result": false,
+      "old_window_yes": true,
+      "or_window_yes": true,
+      "comparability_note": "2018 early cash-PPE terminology differs; window is independently YES from a same-FY revision."
+    },
+    {
+      "start": "2019-09-06",
+      "end": "2020-03-06",
+      "same_fy_cut_dates": [
+        "2019-10-30"
+      ],
+      "same_fy_cut_fiscal_years": [
+        2019
+      ],
+      "prior_fy_final_guidance_midpoint": 16,
+      "prior_fy_final_guidance_url": "https://s21.q4cdn.com/399680738/files/doc_financials/2019/q3/Q3-2019-FB-Earnings-Transcript.pdf",
+      "prior_fy_actual": 15.65,
+      "actual_publication_date": "2020-01-29",
+      "next_fy_first_midpoint": 18,
+      "first_date": "2019-10-30",
+      "first_source_url": "https://s21.q4cdn.com/399680738/files/doc_financials/2019/q3/Q3-2019-FB-Earnings-Transcript.pdf",
+      "actual_known_on_first_date": false,
+      "first_below_guidance": false,
+      "first_below_eventual_actual": false,
+      "old_cross_year_result": false,
+      "or_cross_year_result": false,
+      "old_window_yes": true,
+      "or_window_yes": true,
+      "comparability_note": "Same published cash-capex convention as the existing source ledger; no balance-sheet stock comparison."
+    },
+    {
+      "start": "2020-09-06",
+      "end": "2021-03-06",
+      "same_fy_cut_dates": [],
+      "same_fy_cut_fiscal_years": [],
+      "prior_fy_final_guidance_midpoint": 16,
+      "prior_fy_final_guidance_url": "https://investor.atmeta.com/investor-news/press-release-details/2020/Facebook-Reports-Third-Quarter-2020-Results/default.aspx",
+      "prior_fy_actual": 15.72,
+      "actual_publication_date": "2021-01-27",
+      "next_fy_first_midpoint": 22,
+      "first_date": "2020-10-29",
+      "first_source_url": "https://investor.atmeta.com/investor-news/press-release-details/2020/Facebook-Reports-Third-Quarter-2020-Results/default.aspx",
+      "actual_known_on_first_date": false,
+      "first_below_guidance": false,
+      "first_below_eventual_actual": false,
+      "old_cross_year_result": false,
+      "or_cross_year_result": false,
+      "old_window_yes": false,
+      "or_window_yes": false,
+      "comparability_note": "Same published cash-capex convention as the existing source ledger; no balance-sheet stock comparison."
+    },
+    {
+      "start": "2021-09-06",
+      "end": "2022-03-06",
+      "same_fy_cut_dates": [
+        "2021-10-25"
+      ],
+      "same_fy_cut_fiscal_years": [
+        2021
+      ],
+      "prior_fy_final_guidance_midpoint": 19,
+      "prior_fy_final_guidance_url": "https://investor.atmeta.com/investor-news/press-release-details/2021/Facebook-Reports-Third-Quarter-2021-Results/default.aspx",
+      "prior_fy_actual": 19.24,
+      "actual_publication_date": "2022-02-02",
+      "next_fy_first_midpoint": 31.5,
+      "first_date": "2021-10-25",
+      "first_source_url": "https://investor.atmeta.com/investor-news/press-release-details/2021/Facebook-Reports-Third-Quarter-2021-Results/default.aspx",
+      "actual_known_on_first_date": false,
+      "first_below_guidance": false,
+      "first_below_eventual_actual": false,
+      "old_cross_year_result": false,
+      "or_cross_year_result": false,
+      "old_window_yes": true,
+      "or_window_yes": true,
+      "comparability_note": "Same published cash-capex convention as the existing source ledger; no balance-sheet stock comparison."
+    },
+    {
+      "start": "2022-09-06",
+      "end": "2023-03-06",
+      "same_fy_cut_dates": [
+        "2022-11-09",
+        "2023-02-01"
+      ],
+      "same_fy_cut_fiscal_years": [
+        2023,
+        2023
+      ],
+      "prior_fy_final_guidance_midpoint": 32.5,
+      "prior_fy_final_guidance_url": "https://investor.atmeta.com/investor-news/press-release-details/2022/Meta-Reports-Third-Quarter-2022-Results/default.aspx",
+      "prior_fy_actual": 32.04,
+      "actual_publication_date": "2023-02-01",
+      "next_fy_first_midpoint": 36.5,
+      "first_date": "2022-10-26",
+      "first_source_url": "https://investor.atmeta.com/investor-news/press-release-details/2022/Meta-Reports-Third-Quarter-2022-Results/default.aspx",
+      "actual_known_on_first_date": false,
+      "first_below_guidance": false,
+      "first_below_eventual_actual": false,
+      "old_cross_year_result": false,
+      "or_cross_year_result": false,
+      "old_window_yes": true,
+      "or_window_yes": true,
+      "comparability_note": "Same published cash-capex convention as the existing source ledger; no balance-sheet stock comparison."
+    },
+    {
+      "start": "2023-09-06",
+      "end": "2024-03-06",
+      "same_fy_cut_dates": [
+        "2023-10-25"
+      ],
+      "same_fy_cut_fiscal_years": [
+        2023
+      ],
+      "prior_fy_final_guidance_midpoint": 28,
+      "prior_fy_final_guidance_url": "https://investor.atmeta.com/investor-news/press-release-details/2023/Meta-Reports-Third-Quarter-2023-Results/default.aspx",
+      "prior_fy_actual": 28.1,
+      "actual_publication_date": "2024-02-01",
+      "next_fy_first_midpoint": 32.5,
+      "first_date": "2023-10-25",
+      "first_source_url": "https://investor.atmeta.com/investor-news/press-release-details/2023/Meta-Reports-Third-Quarter-2023-Results/default.aspx",
+      "actual_known_on_first_date": false,
+      "first_below_guidance": false,
+      "first_below_eventual_actual": false,
+      "old_cross_year_result": false,
+      "or_cross_year_result": false,
+      "old_window_yes": true,
+      "or_window_yes": true,
+      "comparability_note": "Same published cash-capex convention as the existing source ledger; no balance-sheet stock comparison."
+    },
+    {
+      "start": "2024-09-06",
+      "end": "2025-03-06",
+      "same_fy_cut_dates": [],
+      "same_fy_cut_fiscal_years": [],
+      "prior_fy_final_guidance_midpoint": 39,
+      "prior_fy_final_guidance_url": "https://investor.atmeta.com/investor-news/press-release-details/2024/Meta-Reports-Third-Quarter-2024-Results/default.aspx",
+      "prior_fy_actual": 39.23,
+      "actual_publication_date": "2025-01-29",
+      "next_fy_first_midpoint": 62.5,
+      "first_date": "2025-01-29",
+      "first_source_url": "https://investor.atmeta.com/investor-news/press-release-details/2025/Meta-Reports-Fourth-Quarter-and-Full-Year-2024-Results/default.aspx",
+      "actual_known_on_first_date": true,
+      "first_below_guidance": false,
+      "first_below_eventual_actual": false,
+      "old_cross_year_result": false,
+      "or_cross_year_result": false,
+      "old_window_yes": false,
+      "or_window_yes": false,
+      "comparability_note": "Same published cash-capex convention as the existing source ledger; no balance-sheet stock comparison."
+    },
+    {
+      "start": "2025-09-06",
+      "end": "2026-03-06",
+      "same_fy_cut_dates": [],
+      "same_fy_cut_fiscal_years": [],
+      "prior_fy_final_guidance_midpoint": 71,
+      "prior_fy_final_guidance_url": "https://investor.atmeta.com/investor-news/press-release-details/2025/Meta-Reports-Third-Quarter-2025-Results/default.aspx",
+      "prior_fy_actual": 72.22,
+      "actual_publication_date": "2026-01-28",
+      "next_fy_first_midpoint": 125,
+      "first_date": "2026-01-28",
+      "first_source_url": "https://investor.atmeta.com/investor-news/press-release-details/2026/Meta-Reports-Fourth-Quarter-and-Full-Year-2025-Results/default.aspx",
+      "actual_known_on_first_date": true,
+      "first_below_guidance": false,
+      "first_below_eventual_actual": false,
+      "old_cross_year_result": false,
+      "or_cross_year_result": false,
+      "old_window_yes": false,
+      "or_window_yes": false,
+      "comparability_note": "Same published cash-capex convention as the existing source ledger; no balance-sheet stock comparison."
+    }
+  ],
+  "old_yes_windows": 5,
+  "or_yes_windows": 5,
+  "window_count": 8,
+  "smoothed_prior": 0.6,
+  "named_cases": [
+    {
+      "name": "between_actual_and_higher_guidance",
+      "type": "cross_year_arithmetic",
+      "new_midpoint": 135,
+      "final_guidance_midpoint": 137.5,
+      "actual": 134,
+      "old_yes": false,
+      "or_yes": true,
+      "expected_old": false,
+      "expected_or": true,
+      "passed": true,
+      "explanation": "Only newly added OR region; next year can grow versus actual yet still qualify."
+    },
+    {
+      "name": "equal_actual_below_guidance",
+      "type": "cross_year_arithmetic",
+      "new_midpoint": 134,
+      "final_guidance_midpoint": 137.5,
+      "actual": 134,
+      "old_yes": false,
+      "or_yes": true,
+      "expected_old": false,
+      "expected_or": true,
+      "passed": true,
+      "explanation": "Lower bound of the added region is inclusive."
+    },
+    {
+      "name": "equal_guidance_above_actual",
+      "type": "cross_year_arithmetic",
+      "new_midpoint": 137.5,
+      "final_guidance_midpoint": 137.5,
+      "actual": 134,
+      "old_yes": false,
+      "or_yes": false,
+      "expected_old": false,
+      "expected_or": false,
+      "passed": true,
+      "explanation": "Upper bound is exclusive; equal is not lower."
+    },
+    {
+      "name": "below_both",
+      "type": "cross_year_arithmetic",
+      "new_midpoint": 133,
+      "final_guidance_midpoint": 137.5,
+      "actual": 134,
+      "old_yes": true,
+      "or_yes": true,
+      "expected_old": true,
+      "expected_or": true,
+      "passed": true,
+      "explanation": "Already counted under the old event; do not add again."
+    },
+    {
+      "name": "actual_higher_than_guidance",
+      "type": "cross_year_arithmetic",
+      "new_midpoint": 139,
+      "final_guidance_midpoint": 137.5,
+      "actual": 140,
+      "old_yes": true,
+      "or_yes": true,
+      "expected_old": true,
+      "expected_or": true,
+      "passed": true,
+      "explanation": "OR does not require being below BOTH references."
+    },
+    {
+      "name": "equal_both",
+      "type": "cross_year_arithmetic",
+      "new_midpoint": 137.5,
+      "final_guidance_midpoint": 137.5,
+      "actual": 137.5,
+      "old_yes": false,
+      "or_yes": false,
+      "expected_old": false,
+      "expected_or": false,
+      "passed": true,
+      "explanation": "Equality alone is not a nominal decline."
+    },
+    {
+      "name": "above_both",
+      "type": "cross_year_arithmetic",
+      "new_midpoint": 145,
+      "final_guidance_midpoint": 137.5,
+      "actual": 140,
+      "old_yes": false,
+      "or_yes": false,
+      "expected_old": false,
+      "expected_or": false,
+      "passed": true,
+      "explanation": "Growth slowing is not a nominal budget decline."
+    },
+    {
+      "name": "actual_not_published",
+      "type": "cross_year_arithmetic",
+      "new_midpoint": 135,
+      "final_guidance_midpoint": 137.5,
+      "actual": null,
+      "old_yes": true,
+      "or_yes": true,
+      "expected_old": true,
+      "expected_or": true,
+      "passed": true,
+      "explanation": "A known guidance comparison is sufficient; do not wait for actuals to reject a valid YES."
+    },
+    {
+      "name": "guidance_unavailable_actual_available",
+      "type": "cross_year_arithmetic",
+      "new_midpoint": 135,
+      "final_guidance_midpoint": null,
+      "actual": 136,
+      "old_yes": true,
+      "or_yes": true,
+      "expected_old": true,
+      "expected_or": true,
+      "passed": true,
+      "explanation": "Known comparable actuals can independently establish YES."
+    },
+    {
+      "name": "no_comparable_reference",
+      "type": "cross_year_arithmetic",
+      "new_midpoint": 135,
+      "final_guidance_midpoint": null,
+      "actual": null,
+      "old_yes": null,
+      "or_yes": null,
+      "expected_old": null,
+      "expected_or": null,
+      "passed": true,
+      "explanation": "Unresolved evidence is not an asserted NO."
+    },
+    {
+      "name": "window_start_included",
+      "type": "event_boundary",
+      "event": {
+        "channel": "same_fy_revision",
+        "n": 135,
+        "previous": 137.5,
+        "published": "2026-09-06T00:00:00-04:00"
+      },
+      "or_yes": true,
+      "expected_or": true,
+      "passed": true,
+      "explanation": "Official disclosure exactly at the opening is in the window."
+    },
+    {
+      "name": "window_deadline_included",
+      "type": "event_boundary",
+      "event": {
+        "channel": "same_fy_revision",
+        "n": 135,
+        "previous": 137.5,
+        "published": "2027-03-06T23:59:00-05:00"
+      },
+      "or_yes": true,
+      "expected_or": true,
+      "passed": true,
+      "explanation": "Official disclosure at the stated deadline qualifies."
+    },
+    {
+      "name": "after_deadline_excluded",
+      "type": "event_boundary",
+      "event": {
+        "channel": "same_fy_revision",
+        "n": 135,
+        "previous": 137.5,
+        "published": "2027-03-07T00:00:00-05:00"
+      },
+      "or_yes": false,
+      "expected_or": false,
+      "passed": true,
+      "explanation": "A later announcement cannot be backdated to the internal approval."
+    },
+    {
+      "name": "before_window_excluded",
+      "type": "event_boundary",
+      "event": {
+        "channel": "same_fy_revision",
+        "n": 135,
+        "previous": 137.5,
+        "published": "2026-09-05T23:59:59-04:00"
+      },
+      "or_yes": false,
+      "expected_or": false,
+      "passed": true,
+      "explanation": "A pre-window cut is part of the baseline, not a new event."
+    },
+    {
+      "name": "private_or_anonymous_plan",
+      "type": "event_boundary",
+      "event": {
+        "channel": "first_next_fy",
+        "n": 135,
+        "g": 137.5,
+        "a": 134,
+        "formal": false
+      },
+      "or_yes": false,
+      "expected_or": false,
+      "passed": true,
+      "explanation": "A media rumour or internal discussion alone is not formal company disclosure."
+    },
+    {
+      "name": "unrestated_accounting_change",
+      "type": "event_boundary",
+      "event": {
+        "channel": "first_next_fy",
+        "n": 135,
+        "g": 137.5,
+        "a": 134,
+        "comparable": false
+      },
+      "or_yes": null,
+      "expected_or": null,
+      "passed": true,
+      "explanation": "Resolve comparability before declaring YES or NO."
+    },
+    {
+      "name": "actual_shortfall_only",
+      "type": "event_boundary",
+      "event": {
+        "channel": "actual_only",
+        "n": 134,
+        "previous": 137.5
+      },
+      "or_yes": false,
+      "expected_or": false,
+      "passed": true,
+      "explanation": "Actual below plan alone is not a plan revision."
+    },
+    {
+      "name": "lower_upper_endpoint",
+      "type": "event_boundary",
+      "event": {
+        "channel": "same_fy_revision",
+        "n": 135,
+        "previous": 137.5
+      },
+      "or_yes": true,
+      "expected_or": true,
+      "passed": true,
+      "explanation": "130–145 to 130–140: the midpoint falls."
+    },
+    {
+      "name": "wider_interval_same_midpoint",
+      "type": "event_boundary",
+      "event": {
+        "channel": "same_fy_revision",
+        "n": 137.5,
+        "previous": 137.5
+      },
+      "or_yes": false,
+      "expected_or": false,
+      "passed": true,
+      "explanation": "130–145 to 125–150: no midpoint fall absent an explicit quantified net cut."
+    },
+    {
+      "name": "raise_then_cut_above_baseline",
+      "type": "event_boundary",
+      "event": {
+        "channel": "same_fy_revision",
+        "n": 140,
+        "previous": 145
+      },
+      "or_yes": true,
+      "expected_or": true,
+      "passed": true,
+      "explanation": "An intervening 145 plan cut to 140 qualifies even though above the initial 137.5 baseline."
+    },
+    {
+      "name": "quantified_approved_later_cash_cut",
+      "type": "event_boundary",
+      "event": {
+        "channel": "approved_quantified_plan",
+        "approved": true,
+        "net_cut": 5,
+        "cash_year": 2028
+      },
+      "or_yes": true,
+      "expected_or": true,
+      "passed": true,
+      "explanation": "An approved net plan cut publicly announced within the window qualifies even if most cash was scheduled for 2028."
+    },
+    {
+      "name": "project_cut_fully_reallocated",
+      "type": "event_boundary",
+      "event": {
+        "channel": "approved_quantified_plan",
+        "approved": true,
+        "net_cut": 0
+      },
+      "or_yes": false,
+      "expected_or": false,
+      "passed": true,
+      "explanation": "A project cancellation offset by equal spending elsewhere has no company-plan net cut."
+    },
+    {
+      "name": "announcement_of_discussion_only",
+      "type": "event_boundary",
+      "event": {
+        "channel": "approved_quantified_plan",
+        "approved": false,
+        "net_cut": 5
+      },
+      "or_yes": false,
+      "expected_or": false,
+      "passed": true,
+      "explanation": "Even official discussion does not establish an approved quantified cut."
+    },
+    {
+      "name": "later_2027_plan_is_same_fy_revision",
+      "type": "event_boundary",
+      "event": {
+        "channel": "same_fy_revision",
+        "n": 135,
+        "previous": 140
+      },
+      "or_yes": true,
+      "expected_or": true,
+      "passed": true,
+      "explanation": "A second 2027 plan is tested against its first 2027 plan, not relabelled as a new first disclosure."
+    }
+  ],
+  "named_case_count": 24,
+  "finite_grid_assertions": 1029,
+  "old_evidence_replay_probability": 0.3220132847825528,
+  "unchanged_input_mechanical_result": 0.3220132847825528,
+  "added_region": "No old-rule YES elsewhere in window AND comparable known G>A AND A<=N<G, where G=prior-year final guidance midpoint, A=prior-year actual, N=next-year first midpoint.",
+  "probability_identity": "P(new)=P(old)+P(new-only region); equality is possible, decrease is not, holding the information/judgment fixed.",
+  "subjective_sensitivity_not_fitted": [
+    {
+      "added_unconditional_probability": 0,
+      "new_probability": 0.3220132847825528,
+      "headline_rounded_percent": 32
+    },
+    {
+      "added_unconditional_probability": 0.005,
+      "new_probability": 0.3270132847825528,
+      "headline_rounded_percent": 33
+    },
+    {
+      "added_unconditional_probability": 0.01,
+      "new_probability": 0.3320132847825528,
+      "headline_rounded_percent": 33
+    },
+    {
+      "added_unconditional_probability": 0.02,
+      "new_probability": 0.34201328478255283,
+      "headline_rounded_percent": 34
+    },
+    {
+      "added_unconditional_probability": 0.03,
+      "new_probability": 0.3520132847825528,
+      "headline_rounded_percent": 35
+    },
+    {
+      "added_unconditional_probability": 0.04,
+      "new_probability": 0.3620132847825528,
+      "headline_rounded_percent": 36
+    }
+  ],
+  "status": "All named and grid assertions passed. Probability sensitivity values are assumptions, not measured frequencies."
+}

--- a/apps/web/public/investment-analysis/reports/meta-capex-6m-assets/thesis-v5/resolution-review.html
+++ b/apps/web/public/investment-analysis/reports/meta-capex-6m-assets/thesis-v5/resolution-review.html
@@ -1,0 +1,185 @@
+<!doctype html><html lang="zh-CN"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Meta v5：跨财年结算规则与概率影响的独立复核</title><link rel="icon" href="data:,">
+<style>
+:root{--ink:#18201d;--muted:#657069;--paper:#fffdf8;--canvas:#eeeae1;--line:#d9d4c8;--accent:#9d3f25;--accent-soft:#f5e7df;--shadow:0 18px 55px rgba(47,42,31,.10)}
+*{box-sizing:border-box}html{scroll-behavior:smooth}
+body{margin:0;color:var(--ink);background:var(--canvas);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei",sans-serif;line-height:1.72}
+.topbar{position:sticky;top:0;z-index:10;background:rgba(255,253,248,.94);backdrop-filter:blur(12px);border-bottom:1px solid var(--line)}
+.topbar-inner{max-width:1480px;margin:auto;padding:10px 24px;display:flex;align-items:center;justify-content:space-between;gap:16px}
+.brand{font-weight:750;letter-spacing:.02em}.brand span{color:var(--accent)}
+.meta{font-size:13px;color:var(--muted)}
+.layout{max-width:1480px;margin:28px auto 64px;padding:0 24px;display:grid;grid-template-columns:250px minmax(0,1fr);gap:24px}
+.toc{position:sticky;top:72px;align-self:start;max-height:calc(100vh - 96px);overflow:auto;padding:18px 14px;border:1px solid var(--line);border-radius:14px;background:rgba(255,253,248,.72)}
+.toc-title{font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin-bottom:10px}
+.toc a{display:block;color:var(--ink);text-decoration:none;font-size:13.5px;padding:4px 8px;border-radius:8px;margin:1px 0}
+.toc a:hover{background:var(--accent-soft);color:var(--accent)}
+main{background:var(--paper);border:1px solid var(--line);border-radius:18px;box-shadow:var(--shadow);padding:40px 48px 56px;min-width:0}
+main h1{font-size:26px;line-height:1.35;margin:.2em 0 .6em;letter-spacing:.01em}
+main h2{font-size:21px;margin:2.2em 0 .7em;padding-top:.6em;border-top:1px solid var(--line)}
+main h3{font-size:17px;margin:1.6em 0 .5em;line-height:1.5}
+main h2:first-of-type{border-top:none;padding-top:0;margin-top:1em}
+main a{color:var(--accent)}
+main blockquote{margin:1.2em 0;padding:12px 18px;border-left:4px solid var(--accent);background:var(--accent-soft);border-radius:0 10px 10px 0}
+main blockquote p{margin:.3em 0}
+.tablewrap{overflow-x:auto;margin:1.1em 0}
+main table{border-collapse:collapse;font-size:14px;min-width:60%}
+main th{background:var(--accent-soft);color:var(--ink);text-align:left;font-weight:650}
+main th,main td{border:1px solid var(--line);padding:8px 12px;vertical-align:top;line-height:1.65}
+main tr:nth-child(even) td{background:rgba(238,234,225,.35)}
+main code{background:var(--canvas);border:1px solid var(--line);border-radius:6px;padding:1px 6px;font-size:.9em}
+main hr{border:none;border-top:1px solid var(--line);margin:2em 0}
+main li{margin:.25em 0}
+main ul ul,main ol ul{margin-top:.2em}
+main strong{color:#111}
+main u.key{text-decoration:underline;text-decoration-color:var(--accent);text-decoration-thickness:2px;text-underline-offset:4px}
+main u.minor{text-decoration:underline dotted;text-decoration-color:#9aa39d;text-decoration-thickness:1.5px;text-underline-offset:4px}
+.tag{display:inline-block;font-size:11.5px;line-height:1;padding:3px 6px;border-radius:5px;background:var(--canvas);border:1px solid var(--line);color:var(--muted);margin-right:5px;vertical-align:1px;white-space:nowrap}
+.note{display:block;font-size:12.5px;color:var(--muted);margin-top:5px;line-height:1.55;font-weight:400}
+.legend{font-size:13.5px;color:#4d5651;background:rgba(238,234,225,.5);border:1px dashed var(--line);border-radius:10px;padding:10px 14px;margin:.6em 0 1.2em;line-height:1.75}
+.legend p{margin:.2em 0}
+.formula{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,"PingFang SC","Hiragino Sans GB",monospace;background:var(--canvas);border:1px solid var(--line);border-radius:10px;padding:14px 18px;margin:1em 0;line-height:2;font-size:13.5px;overflow-x:auto;white-space:nowrap}
+.formula b{color:var(--accent)}
+.org td:first-child,.tight1 td:first-child{white-space:nowrap}
+.org td:first-child{font-weight:650}
+.org td:nth-child(2){width:58%}
+.org td:nth-child(3){min-width:260px}
+@media(max-width:960px){.layout{grid-template-columns:1fr}.toc{position:static;max-height:none}main{padding:24px 20px}}
+</style></head><body>
+<div class="topbar"><div class="topbar-inner"><div class="brand">Predict-Raven</div><div class="meta">Meta v5：跨财年结算规则与概率影响的独立复核｜生成 2026-09-06｜research-only / market-blind</div></div></div>
+<div class="layout"><nav class="toc"><div class="toc-title">目录</div><a href="#meta-v5">Meta v5：跨财年结算规则与概率影响的独立复核</a>
+<a href="#_1">结论</a>
+<a href="#_2">新增区域究竟是什么</a>
+<a href="#_3">八个历史窗口：同时检查同年修订和首次次年预算</a>
+<a href="#32">现有 32% 模型已经包含哪些跨年内容</a>
+<a href="#_4">披露日历权重已经核对，暂不因本次修复改变</a>
+<a href="#_5">为什么只建议小幅提高</a>
+<a href="#_6">边界与复核产物</a></nav><main><div class="legend"><p>公开附件：保留来源链接、获取状态与研究归纳。完整字幕及内部工作文件保存在本地；请通过节目或原帖链接阅读原文。</p></div><div class="legend"><p>独立复核原始记录。最终版本采纳主概率 34%、NO 66%、范围 20–45%；新增跨年区域单列为 2 个百分点，不全部归于工程支付。下文建议与历史检查保留用于审计。</p></div><h1 id="meta-v5">Meta v5：跨财年结算规则与概率影响的独立复核</h1>
+<p>复核范围：只审查冻结规则、已有历史台账、v2 概率回放和 v4 报告之间的一致性。没有重新采集一轮市场信息，没有读取预测市场概率，没有以 GPT Pro 的 30% 作为输入。主报告、概率输入和网站均未修改。</p>
+<h2 id="_1">结论</h2>
+<p><strong>应恢复原题的“或”：下一年首次全年 capex 指引中点，低于上一年最终指引中点或实际值，任一可比比较成立即 YES。</strong> v4 第 4.1 节及 v2 <code>framing</code> 写成“实际优先，缺失时才看指引”，不是原题的同义表达。</p>
+<p>恢复后，已核验的 8 个历史窗口仍为 <strong>5 个 YES / 8 个窗口</strong>，加一平滑起点仍为 <strong>60%</strong>。但“历史频率没变”不能推出“当前概率必然不变”：新规则确实新增了一个原规则没有覆盖的事件区域，只是它未出现在这 8 个历史窗口里。</p>
+<p>我建议将当前判断温和上移至约 <strong>34%（YES）/ 66%（NO）</strong>，而不是因为规则修复大幅提高概率。这里约增加 2 个百分点是对新增区域的<strong>主观留量</strong>，并非历史样本估计或新证据似然。合理的额外留量可以在 0–4 个百分点之间争论，约 33–34% 都处于相同判断精度。现有 20–45% 主观范围本来很宽，若主会话保留该范围，应说明未因这次编辑增加统计确定性。</p>
+<h2 id="_2">新增区域究竟是什么</h2>
+<p>令 G 为上一年最终指引中点，A 为上一年实际值，N 为下一年首次指引中点；所有数字均须按同一资本开支范围比较。</p>
+<ul>
+<li>旧规则在两项均已知时要求 N &lt; A。</li>
+<li>恢复的规则要求 N &lt; G <strong>或</strong> N &lt; A；两项均已知时，数学上等于 N &lt; max(G, A)。报告正文最好保留“分别比较、任一成立”的直观表达。</li>
+<li><strong>新旧差集仅为：G &gt; A，且 A ≤ N &lt; G。</strong> 也就是上一年实际少于最终指引，而下一年虽比实际持平或增长，仍低于上一年的最终计划。</li>
+</ul>
+<p>例：G = 137.5、A = 134、N = 135。旧规则为 NO，原题为 YES。只出现 A = 134 而没有新的可比计划，仍不构成 YES。</p>
+<p>要增加的是这个差集在<strong>整个窗口此前没有任何旧规则 YES</strong>的概率。若公司已在 Q3 正式下调当年指引，再在次年首次预算触发另一项条件，同一观察窗仍只算一次；不能重复增加两个 YES。</p>
+<p>因此，保持信息和判断不变时：</p>
+<p><code>P（新规则）＝P（旧规则）＋P（新增区域，且窗口内无其他旧规则 YES）</code></p>
+<p>新规则不能机械降低当前概率。它也不要求所有情况下都严格上升：若新增区域概率为零，可以相等；但现有历史资料并不足以证明该区域概率为零。</p>
+<h2 id="_3">八个历史窗口：同时检查同年修订和首次次年预算</h2>
+<p>单位：十亿美元。G、N 和发布日期来自 <code>research/history.json</code>；实际值 A 及其出处已载于 v4 附录 A2.1。这里没有把次年第二次指引冒充“首次”，也没有把实际少花记为一次指引削减。</p>
+<div class="tablewrap"><table>
+<thead>
+<tr>
+<th>窗口起始年</th>
+<th style="text-align: right;">上年最终指引中点 G</th>
+<th style="text-align: right;">上年实际 A</th>
+<th style="text-align: right;">次年首次中点 N</th>
+<th>首次发布日期</th>
+<th>跨年 OR 单独触发？</th>
+<th>完整窗口结果</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>2018</td>
+<td style="text-align: right;">14.25</td>
+<td style="text-align: right;">13.92</td>
+<td style="text-align: right;">19</td>
+<td>2018-10-30</td>
+<td>否</td>
+<td>YES：2018 年同年下修</td>
+</tr>
+<tr>
+<td>2019</td>
+<td style="text-align: right;">16</td>
+<td style="text-align: right;">15.65</td>
+<td style="text-align: right;">18</td>
+<td>2019-10-30</td>
+<td>否</td>
+<td>YES：2019 年同年下修</td>
+</tr>
+<tr>
+<td>2020</td>
+<td style="text-align: right;">16</td>
+<td style="text-align: right;">15.72</td>
+<td style="text-align: right;">22</td>
+<td>2020-10-29</td>
+<td>否</td>
+<td>NO</td>
+</tr>
+<tr>
+<td>2021</td>
+<td style="text-align: right;">19</td>
+<td style="text-align: right;">19.24</td>
+<td style="text-align: right;">31.5</td>
+<td>2021-10-25</td>
+<td>否</td>
+<td>YES：2021 年同年下修</td>
+</tr>
+<tr>
+<td>2022</td>
+<td style="text-align: right;">32.5</td>
+<td style="text-align: right;">32.04</td>
+<td style="text-align: right;">36.5</td>
+<td>2022-10-26</td>
+<td>否</td>
+<td>YES：已公布的 2023 年计划后来下修</td>
+</tr>
+<tr>
+<td>2023</td>
+<td style="text-align: right;">28</td>
+<td style="text-align: right;">28.10</td>
+<td style="text-align: right;">32.5</td>
+<td>2023-10-25</td>
+<td>否</td>
+<td>YES：2023 年同年下修</td>
+</tr>
+<tr>
+<td>2024</td>
+<td style="text-align: right;">39</td>
+<td style="text-align: right;">39.23</td>
+<td style="text-align: right;">62.5</td>
+<td>2025-01-29</td>
+<td>否</td>
+<td>NO</td>
+</tr>
+<tr>
+<td>2025</td>
+<td style="text-align: right;">71</td>
+<td style="text-align: right;">72.22</td>
+<td style="text-align: right;">125</td>
+<td>2026-01-28</td>
+<td>否</td>
+<td>NO</td>
+</tr>
+</tbody>
+</table></div>
+<p>所有 N 都高于 G 和 A。无论只使用首次公告当时已知的实际值，还是复查截至各窗口结束前已正式公布的实际值，都没有新增历史 YES。</p>
+<p>2018 年存在早期现金购建资产定义与后续含租赁本金表达的可比性提示，不能把跨年金额当作已完全重述的严格样本。但这一窗口本就因同财年正式修订独立满足 YES，故该定义边界不影响 5/8 结果。其余年份也不能由这张表进一步推导“不同财年所有资产/会计口径绝对完全一致”。</p>
+<p>尤其注意 2023 年 2 月的 2023 年预算 30–33：这不是首次 2023 年预算。它是此前 34–39、34–37 之后的同财年下修，属于已有的 2022 起始窗口 YES；不能再次当作新跨年首次事件。</p>
+<h2 id="32">现有 32% 模型已经包含哪些跨年内容</h2>
+<p>v2 <code>forecast-input.json</code> 的预测题、结算描述和不确定性列表都包含 2027 年首次预算。资本意愿证据明确覆盖 2026 与 2027，需求/战略路径也可以通过较低的 2027 年计划实现。因此，现有 32% <strong>不是只预测 2026 年 Q3 下修</strong>；应避免把整个跨年渠道作为新增事件重新计入。</p>
+<p>旧回放从 60% 出发，有效对数调整总和为 −1.15，结果是 0.3220132847825528。六条路径只按原因分组，没有单列“同年修订”和“跨年首次预算”的互斥概率，更没有量化上述 G/A 之间的新区域。因此，无法从现有日志直接抽出一个已校准的“新增 2%”。</p>
+<p>只替换输入中的结算文字、保留全部旧权重，再运行同一引擎，仍会得到相同的 32.2013%。这种机械不变只能说明输入权重没有变，<strong>不能作为新旧事件概率相同的证据</strong>。若主会话采用 34%，建议在 v5 审计明确记录：旧证据回放约 32.2%，修复结算差集的主观增量约 2 个百分点，最终按整数报 34%；不要伪装成一条新的市场证据或第五轮独立研究。</p>
+<h2 id="_4">披露日历权重已经核对，暂不因本次修复改变</h2>
+<p>曾疑问：为什么“未来首次下一年指引移至 Q4”的证据指向 2023 年 Q3 公告，而同一份公告仍给出 2024 年 30–35 区间？重新打开官方原文后确认两者不矛盾：2023 年这一份仍给了次年初步区间，同时说明<strong>未来</strong>首次下一年展望改在 Q4 业绩会给出。见 <a href="https://investor.atmeta.com/investor-news/press-release-details/2023/Meta-Reports-Third-Quarter-2023-Results/default.aspx" target="_blank" rel="noopener noreferrer">Meta 2023 年 Q3 官方公告</a> CFO 展望结尾。</p>
+<p>原 −0.35 调整针对的是“秋季先给出下一年区间，随后在窗口内再下修”的机会减少。跨年首次预算仍可能在一月低于前一年的可比基准，所以这个权重不应被解释成整个跨年渠道消失。本次规则修复并未证明应将该权重删除。</p>
+<h2 id="_5">为什么只建议小幅提高</h2>
+<p>新增区域需要几个条件同时满足：2026 年实际低于最终指引；公司此前没有通过正式下修触发旧规则 YES；2027 年首次计划落在实际与最终指引之间。现有 8 个窗口的次年首次预算都没有接近这一区域，当前已核验的容量意愿也覆盖 2027 年。这些因素支持新增留量较小。</p>
+<p>它仍不能被排除：年度现金支出可因交付或付款跨年而低于最终计划，而管理层并未承诺 2027 年名义美元预算必须超过 2026 年最终指引。量、单价和付款年份不同，容量增长也不等于现金资本开支必然增加。所以留约 2 个百分点比武断记零更审慎，且不足以改变“倾向不下调、YES 主要来自执行时点”的主判断。</p>
+<p>这不是新增独立工程延期证据。如果原路径中的工程支付类保留 20 个百分点，即使主答案提高到 34%，它仍占 YES 的约 59%，可支持“若出现下调，更可能出在交付与付款时点”这种带条件判断。不能把全部新增差集自动分给工程类：较低的次年首次计划也可能由价格、资源重配或需求驱动。若必须维持六条互斥路径，主会话应明确重新分配，而不能只将 2 加到一行、忘记减少 NO 或重复计入其他 YES。</p>
+<h2 id="_6">边界与复核产物</h2>
+<p>已写入 <code>resolution-cases.json</code>：8 个完整历史窗口、24 个命名边界案例、1,029 个有限网格数学断言，全部通过。覆盖差集两端的等号、实际高于指引、两项均低于/高于、缺失参考、正式渠道、可比性待定、窗口起止、实际少花、先上调再下调、区间只动端点、计划批准但支付在窗口外、项目削减后等额转投，以及次年第二次指引按同财年修订比较。</p>
+<p>缺少可比重述或缺少参考值时，记录“待判定”，不直接写成 NO。原题没有要求两项参考必须同时存在，故已知的最终指引比较已经满足时，不得因实际尚未公布而拒绝 YES。对于先公布次年计划、稍后才公布上年实际的罕见时序，应使用观察窗内可核验的正式材料分别比较，保留各自公开日期；不要再次悄悄加入“必须首次公告同日已知实际”的新限制。截止之后的新计划不能倒填为观察窗内公告。</p>
+<p>可复现命令：</p>
+<p><code>bash
+/tmp/meta-report-venv/bin/python invest_targets/meta/runs/20260906/research/thesis-v5/check-resolution.py</code></p>
+<p>以上是研究审计建议，最终概率及主文由主会话负责选择和同步；本文件没有修改旧版报告或旧回放的历史记录。</p></main></div>
+</body></html>

--- a/apps/web/public/investment-analysis/reports/meta-capex-6m.html
+++ b/apps/web/public/investment-analysis/reports/meta-capex-6m.html
@@ -1,6 +1,6 @@
 <!doctype html><html lang="zh-CN"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Meta 半年内下调资本开支的概率 · 第四版</title><link rel="icon" href="data:,">
+<title>Meta 半年资本开支预测</title><link rel="icon" href="data:,">
 <style>
 :root{--ink:#18201d;--muted:#657069;--paper:#fffdf8;--canvas:#eeeae1;--line:#d9d4c8;--accent:#9d3f25;--accent-soft:#f5e7df;--shadow:0 18px 55px rgba(47,42,31,.10)}
 *{box-sizing:border-box}html{scroll-behavior:smooth}
@@ -46,11 +46,11 @@ main u.minor{text-decoration:underline dotted;text-decoration-color:#9aa39d;text
 .org td:nth-child(3){min-width:260px}
 @media(max-width:960px){.layout{grid-template-columns:1fr}.toc{position:static;max-height:none}main{padding:24px 20px}}
 </style></head><body>
-<div class="topbar"><div class="topbar-inner"><div class="brand">Predict-Raven</div><div class="meta">Meta 半年内下调资本开支的概率 · 第四版｜生成 2026-09-06｜research-only / market-blind</div></div></div>
+<div class="topbar"><div class="topbar-inner"><div class="brand">Predict-Raven</div><div class="meta">Meta 半年资本开支预测｜生成 2026-09-06｜research-only / market-blind</div></div></div>
 <div class="layout"><nav class="toc"><div class="toc-title">目录</div><a href="#meta">Meta 会在半年内下调资本开支吗？</a>
 <a href="#1">1. 阅读结论</a>
 <a href="#2">2. 资本开支结构与分项预测</a>
-<a href="#3-insight-summary">3. Insight Summary：哪些变化最值得跟踪？</a>
+<a href="#3">3. 核心判断：预算为什么仍受到支撑？</a>
 <a href="#4">4. 结算口径</a>
 <a href="#5">5. 情景与路径</a>
 <a href="#6">6. 关键证据表</a>
@@ -62,7 +62,7 @@ main u.minor{text-decoration:underline dotted;text-decoration-color:#9aa39d;text
 <a href="#a2">A2. 基准率与可比案例</a>
 <a href="#a3">A3. 口径敏感性</a>
 <a href="#a4">A4. 下一次更新清单</a></nav><main><h1 id="meta">Meta 会在半年内下调资本开支吗？</h1>
-<p class="report-kicker">Predict-Raven · 深度研究 · 2026-09-06 · 第四版 · 预测主线与情形解释</p>
+<p class="report-kicker">Predict-Raven · 深度研究 · 2026-09-06 · 第五版 · 立场、业务产出与预算支撑</p>
 <p class="note">窄屏阅读时，表格可以左右滑动。</p>
 
 <style>
@@ -143,11 +143,12 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 <p><strong>从 2026-09-06 起至 2027-03-06 23:59（美国东部时间）止，Meta Platforms, Inc. 是否会通过正式公开渠道，明确下调其可比口径下的名义资本开支计划？</strong></p>
 </blockquote>
 <div class="hero">
-<div class="number">32%</div>
+<div class="number">34%</div>
 <div class="caption">正式下调的主观概率 · 倾向 NO · 合理范围 20–45% · 主观置信度：中低</div>
 </div>
 
-<p>资本开支（capex）指用于服务器、网络、数据中心等长期资产的投入；本题沿用 Meta 含融资租赁本金偿还的现金口径。<strong>押 NO。</strong> 近两年的容量扩张意愿、法律冲击后维持预算的行动，共同压低正式下调的可能；最容易推翻判断的是年底交付、验收或付款集中后移，进而进入正式全年指引。长期看好 AI 和短期下修现金预算，可以同时成立。</p>
+<p><strong>一句话立场：我们判断，未来半年 Meta 更可能维持或上调可比资本开支计划；多个业务的算力需求、资源重配和融资缓冲共同支撑预算，即使出现下调，也更可能来自年末交付与付款跨年。</strong></p>
+<p>资本开支（capex）是用于服务器、网络、数据中心等长期资产的投入。本题采用 Meta 含融资租赁本金偿还的现金口径。上面的后半句是对下调原因的条件判断：交付延期只有进一步影响付款、未被其他资本支出抵消，并进入正式指引，才会触发本题。第 3.4 节用具体情形解释。</p>
 <div class="tablewrap"><table>
 <thead>
 <tr>
@@ -163,8 +164,8 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 <tr>
 <td><strong>半年内 Meta 会下调 capex 的概率？</strong><span class="note">主口径：正式下调可比名义计划，按第 4 节结算。</span></td>
 <td>2027-03-06 23:59</td>
-<td style="text-align: right;"><strong>32%</strong></td>
-<td style="text-align: right;"><strong>68%</strong></td>
+<td style="text-align: right;"><strong>34%</strong></td>
+<td style="text-align: right;"><strong>66%</strong></td>
 <td><strong>20–45%</strong></td>
 <td>中低</td>
 </tr>
@@ -187,17 +188,17 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 </tbody>
 </table></div>
 <p>主口径允许小幅下修，因此高于“至少减少 5%”的实质削减判断；两者并非严格包含关系，因为后者还接受可靠的内部计划证据。“转鸽但不削减”与主口径互斥，其 NO 也包括正式下调。附录 A3 给出交叉关系，三个 YES 不能相加。</p>
-<h3 id="_1">先把预测任务说清楚</h3>
-<p><strong>要预测资本开支，就要预测各类资产买多少、成交单价多少、何时形成现金支付，再把全部项目加总。</strong> 对本题还要多走一步：这些变化是否让 Meta 在观察窗内正式调低可比计划。业务需求、工程进度和公司公告，因此是三个不同层次的证据。</p>
-<p>服务器主要看采购数量与单价，机房主要看工程规模与付款节点，网络要同时看集群设备和长期建设；最后另加融资租赁本金。某团队少用 GPU、某园区延期、某供应商降价，都只改变其中一环，不能直接当作公司总额下调。</p>
+<h3 id="_1">为什么我们倾向于不下调？</h3>
+<p><strong>预测 capex，要先判断业务还需要多少新增容量，再判断公司能否、以及何时为这批容量付款。</strong> 服务器看数量和单价，机房看工程规模与付款节点，网络看设备及建设进度；把这些资本现金支出与融资租赁本金加总，才是本题的总额。最后还须判断 Meta 是否会正式降低这个可比计划。</p>
+<p>目前，支撑总预算的逻辑可以集中为三个相连的判断。</p>
 <div class="rv-priorities" id="forecast-priorities">
-<p class="rv-priority"><strong>最先跟踪：原定今年的钱，能否在今年付出去？</strong><span>年底交付、验收和付款后移，即使扩建意愿不变，也可能压低当年现金计划。要核对延期金额、付款条款，以及能否被其他资本项目补上。</span><a href="#insight-timing">看工程与付款判断 →</a></p>
-<p class="rv-priority"><strong>再看：少用算力，是否真的变成少买设备？</strong><span>广告、推荐和其他模型可能接走空出的容量。只有需求未被接替、后续订单确实减少，且单价等因素没有抵消，才更接近总额下修。</span><a href="#insight-demand">看需求如何传到订单 →</a></p>
-<p class="rv-priority"><strong>持续核对：买得更便宜，还是用同样预算买得更多？</strong><span>设备单价会改变名义支出；采购承诺决定能否调整；主营现金流与融资条件决定管理层能坚持多久。这些因素共同决定节省是否留在公司层面。</span><a href="#insight-orders">看采购、价格与承诺 →</a></p>
+<p class="rv-priority"><strong>多个内部买方：仍有业务争取新增算力</strong><span>这里的“买方”是向公司申请计算资源的业务团队。广告有成熟商业规模，推荐有产品效果，企业代理和助手也出现使用证据。这让基础设施预算拥有多个需求来源，但各业务的回报证明程度不同。</span><a href="#business-evidence">看各业务能支持到哪一步预算申请 →</a></p>
+<p class="rv-priority"><strong>资源重配：一个团队节省，未必变成公司少买</strong><span>只要设备兼容、其他业务仍有足够且值得满足的净需求，空出的容量就可能被接走，节省也可能用于新的任务。因此，下调总预算通常还需要看到公司整体的剩余容量缺口缩小。</span><a href="#insight-demand">看资源如何影响下一批采购 →</a></p>
+<p class="rv-priority"><strong>融资缓冲：短期现金压力有其他承接方式</strong><span>公司可以使用现金储备、借款或合作方资本，并减少回购等现金用途，继续支付获批建设。这延长了等待业务回报的时间；新增利息、租金和担保责任仍由未来现金流承担。</span><a href="#insight-finance">看融资缓冲的来源与限度 →</a></p>
 </div>
 
-<p><strong>目前的概括是：继续扩容的意愿仍强，但付款年度有调整风险。</strong> 近期容量目标及八月维持指引的行动支持前半句；下半年待支付金额较大，使交付与付款节点值得优先追踪。后半句是研究判断，现有材料尚未证明已发生足以压低总计划的项目延期。正式披露与计算依据见第 3 节。</p>
-<p>因此，这次预测的重点是核对“哪一笔钱会从当前计划中消失、为何消失、是否转投别处”，而不是只判断 Meta 是否继续看好 AI。窗口还跨过下一年度预算发布期：对首次公布的 2027 年预算，要按第 4 节的可比基准另行判断，不能把上述 2026 年付款逻辑直接套用。</p>
+<p><strong>三者分别回答“谁还需要、能否转用、钱从哪里来”。</strong> 它们共同支持继续投入：某个模型效果不佳，不一定使公司整体缺少值得满足的需求；短期现金流变薄，也不一定迫使建设立即收缩。这个判断并不要求所有 AI 产品都已经盈利，但要求成熟业务的新增回报和新业务的容量需求仍足以支撑采购。</p>
+<p><strong>最薄弱的一环在年末执行。</strong> 公司愿意继续投入，也可能因为交付、验收和付款后移，把原定当年的现金支出挪到下一年。若其他资本项目补不上，并由公司正式下修可比指引，本题仍会结算为 YES。下一财年首次预算另按第 4 节比较，不能只用项目跨年的解释代替结算。</p>
 <p><strong>基线口径卡</strong>（以下金额以十亿美元计；1 十亿美元＝10 亿美元）：</p>
 <div class="tablewrap"><table>
 <thead>
@@ -238,8 +239,8 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 </tbody>
 </table></div>
 <p>信息截点为 2026-09-06 本次检索；第二轮补漏与第三版结构核对仍严格使用该日及以前的材料。尽可能覆盖会改变结论的公开信息；付费墙后全文、未公开预算和未开展的专家访谈不在已掌握证据之内。全文把公告事实、公司判断、媒体消息和我们的推断分开。</p>
-<p><strong>第四版变化：</strong> 补上预测任务与跟踪优先级，重写 Insights，把假设金额演算改为四种情形对照。第二版已据新增视频、访谈与社交材料重写五条 Insights；第三版进一步补充资产决策时序，但此前没有充分概括这些信息如何共同回答预测题。本版修正的是综合与表达，未新增一轮采集或独立计权，主概率及合理范围维持不变。</p>
-<p>快速阅读：<a href="#forecast-priorities">预测任务与重点</a> · <a href="#capex-structure">资本开支结构</a> · <a href="#capex-forecast">各项预测</a> · <a href="#capex-scenarios">四种情形</a> · <a href="#insight-timing">核心判断</a>。</p>
+<p><strong>第五版变化：</strong> 增加一句话立场，以“多个内部买方＋资源重配＋融资缓冲”重写核心判断，并核验业务产出证据。本版同时纠正跨年首次预算规则：与上年最终指引及实际值分别比较，任一可比下调即成立。主概率由 32% 调整至 34%，合理范围仍为 20–45%；约 2 个百分点来自新增结算情形的主观估计，未将重复业务材料另行加权。详见附录 A1 及<a href="/investment-analysis/reports/meta-capex-6m-assets/thesis-v5/index.html" target="_blank" rel="noopener noreferrer">本版复核记录</a>。</p>
+<p>快速阅读：<a href="#forecast-priorities">预算为何受到支撑</a> · <a href="#capex-structure">资本开支结构</a> · <a href="#capex-forecast">各项预测</a> · <a href="#business-evidence">业务产出与预算申请</a> · <a href="#delivery-payment">交付与付款跨年</a>。</p>
 <h2 id="2">2. 资本开支结构与分项预测</h2>
 <h3 id="21">2.1 先按钱花在哪里拆，再按谁使用拆</h3>
 <p><strong>主结构是服务器与芯片、数据中心建设、网络，以及其他资本化资产。</strong> 前三项沿用 Meta 正式电话会的投向；“其他”用于覆盖其余资本化资产。融资租赁本金单独桥接到公司现金口径。广告、模型训练和产品推理属于用途：它们会共用服务器、网络与机房，不能再与资产类别相加。<a href="https://s21.q4cdn.com/399680738/files/doc_financials/2024/q4/META-Q4-2024-Earnings-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">历史结构说明</a>、<a href="https://s21.q4cdn.com/399680738/files/doc_financials/2024/q4/META-Q4-2024-Follow-Up-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">用途定义</a></p>
@@ -280,7 +281,22 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 <details class="cx-detail" id="detail-lease"><summary>融资租赁本金<span>以现金计划核对 · 展开依据与改判条件</span></summary><div><p><strong>判断：</strong>已经开始的合同通常比未下单设备难以主动压缩；新增租赁开始时间仍可能改变未来本金现金。判断需要逐项合同，不能把全部未来租赁义务当成当年付款。</p><p><strong>依据：</strong>上半年现金本金偿还为 1.805 十亿美元；付款义务与资产非现金入账分开披露。</p><p><strong>什么会让本项下修：</strong>新租赁开始时间后移、合同变更等确实降低可比期间本金现金，并获财务确认。</p><p><strong>什么可能抵消：</strong>已有合同付款延续；新设施开始使用也可能增加本金偿还。</p><p><strong>沿着谁查：</strong>租赁会计与资金负责人：起租日、偿还表、变更条款及经营/融资租赁分类。</p><p><strong>证据边界：</strong>此项不得与同一租赁资产取得时的非现金金额重复相加；未披露全年分项指引。</p><p>原始来源：<a href="https://www.sec.gov/Archives/edgar/data/1326801/000162828026050705/meta-20260630.htm" target="_blank" rel="noopener noreferrer">2026-07-30 季报</a> · <a href="https://investor.atmeta.com/investor-news/press-release-details/2026/Meta-Reports-Second-Quarter-2026-Results/default.aspx" target="_blank" rel="noopener noreferrer">2026-07-29 业绩公告</a></p></div></details>
 
 <p><strong>按用途再看一次：</strong> 核心 AI 的推荐与广告回报，支撑追加服务器和配套网络；生成式 AI 的训练排期、产品调用量，更容易影响服务器批次及型号；非 AI 基础服务仍有容量和更新需求。三者都使用机房与网络。某个模型少训练，只有在释放的容量未被其他用途接走、后续采购因此减少时，才会压低服务器总计划。<a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q1/META-Q1-2026-Earnings-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">Q1 电话会</a>、<a href="https://cheekypint.transistor.fm/2/transcript" target="_blank" rel="noopener noreferrer">Li 访谈</a>、<a href="https://stripe.com/br/sessions/2026/a-conversation-with-daniel" target="_blank" rel="noopener noreferrer">Gross 访谈</a></p>
-<h3 id="23">2.3 从分项消息到公司总额：四种情形怎么判断？</h3>
+<h3 id="23">2.3 业务产出，能支持到哪一步预算申请？</h3>
+<p><strong>产出证据说明业务有理由申请资源，新增资本预算还要证明“现有容量不够用”。</strong> 下面的申请阶段是我们的分析映射；Meta 没有逐项公开完整投资门槛或审批结果。广告、推荐与创意工具可能作用于同一笔广告收入，不能相加成独立回报，也不能与前面的资产类别重复加总。</p>
+<div class="tv-evidence" id="business-evidence" aria-label="业务产出与预算申请对照">
+<div class="tv-evidence-row tv-evidence-head" aria-hidden="true"><span>业务申请方</span><span>已披露产出与证明限度</span><span>可支持的预算申请（分析判断）</span></div>
+<div class="tv-evidence-row"><h4>广告优化</h4><div><span class="tv-label">已披露产出与证明限度</span><p>Advantage+ 端到端方案收入年化运行率超过 <b>750 亿美元</b>。</p><small>公司披露的商业规模，不是 AI 增量收入或已实现全年收入。</small><a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q2/META-Q2-2026-Earnings-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">Q2 第 7 页 · 2026-07-29</a></div><div><span class="tv-label">可支持的预算申请</span><p>可支持模型实验与线上推理资源申请。进一步增购设备，需要证明额外计算带来的广告利润能够覆盖成本，且现有容量不足。</p></div></div>
+<div class="tv-evidence-row"><h4>内容推荐</h4><div><span class="tv-label">已披露产出与证明限度</span><p>管理层称 Q1 排序改进使 Instagram Reels 观看时长提升 <b>10%</b>。</p><small>管理层对改进效果的归因，不是全部时长的同比增长，也不是利润增长。</small><a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q1/META-Q1-2026-Earnings-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">Q1 第 5 页 · 2026-04-29</a></div><div><span class="tv-label">可支持的预算申请</span><p>可支持继续优化推荐模型、申请训练与推理资源。扩大设备预算还要证明新增参与度能变现，追加收益高于计算成本。</p></div></div>
+<div class="tv-evidence-row"><h4>广告创意工具</h4><div><span class="tv-label">已披露产出与证明限度</span><p>超过 <b>900 万家小企业</b>使用至少一种 AI 创意工具；另有 Q1 视频生成测试，广告主转化率相对提升<b>超过 3%</b>。</p><small>采用规模与测试效果来自不同人群，不能相乘；超过 3% 不是增加 3 个百分点。</small><a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q2/META-Q2-2026-Earnings-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">Q2 第 7 页；测试见 Q1 第 7 页 · 2026-07-29</a> · <a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q1/META-Q1-2026-Earnings-Call-Transcript.pdf#page=7" target="_blank" rel="noopener noreferrer">Q1 测试原文</a></div><div><span class="tv-label">可支持的预算申请</span><p>采用数据支持服务容量，测试结果支持扩大试验。新增设备申请仍需持续调用量、增量广告收益与单位生成成本。</p></div></div>
+<div class="tv-evidence-row"><h4>企业代理</h4><div><span class="tv-label">已披露产出与证明限度</span><p>Meta 转述 Movida 个案：一个月观察期内，WhatsApp 日均预订同比增加 <b>44%</b>，<b>85%</b> 对话由 AI 独立处理。</p><small>单一客户、单一渠道的效果，不是 Meta 收入，也不证明全体客户可复制。</small><a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q2/META-Q2-2026-Earnings-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">Q2 第 8 页 · 2026-07-29</a></div><div><span class="tv-label">可支持的预算申请</span><p>可支持试点扩展、客户接入和稳定服务。大规模商业容量申请还需多个客户复现、持续付费及正毛利。</p></div></div>
+<div class="tv-evidence-row"><h4>Meta AI 助手</h4><div><span class="tv-label">已披露产出与证明限度</span><p>管理层称重建助手并整合 Muse Spark 后，每日互动人数增加 <b>60%</b>。</p><small>用量变化；该段未给精确对照日期和绝对人数，不能解释为付费用户或收入增长。</small><a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q2/META-Q2-2026-Earnings-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">Q2 第 2 页 · 2026-07-29</a></div><div><span class="tv-label">可支持的预算申请</span><p>可支持满足真实推理需求、改善响应。能否增加自有设备，取决于留存、服务成本及现有或外部容量是否足够。</p></div></div>
+<div class="tv-evidence-row"><h4>模型 API</h4><div><span class="tv-label">已披露产出与证明限度</span><p>Q2 确认 Muse Spark 1.1 已通过公开 API 提供，并拓展 OpenRouter 分发。</p><small>产品上线与渠道进展；Q1/Q2 未披露可独立核验的该 API 收入、利润或付费留存。</small><a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q2/META-Q2-2026-Earnings-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">Q2 第 2、8 页 · 2026-07-29</a></div><div><span class="tv-label">可支持的预算申请</span><p>可支持接口运维与开发者接入，按真实请求量扩展服务。更大的资本申请仍需持续付费使用和正毛利。</p></div></div>
+</div>
+
+<p class="tv-budget-chain"><strong>从产品效果到资本预算：</strong>业务出现产出 → 额外计算值得投入 → 现有设备与效率优化仍不够 → 形成净容量缺口 → 比较购置设备与外部服务 → 安排年度资本现金付款。</p>
+
+<p>广告的商业规模、推荐的产品效果，是当前较成熟的申请依据；代理个案、助手用量与 API 上线支持继续验证和服务供给。它们共同增加潜在用途，但尚未把每一步新增服务器采购都证明为高回报。<a href="/investment-analysis/reports/meta-capex-6m-assets/thesis-v5/business-evidence.html" target="_blank" rel="noopener noreferrer">逐项官方核验</a>。</p>
+<h3 id="24">2.4 从分项消息到公司总额：四种情形怎么判断？</h3>
 <p>这部分用于判断一条“少花钱”的消息有没有预测价值。关键是分清：钱只是晚付、需求真的减少、采购变便宜，还是换了一个地方花。下面把各自的条件展开，不再用任意金额代替研究判断。</p>
 <figure class="cx-figure" id="capex-scenarios" aria-labelledby="rv-case-title">
 <figcaption class="cx-title" id="rv-case-title">同样是少花，哪些变化会压低总计划？</figcaption>
@@ -319,7 +335,7 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 <noscript><p>未启用脚本时，四种情形依次展示，全部文字仍可阅读。</p></noscript>
 </figure>
 
-<h3 id="24">2.4 关键人关系表</h3>
+<h3 id="25">2.5 关键人关系表</h3>
 <p>“穿透”在这里指沿着预算提出、批准和执行的链条找具体负责人。“关键-1”指直接下属，“关键-2”指再下一层。本表的“打灯”衡量<strong>公开证据对关系状态的可见度</strong>：5 分有近期正式资料且能交叉验证，3 分主要依赖报道，1 分仅有零散线索；它不是个人能力、关系好坏或预算否决力的评分。没有依据的审批权不补写。</p>
 <div class="tablewrap"><table>
 <thead>
@@ -400,7 +416,7 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 </tbody>
 </table></div>
 <p>上述职责分工拼成的是<strong>分析图</strong>：业务及研究提出需求 → 财务评估回报与规模 → CEO 和董事会战略权衡与监督 → Meta Compute、基础设施和资本合作团队组织执行。Meta 没有公开一张完整的金额审批表。</p>
-<h3 id="25">2.5 组织要素快照</h3>
+<h3 id="26">2.6 组织要素快照</h3>
 <div class="org">
 <div class="tablewrap"><table>
 <thead>
@@ -449,43 +465,52 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 </tbody>
 </table></div>
 </div>
-<h2 id="3-insight-summary">3. Insight Summary：哪些变化最值得跟踪？</h2>
-<p><strong>最值得优先验证的下调路径，是“工程与交付后移 → 当年付款减少 → 其他项目补不上”。</strong> 它无需管理层改变 AI 战略。更深一层的削减则需要“需求或回报下降 → 空余算力无人接手 → 后续采购减少”。设备价格、已签承诺与融资能力，会加强或阻断这两条路径。下面按这些问题展开；优先级是研究判断，不是已确认事件。</p>
-<p class="note">本节已重新综合前两轮材料。🏛️ 为正式文件，🎙️ 为本人访谈，📰 为新闻或本人原帖；下划线标出关键依据。来源所述事实与我们的推断分别表述。</p>
+<h2 id="3">3. 核心判断：预算为什么仍受到支撑？</h2>
+<p><strong>我们的判断是，Meta 的资本预算目前有多条业务需求支撑；资源可以在部分用途之间重新分配，外部资本又缓解了当期付款压力，因此一次产品失利或一季现金流变薄，还不足以推出总预算下调。</strong> 如果窗口内发生下调，我们更看重年末交付和付款错位这条路径。下面分别说明支撑从哪里来，以及什么会使它失效。</p>
+<p class="note">🏛️ 为正式文件，🎙️ 为本人访谈，📰 为新闻或本人原帖；下划线标出关键依据。业务指标是公司披露或归因，预算含义是我们的分析，不代表已知的内部审批结果。</p>
 
-<p><span id="insight-timing"></span></p>
-<h3 id="31">3.1 【传导路径】半年内的小幅下修，最值得查的是年底付款能否落地</h3>
-<p><strong>Meta 可以继续批准扩建，却仍然下修当年现金预算。</strong> 工程晚完工、设备晚交付，只有在相应付款也顺延、其他资本支出没有补上时，才会把项目延误传到公司总额。这是本次最优先核验的路径，因为它不需要先发生一次战略转向。</p>
-<p>🏛️ <a href="https://investor.atmeta.com/investor-news/press-release-details/2026/Meta-Reports-Second-Quarter-2026-Results/default.aspx" target="_blank" rel="noopener noreferrer">Q2 公告</a>（2026-07-29）披露上半年资本现金支付 50.918 十亿美元。用全年区间扣除已付金额，<u class="key">下半年仍需支付 79.082–94.082 十亿美元</u>；这是算术推导，不是公司单独发布的半年指引。📰 Janardhan 在<a href="https://www.linkedin.com/posts/sjanardhan_americas-workforce-academy-the-future-is-activity-7469869698331922432-JYIA" target="_blank" rel="noopener noreferrer">本人原帖</a>（2026-06-08）提到熟练施工人员不足，并公布培训措施，说明执行能力是负责人关注的约束。</p>
-<p>但付款集中在下半年，本身不能证明延期；用工风险也早于七月指引，可能已被公司考虑。<strong>能改变判断的，是指引发布后的具体进度变化。</strong> 下一步应核对原定年内验收的项目、相应付款节点及替代支出。公司若提前采购别的设备，仍可能维持总预算。普通云服务运营费用不能直接填补资本开支现金缺口。</p>
+<p><span id="insight-buyers"></span></p>
+<h3 id="31">3.1 【本质驱动】广告和推荐提供较成熟的申请依据，新业务增加了可争取资源的用途</h3>
+<p><strong>Meta 不需要等通用助手单独盈利，才有理由继续申请计算资源。</strong> 广告优化可以通过广告主效果与收入检验投入，推荐可以通过参与度及后续变现检验投入；企业代理、创意工具和助手则提供成熟度不同的新需求。因此，预算是否收缩，取决于这些用途合在一起还需要多少新增容量。</p>
+<p>🏛️ <a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q2/META-Q2-2026-Earnings-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">Q2 官方电话会</a>（2026-07-29，第 7 页）披露 <u class="key">Advantage+ 端到端方案收入年化运行率超过 750 亿美元</u>，说明相关工具已有商业规模；它没有证明这笔收入全部由 AI 额外创造。🏛️ <a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q1/META-Q1-2026-Earnings-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">Q1 电话会</a>（2026-04-29，第 5 页）把 Reels 观看时长提升归因于排序改进，说明推荐有可观察的产品效果；效果仍需转成覆盖计算成本的收益，才能支持更大的设备申请。各项证据与边界见第 2.3 节。</p>
+<p>这使广告与推荐成为目前较有说服力的预算申请方。企业代理的客户案例、助手的使用增长，则支持继续验证和满足实际服务需求，还不能承担同等强度的资本回报论证。<strong>我们因此接受“多个业务支撑容量需求”，但没有把它写成“全部 AI 投资已证明盈利”。</strong> 若广告与推荐的追加计算收益也变弱，新业务又无法接替，保护总预算的第一层理由才会明显削弱。</p>
 <p><span id="insight-demand"></span></p>
-<h3 id="32">3.2 【传导路径】需求变弱以后，还要看空出的算力有没有人接走</h3>
-<p><strong>某个模型少训练，并不直接意味着下一批服务器少买。</strong> Meta 可以把空出的容量调给广告、推荐或其他模型。只有这些用途也不需要新增容量，财务与基础设施团队才有理由收回采购额度。因此，应追踪公司整体的追加需求，而不是用一个产品的成败代替资本预算判断。</p>
-<p>🎙️ Susan Li 在 <a href="https://cheekypint.transistor.fm/2/transcript" target="_blank" rel="noopener noreferrer">Cheeky Pint</a>（2025-06-18，24:16 起）解释，<u class="key">GPU 可以由中央重新分配</u>，同时承认广告吸收额外算力的能力也有上限。🎙️ Gross 在 <a href="https://www.youtube.com/watch?v=l9wzs_QIyp0" target="_blank" rel="noopener noreferrer">Stripe Sessions 原视频</a>（会期 2026-04-30，5 月 19 日上传，20:34–22:35）讨论用小模型完成部分任务、按生成物的经济价值分配预算；<a href="https://stripe.com/br/sessions/2026/a-conversation-with-daniel" target="_blank" rel="noopener noreferrer">发布方实录</a>可交叉核对。这些材料说明如何筛选需求，尚不能证明筛选已经减少公司设备订单。</p>
-<p>新增访谈让这一步更清楚：🎙️ Li 在 <a href="https://ca.investing.com/news/transcripts/meta-at-morgan-stanley-conference-ai-strategy-and-financial-insights-93CH-4495629" target="_blank" rel="noopener noreferrer">Morgan Stanley 访谈</a>（2026-03-04，第三方完整转录）描述按实验和追加回报评估预算；Bosworth 在 <a href="https://www.youtube.com/watch?v=qZhCeV6XATw" target="_blank" rel="noopener noreferrer">Big Technology</a>（2026-07-08，08:20–11:00；<a href="https://www.bigtechnology.com/p/metas-path-to-ai-relevance-according" target="_blank" rel="noopener noreferrer">编辑实录</a>7 月 9 日发布）说明自研也有约束外部模型价格的作用。所以外购增加与自研继续投入可以并存。</p>
-<p><strong>最有用的新证据，是取消训练之后的容量去向和采购变更。</strong> 如果资源很快被别的业务接走，削减信号就弱；若持续闲置并导致后续订单取消，信号才强。节省调用费、使用小模型或外购合作，都需要补齐这一步。</p>
-<p><span id="insight-orders"></span></p>
-<h3 id="33">3.3 【本质驱动】园区开工没有锁死全部设备预算，服务器数量和单价仍要分别预测</h3>
-<p><strong>机房先建、服务器后买，意味着“继续建园区”与“调整下一批设备”可以同时发生。</strong> 对已经进入建设阶段的长期资产，要查工程和付款承诺；对尚未下单的服务器，要查数量、采购价格和交付批次。不能用远期园区规模，推定全部设备支出已经不可调整。</p>
-<p>🏛️ <a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q2/META-Q2-2026-Earnings-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">Q2 正式电话会</a>（2026-07-29，PDF 第 8 页）区分了近期扩容与远期选择：面向 2028 年以后，<u class="key">先建设数据中心和网络基础，为后续服务器投资保留空间</u>。🎙️ Janardhan 的<a href="https://www.business-standard.com/companies/people/we-want-to-be-part-of-india-s-growth-story-meta-s-santosh-janardhan-126061801239_1.html" target="_blank" rel="noopener noreferrer">本人采访</a>（2026-06-19）也介绍分阶段建设、保留以后扩容选择。两者支持投资分阶段决定，均未披露半年内可撤销的设备金额。</p>
-<p>价格是另一条独立的金额通道。🏛️ <a href="https://investor.atmeta.com/investor-news/press-release-details/2026/Meta-Reports-First-Quarter-2026-Results/default.aspx" target="_blank" rel="noopener noreferrer">Q1 公告</a>（2026-04-29）把当次资本指引上调主要归因于组件价格上涨，另有部分未来容量投入。<strong>既然单价上涨能推高名义预算，单价回落也可能在需求不变时降低预算；但这是条件推演，尚不是已经发生的价格下行。</strong> 如果公司把便宜下来的预算用于多买设备，总额仍可不变。</p>
-<p>下一步应拿到后续服务器批次的数量、报价、取消条款和付款年度，再核对节省是否转投。公司仍强调尽可能增加近期容量，因此目前更应留意批次与单价调整；远期建设的灵活性，不能直接当作本窗口内必然削减的证据。</p>
-<p><span id="insight-intent"></span></p>
-<h3 id="34-ai">3.4 【本质驱动】仅有“AI 回报来得慢”，还不足以推翻继续扩容的判断</h3>
-<p><strong>Zuckerberg 已经把提前投入可能造成的损失纳入选择。</strong> 如果预测依赖“管理层发现 AI 有泡沫，所以马上少花”，就需要证明他对错过算力的担忧减弱了，或公司已承受不起等待成本。单纯重复过度投资的风险，不能完成这一步。</p>
-<p>🎙️ <a href="https://www.youtube.com/watch?v=23FyskyFoP8" target="_blank" rel="noopener noreferrer">Access 长访谈</a>（2025-09-18，01:09:10–01:13:55）中，他承认基础设施可能出现泡沫，但<u class="key">仍认为建设太慢、到时没有准备好的风险更大</u>，并以 Meta 能承受损失解释取舍。这是历史上的本人陈述；🏛️ <a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q2/META-Q2-2026-Earnings-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">七月业绩会</a>（2026-07-29）强调近期容量扩张，<a href="https://about.fb.com/news/2026/08/agreement-with-state-attorneys-general-supporting-teens/" target="_blank" rel="noopener noreferrer">八月和解公告</a>（2026-08-26）维持其余指引，提供了更近的行动依据。</p>
-<p>这支持继续投入的基准判断，却没有排除前述付款下修。<strong>真正会动摇战略投入的，是追加算力不再有吸引力，或主营业务与融资能力同时恶化。</strong> 需要查新年度预算评审是否出现明确的现金、负债或回报约束，以及触及约束后哪批项目先被停止。</p>
+<h3 id="32">3.2 【传导路径】资源重配使单项节省更难传到总额，但不能凭空制造需求</h3>
+<p><strong>一个团队少用算力后，先要问这些资源去了哪里。</strong> 如果广告或推荐可以接走，原本准备给这些业务购买的部分容量就能由旧设备满足；与此同时，其他尚未满足的需求仍可能保住公司总体采购。真正决定总预算的，是重新分配后还剩多少值得满足的容量缺口。</p>
+<p>🎙️ Susan Li 在 <a href="https://cheekypint.transistor.fm/2/transcript" target="_blank" rel="noopener noreferrer">Cheeky Pint</a>（2025-06-18，24:16 起）说明 <u class="key">GPU 可以由中央重新分配，同时广告吸收更多算力也有上限</u>。她在 <a href="https://ca.investing.com/news/transcripts/meta-at-morgan-stanley-conference-ai-strategy-and-financial-insights-93CH-4495629" target="_blank" rel="noopener noreferrer">Morgan Stanley 访谈</a>（2026-03-04，第三方完整转录）描述以实验和追加回报评估资源。这说明预算可以跨业务比较，而不是每个团队永久占有自己的额度。</p>
+<p>这里有两个条件：设备、网络和任务须兼容，承接业务也须有足够的净需求。调拨旧设备本身不增加资本开支；如果它已经填平其他业务的缺口，反而可能减少下一批采购。Gross 在 <a href="https://www.youtube.com/watch?v=l9wzs_QIyp0" target="_blank" rel="noopener noreferrer">Stripe Sessions</a>（2026-04-30，20:34–22:35；<a href="https://stripe.com/br/sessions/2026/a-conversation-with-daniel" target="_blank" rel="noopener noreferrer">发布方实录</a>）讨论小模型和按任务价值配置预算，提供了节省来源，却没有披露节省已经变成公司净取消订单。</p>
+<p><strong>当前材料更支持公司继续筛选用途、重配资源；尚未证明筛选后出现了足以降低总预算的持续闲置。</strong> 会改变判断的证据，是跨团队调拨后仍有闲置，且下一批服务器订单同步减少。只看到某个模型训练变少，传导链还没有走完。</p>
 <p><span id="insight-finance"></span></p>
-<h3 id="35">3.5 【传导路径】现金吃紧是否会变成少建项目，取决于融资缓冲还能用多久</h3>
-<p><strong>自由现金流变薄之后，公司仍可以调整回购、借款或引入合作方，继续支付建设费用。</strong> 这些选择延后了被迫削减的时点，也增加未来偿付责任。因此，资本预算保持不变，并不能说明投入已经产生足够回报。</p>
-<p>🏛️ <a href="https://www.sec.gov/Archives/edgar/data/1326801/000162828026050705/meta-20260630.htm" target="_blank" rel="noopener noreferrer">Q2 季报</a>（2026-07-30）显示<u class="key">上半年没有回购，五月发行了 25 十亿美元债券</u>；<a href="https://investor.atmeta.com/investor-news/press-release-details/2026/Meta-Announces-New-Strategic-Venture-with-BlackRock-to-Develop-Data-Center-in-El-Paso/default.aspx" target="_blank" rel="noopener noreferrer">El Paso 公告</a>（2026-07-28）宣布合作开发约 14 十亿美元长期资产。📰 Dina 的 <a href="https://www.linkedin.com/posts/dina-powell-mccormick_with-meta-compute-were-uniting-capital-activity-7448071525326401536-Mzeh" target="_blank" rel="noopener noreferrer">FII 本人原帖及视频转录</a>（2026-04-09）介绍资产负债表、主权基金、机构和能源伙伴等融资方向；季报和项目公告说明部分安排已经落地，原帖本身不证明所有资金均已落实。</p>
-<p>🏛️ <a href="https://about.fb.com/news/2026/08/agreement-with-state-attorneys-general-supporting-teens/" target="_blank" rel="noopener noreferrer">八月和解公告</a>及<a href="https://s21.q4cdn.com/399680738/files/doc_events/META-Conference-Call-on-Agreement-with-Bipartisan-Attorneys-General-Transcript.pdf" target="_blank" rel="noopener noreferrer">电话会</a>将付款分布在多年，同时保留七月其余指引。这次冲击被吸收，是当前预算韧性的证据，不能外推为任何冲击都能承受。<strong>最值得跟踪的是下一批融资的成本与条件，以及融资不及预期时公司是否削减已批准项目。</strong> 合作持有也可能改变报表分类；必须核对可比资本现金与租赁、担保责任，不能把融资安排直接算成经济投入下降。</p>
+<h3 id="33">3.3 【传导路径】融资缓冲让公司可以等回报，代价是未来仍要付钱</h3>
+<p><strong>融资缓冲，就是在建设付款早于业务回款时，帮助公司继续付款的资金余地。</strong> 现金储备可以补当期缺口；债券把一部分负担移到未来偿付；合作方出资可以分担前期建设。减少回购则是把原本可能返还股东的钱留给公司，它属于现金用途调整，本身不是融资。</p>
+<p>🏛️ <a href="https://www.sec.gov/Archives/edgar/data/1326801/000162828026050705/meta-20260630.htm" target="_blank" rel="noopener noreferrer">Q2 季报</a>（2026-07-30）披露 <u class="key">上半年没有回购，五月发行 250 亿美元债券</u>。这两件事说明现金安排已经发生变化，但不能据此认定所有留存或募集资金都专款用于 AI。🏛️ <a href="https://investor.atmeta.com/investor-news/press-release-details/2026/Meta-Announces-New-Strategic-Venture-with-BlackRock-to-Develop-Data-Center-in-El-Paso/default.aspx" target="_blank" rel="noopener noreferrer">El Paso 公告</a>（2026-07-28）宣布，约 140 亿美元的建筑及长期电力、冷却、连接设施由 BlackRock 管理的基金与 Meta 按 80/20 权益分担；Meta 将租用园区，并承担附条件的残值担保。这里的融资没有覆盖全部服务器成本，也没有消除 Meta 的长期责任。</p>
+<p>这解释了为什么现金压力未必立即迫使公司少建。🏛️ <a href="https://about.fb.com/news/2026/08/agreement-with-state-attorneys-general-supporting-teens/" target="_blank" rel="noopener noreferrer">八月和解公告</a>（2026-08-26，次日更新）在法律费用冲击后仍维持七月其余指引，且相关付款分布在多年，是预算承受了一次实际冲击的依据。<a href="https://s21.q4cdn.com/399680738/files/doc_events/META-Conference-Call-on-Agreement-with-Bipartisan-Attorneys-General-Transcript.pdf" target="_blank" rel="noopener noreferrer">正式电话会</a>可交叉核对付款安排。</p>
+<p><strong>融资买到的是时间，项目回报仍要由业务来证明。</strong> 债务要付利息，合作项目可能要付租金或履行担保；融资也不能使延误的设备提前到场。若经营现金流恶化、融资成本升高或担保负担加重，缓冲会变薄，届时才更容易把财务压力传成资本削减。判断合资安排时还须还原可比现金口径，不能把报表分类移动当成真实投入下降。</p>
+<p><span id="insight-timing"></span></p>
+<h3 id="34">3.4 【传导路径】如果发生下调，更可能来自年末交付与付款跨年</h3>
+<p><strong>交付跨年是实物进度改变，付款跨年是现金时间改变。</strong> 例如，原定十二月交付并验收的服务器拖到一月，是交付跨年。合同若约定验收后付款，相关现金也可能移到下一年；若已预付，晚交付却不一定使当年付款减少。反过来，设备十二月已经验收、合同约定一月结算，也可能只有付款跨年。能否形成下修，还要看这些日期是否较原计划后移。</p>
+<figure class="cx-figure tv-timeline" id="delivery-payment" aria-labelledby="delivery-payment-title">
+<figcaption class="cx-title" id="delivery-payment-title">从晚交付到下调预算，中间还有三步</figcaption>
+<p class="cx-sub">以原定十二月交付、验收后付款的设备为例；这是条件示例，并非已确认的 Meta 项目延期。</p>
+<ol class="tv-steps"><li><strong>设备一月才验收</strong><span>实物交付跨年</span></li><li><strong>对应付款也顺延</strong><span>取决于合同与预付款</span></li><li><strong>其他资本支出补不上</strong><span>当年公司总额才减少</span></li><li><strong>Meta 正式降低可比指引</strong><span>本题才结算 YES</span></li></ol>
+<p class="cx-sub">只公布实际支出低于指引，不自动算计划下调；普通云服务运营费用也不能补进本题资本现金总额。</p>
+</figure>
+
+<p>🏛️ <a href="https://investor.atmeta.com/investor-news/press-release-details/2026/Meta-Reports-Second-Quarter-2026-Results/default.aspx" target="_blank" rel="noopener noreferrer">Q2 公告</a>（2026-07-29）给出的全年区间扣除上半年已付金额后，<u class="key">下半年仍需支付 790.82–940.82 亿美元</u>；这是我们的算术推导，并非单独发布的半年指引。📰 Janardhan 的<a href="https://www.linkedin.com/posts/sjanardhan_americas-workforce-academy-the-future-is-activity-7469869698331922432-JYIA" target="_blank" rel="noopener noreferrer">本人原帖</a>（2026-06-08）说明施工技能人员不足，也公布了培训措施。这些材料让执行时点成为重要风险，但后置付款和用工问题可能已包含在七月指引中，不能直接当作新的延期证据。</p>
+<p><strong>我们把交付和付款错位看作下调情景中的主要路径，因为它不需要管理层先放弃扩建。</strong> 如果公司能按期付款，或者提前执行其他资本项目，总额仍可不变；如果晚付已经被原预算考虑，也不形成新的下修。预测最需要补齐的事实，是七月指引之后哪些项目的现金日期发生变化、金额多大、是否被其他资本支出抵消。</p>
+<p><span id="insight-orders"></span>
+<span id="insight-intent"></span></p>
+<h3 id="35">3.5 【本质驱动】长期建设保留选择，服务器的数量和单价仍会改变近期金额</h3>
+<p><strong>继续建园区，只能证明一部分长期投入仍在推进。</strong> 🏛️ <a href="https://s21.q4cdn.com/399680738/files/doc_financials/2026/q2/META-Q2-2026-Earnings-Call-Transcript.pdf" target="_blank" rel="noopener noreferrer">Q2 正式电话会</a>（2026-07-29，第 8 页）明确区分近期容量与远期选择：面向 2028 年以后，<u class="key">先建设数据中心和网络，为后续服务器投资保留空间</u>。因此，远期园区没有锁死全部后续设备预算；尚未下单的服务器数量、采购价格与付款批次仍值得分别预测。</p>
+<p>🏛️ <a href="https://investor.atmeta.com/investor-news/press-release-details/2026/Meta-Reports-First-Quarter-2026-Results/default.aspx" target="_blank" rel="noopener noreferrer">Q1 公告</a>（2026-04-29）把当次资本指引上调主要归因于组件价格上涨，说明单价能改变名义预算。未来若价格下降，且节省没有用于增购设备，即使容量需求不变，也可能出现符合本题的正式下修。这是与付款时点并列的金额通道，目前尚无材料足以确认它已形成新的总额下调。</p>
+<p>管理层仍有较强的提前建设意愿。🎙️ Zuckerberg 在 <a href="https://www.youtube.com/watch?v=23FyskyFoP8" target="_blank" rel="noopener noreferrer">Access 长访谈</a>（2025-09-18，01:09:10–01:13:55）承认过早建设可能造成损失，仍更担心届时容量不足；七月容量表态与八月维持预算提供了较近依据。集中控制权使这种偏好更容易延续，也使其改变判断时可以较快重排资源，不能当成不会纠错的保证。</p>
+<p><strong>综合起来，近期总额受业务需求和融资支撑，仍有时点、单价和后续采购批次可以调整。</strong> 支持更深削减的证据，需要同时指向追加回报减弱、重配后需求不足，或融资条件已限制获批项目；目前公开材料尚未补齐这条链。</p>
 <h2 id="4">4. 结算口径</h2>
 <h3 id="41-yes">4.1 什么算 YES？</h3>
 <p>观察窗按美国东部时间从 <strong>2026-09-06 00:00</strong> 到 <strong>2027-03-06 23:59</strong>。任一合格下调一经正式公开，即锁定 YES，之后再上调也不撤销。只考察名义美元计划，不做通胀调整。</p>
 <ul>
 <li><strong>同一财年修订：</strong> 新区间中点低于紧接此前的有效区间中点；或公司明确宣布下调，并给出可比的量化计划。先上调再下调，只要后一步合格，即使仍高于基线也算。</li>
-<li><strong>跨财年首次预算：</strong> 下一财年首次区间中点低于上一财年的可比基准，算 YES。为避免事后挑选，本报告优先使用宣布当时已经公布的上一年实际值；尚无实际值时使用上一年最后有效指引中点。</li>
+<li><strong>跨财年首次预算：</strong> 将下一财年首次全年指引中点，与上一财年最终有效指引中点、正式公布的实际值分别比较；<strong>低于任一可比基准即为 YES</strong>，不设“实际优先”。只用可追踪的正式材料，记录计划及各基准的首次公开日期；若实际稍后在窗口内公布，补做实际比较。已知指引比较成立时，不必等实际值；缺少必要基准或可比重述时保留待判定，不凭未知值判 NO。截止后的新计划不能倒填进窗口。</li>
 <li><strong>单独批准的方案：</strong> 公司正式宣布已批准、可量化、能还原为公司可比资本计划净减少的方案，算 YES。减少的现金支出可以主要发生在截止日以后。取消单项目后等额转投其他项目、不降低同一计划总额，不按公司计划下调处理。</li>
 </ul>
 <p>NO 指整个窗口都没有上述事件；它不意味着资金紧张、项目延期或内部讨论从未发生。</p>
@@ -493,7 +518,7 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 <p>正式渠道包括 Meta 的投资者关系公告、公司正式新闻稿、SEC 文件、公开业绩会和有可追踪记录的正式投资者活动。具有明确代表公司披露预算性质的管理层原始公开声明可以采用；个人随口评论、转述、分析师猜测或匿名内部讨论不能代替公司决定。</p>
 <p>以<strong>首次公开的时间</strong>判断是否落在窗口内。截止后补发文件，只有存在可复现的截止前正式公开记录，才使用较早时间；会计上的批准日或生效日不能倒填公告日期。</p>
 <p>统一到原有资本开支范围，保留融资租赁本金的处理；区分现金购建资产、租赁资产非现金增加、云服务运营费用和并购价款。若合作持有、并表或租赁分类变化导致表面下降，先还原；还原后没有下降，不算 YES。金额下降来自设备降价，只要可比名义预算正式下降，仍然算 YES。</p>
-<h3 id="43">4.3 五个容易出现的边界案例</h3>
+<h3 id="43">4.3 六个容易出现的边界案例</h3>
 <div class="tablewrap"><table>
 <thead>
 <tr>
@@ -519,6 +544,11 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 <td>实际少花不自动构成“计划下调”。它可以成为下一年首次预算的比较基准。</td>
 </tr>
 <tr>
+<td>上年最终指引中点 137.5、实际 134，次年首次中点 135；口径均可比</td>
+<td>YES</td>
+<td>135 虽高于实际，仍低于最终指引 137.5；原题的“或”满足。以上为假设金额。</td>
+</tr>
+<tr>
 <td>数据中心延期，但全年资本区间不变；或 2027 预算继续增加而增速放缓</td>
 <td>NO</td>
 <td>前者没有正式净下修，后者没有年度名义下降。</td>
@@ -532,7 +562,7 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 </table></div>
 <p>“至少减少 5%”只属于敏感性口径。它比较<strong>同一未来十二个月</strong>与基线版本的计划，不能用 2026 全年中点直接替代跨年的十二个月基准。基线日没有公开的完整滚动十二个月预算，因此这项判断的证据要求更高、置信度更低。</p>
 <h2 id="5">5. 情景与路径</h2>
-<p>分类顺序先看窗口内是否出现合格下调。出现后按<strong>首次合格决定的主导原因</strong>分类；若混合原因同样重要，依次归入需求/财务约束、主动战略、工程支付，避免重复。没有合格下调时，先识别相对既有计划的明确放缓，再识别上调或更高的新财年预算，最后归入维持。一般性的风险提示不叫“转鸽”。</p>
+<p>分类顺序先看窗口内是否出现合格下调。仅由本次恢复的跨年比较触发、且全窗没有其他合格下调的情况，单列“新增跨年边界”，不预设原因。其余出现下调后按<strong>首次合格决定的主导原因</strong>分类；若混合原因同样重要，依次归入需求/财务约束、主动战略、工程支付，避免重复。没有合格下调时，先识别相对既有计划的明确放缓，再识别上调或更高的新财年预算，最后归入维持。一般性的风险提示不叫“转鸽”。</p>
 <div class="tablewrap"><table>
 <thead>
 <tr>
@@ -595,9 +625,10 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 </tr>
 </tbody>
 </table></div>
+<p><strong>新增跨年边界：</strong> 下一年首次预算虽不低于上年实际，却低于上年最终指引，也可触发 YES。这可能来自价格、需求或付款年度的组合变化，不能全部归为工程延期。其概率在附录单列，避免与已经发生的其他下调重复计算。</p>
 <p><strong>最容易误判的图景：</strong> 训练延期以后把设备调给推荐系统；自研芯片减少单位成本但增加总调用；运营费用和招聘被砍而资本计划继续增加；项目改由合作方持有；实际单季支付下降。这些都要再走一步：有没有公司正式、可比、净额的计划下修？</p>
 <p><strong>支持 YES 的最强论证。</strong> 历史上 Meta 确实在年末修改过预算；今年下半年支付规模明显大于上半年，硬件、验收、供电中的任何延误都可能迫使现金指引下修。若广告或融资再受打击，管理层也存在快速纠错先例。最薄弱的一环是：执行压力可能通过跨项目调拨、替代供应或融资吸收，最后没有降低正式计划。</p>
-<p><strong>支持 NO 的最强论证。</strong> 正式近年容量目标仍强，推荐与广告提供较成熟的需求，合同和合作安排增加撤销成本；八月真实法律冲击后仍保留资本区间。最薄弱的一环是：这些证据主要说明投资意愿，不保证设备、验收和付款能在原财年完成；小幅下修不需要管理层承认 AI 战略错误。</p>
+<p><strong>支持 NO 的最强论证。</strong> 广告和推荐有较成熟的产出依据，新业务增加可使用算力的用途；资源重配使单项节省未必降低整体容量缺口，现金与融资安排又使获批建设能够继续。八月真实法律冲击后仍保留资本区间，是这套预算支撑经受过一次检验的依据。最薄弱的一环是：这些证据主要说明投资意愿，不保证设备、验收和付款能在原财年完成；小幅下修不需要管理层承认 AI 战略错误。</p>
 <h2 id="6">6. 关键证据表</h2>
 <p>A 为 Meta 或政府正式披露及 SEC 文件；B 为主流原创报道；C 为供应链公告、地方或行业媒体、当事人访谈；D 为匿名单一消息和二手转述；E 为社交转载。文件能确认“公司这样说过”，不等于能保证预测兑现。下表限定为二十条，完整历史逐次记录在附录。</p>
 <div class="tablewrap"><table>
@@ -846,7 +877,7 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 <p><strong>能改变什么：</strong> 改变“执行调整进入正式指引”和“外部冲击迫使总预算变化”，幅度中；难以独立证明公司整体预算。</p>
 <p><strong>好不好约：</strong> 中高。公开项目多，但要防止把单个环节的信息误当全局。</p>
 <h2 id="8">8. 信源梯度反馈</h2>
-<p><strong>第四版综合说明：</strong> 本次按付款时点、需求转订单、采购价格与承诺、投入意愿及融资能力重写 Insights，使用已归档且截点内的材料。没有把编辑重组算作新增搜索，也没有声称填补 X 原帖正文缺口。<a href="/investment-analysis/reports/meta-capex-6m-assets/readability-v4/index.html" target="_blank" rel="noopener noreferrer">版本改写与检查记录</a>。</p>
+<p><strong>第五版定向复核：</strong> 从 Word 提供的业务线索回到 Q1/Q2 官方电话会，逐项核验产出数字，并重写它们如何支持预算申请。另独立复核跨年结算规则和历史窗口。这是针对原文与逻辑的核对，未新增一轮视频或社交采集，X 原帖正文缺口仍在。<a href="/investment-analysis/reports/meta-capex-6m-assets/thesis-v5/index.html" target="_blank" rel="noopener noreferrer">本版复核记录</a>；<a href="/investment-analysis/reports/meta-capex-6m-assets/readability-v4/index.html" target="_blank" rel="noopener noreferrer">第四版表达调整归档</a>。</p>
 <p><strong>第三版结构核对：</strong> 回到 2024 Q4 与 2026 Q1/Q2 正式电话会及 Q2 季报，核对资产类别、现金与存量、组件价格及长期建设与服务器决策的时序。核验记录及分项判断见<a href="/investment-analysis/reports/meta-capex-6m-assets/capex-structure/index.html" target="_blank" rel="noopener noreferrer">结构研究台账</a>与<a href="/investment-analysis/reports/meta-capex-6m-assets/capex-structure/components.json" target="_blank" rel="noopener noreferrer">结构数据</a>。这次是有针对性的原文核对，未把它计作新一轮视频或社交采集。</p>
 <p><strong>第二轮补上了第一版明显不足的视频与社交覆盖，但仍不能称为穷尽。</strong> 第一版有 Susan Li 的文字访谈及正式电话会，却没有保存视频字幕，没有读取 X 原帖，也没有实际展开 Reddit 评论。本版把候选、正文、字幕和访问失败分别登记。</p>
 <div class="tablewrap"><table>
@@ -907,7 +938,7 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 <p>第一版的其他纠错继续有效：2022 年 Kuna／Temple 暂停建设没有被算作 2026 年新事件；Q2 电话会末页更正为供给受限；八月和解的费用确认不等于同额现金立即流出；已离职人员不再被列作现任审批人。原始出处保留在<a href="/investment-analysis/reports/meta-capex-6m-assets/source-coverage.html" target="_blank" rel="noopener noreferrer">第一版来源记录</a>。</p>
 <p><strong>充分性判断：</strong> 本轮已能比较主要管理层的预算逻辑，并用原始文件检验论坛反方；它仍不足以观察公司内部已经批准、尚未公开的计划。下一份最有可能改变判断的材料，是具体订单或验收日程如何进入财务预算，而非另一篇关于 AI 泡沫的观点。X、付费全文和自采访谈的缺口明确保留，不能用来源数量或检查通过数来替代。</p>
 <h2 id="9-qa">9. 自检结果（QA）</h2>
-<p>本次工程层指模型之外管理检索记录、来源、去重和概率计算的程序。实际调用已有 Predict-Raven 预测引擎，把本会话核验的证据按四轮回放；判断与权重来自本次研究，没有把回放包装成额外模型独立研究。原始检索记录与引擎回放日志分别保存。第三版沿用第二版四轮计算审计；本次资产拆分与可视化没有新增独立计权项，也没有把重复执行相同输入当成新一轮研究。</p>
+<p>本次工程层指模型之外管理检索记录、来源、去重和概率计算的程序。实际调用已有 Predict-Raven 预测引擎，把本会话核验的证据按四轮回放；判断与权重来自本次研究，没有把回放包装成额外模型独立研究。原始检索记录与引擎回放日志分别保存。第三版沿用第二版四轮计算审计；此前资产拆分与可视化没有新增独立计权项。第五版保留旧回放的历史记录，单独计算恢复跨年规则后的事件差集；没有把回放包装成额外模型独立研究，也没有把业务指标重复计权。</p>
 <div class="tablewrap"><table>
 <thead>
 <tr>
@@ -955,7 +986,7 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 <tr>
 <td>不看事件市场赔率</td>
 <td>PASS</td>
-<td>不使用预测市场、博彩赔率或他人对本事件的概率；引擎相应开关开启。</td>
+<td>不使用预测市场或博彩赔率；已阅读 Word 的其他预测，但没有用其概率校准、平均或加权本报告。原回放保持盲于市场赔率。</td>
 </tr>
 <tr>
 <td>三种口径</td>
@@ -965,12 +996,12 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 <tr>
 <td>路径互斥和加总</td>
 <td>PASS</td>
-<td>程序实际相加，并核对主结果路径总额与四舍五入后的引擎结果一致。</td>
+<td>程序核对旧回放加规则差集后的主结果，七条互斥路径与 YES / NO 合计一致。</td>
 </tr>
 <tr>
 <td>概率位置</td>
 <td>PASS</td>
-<td>概率只在第 1 节与附录；依模板要求第 10 节重复主结论。正文财务百分比和股权比例不属于事件概率；分项风险采用定性判断，四种情形用于解释因果条件，不构成独立概率输入。</td>
+<td>概率只在第 1 节与附录；依模板要求第 10 节重复主结论。正文业务效果、财务百分比和股权比例不属于事件概率；分项风险采用定性判断，四种情形用于解释因果条件，不构成独立概率输入。</td>
 </tr>
 <tr>
 <td>精度与范围</td>
@@ -980,7 +1011,7 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 <tr>
 <td>洞察准入</td>
 <td>PASS</td>
-<td>五条围绕具体资本决策因果链重写，均有承重来源；没有将访问缺失、结算口径或泛泛市场叙事充作洞察。</td>
+<td>五条围绕预算支撑与失效条件重写，均有关键原始依据；没有将访问缺失、结算口径或泛泛市场叙事充作洞察。</td>
 </tr>
 <tr>
 <td>视频与社交获取</td>
@@ -1009,12 +1040,12 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 </tr>
 </tbody>
 </table></div>
-<p>研究文件：<a href="/investment-analysis/reports/meta-capex-6m-assets/history.csv" target="_blank" rel="noopener noreferrer">历史明细</a>、<a href="/investment-analysis/reports/meta-capex-6m-assets/source-coverage.html" target="_blank" rel="noopener noreferrer">来源与覆盖记录</a>、<a href="/investment-analysis/reports/meta-capex-6m-assets/forecast-audit-v2.json" target="_blank" rel="noopener noreferrer">计算审计</a>、<a href="/investment-analysis/reports/meta-capex-6m-assets/qa-results-v4.json" target="_blank" rel="noopener noreferrer">验收记录</a>。正文能独立阅读，附属文件用于复核计算及访问边界。</p>
+<p>研究文件：<a href="/investment-analysis/reports/meta-capex-6m-assets/history.csv" target="_blank" rel="noopener noreferrer">历史明细</a>、<a href="/investment-analysis/reports/meta-capex-6m-assets/source-coverage.html" target="_blank" rel="noopener noreferrer">来源与覆盖记录</a>、<a href="/investment-analysis/reports/meta-capex-6m-assets/forecast-audit-v2.json" target="_blank" rel="noopener noreferrer">原证据回放</a>、<a href="/investment-analysis/reports/meta-capex-6m-assets/thesis-v5/forecast-audit-v5.json" target="_blank" rel="noopener noreferrer">本版规则与概率审计</a>、<a href="/investment-analysis/reports/meta-capex-6m-assets/qa-results-v5.json" target="_blank" rel="noopener noreferrer">验收记录</a>。正文能独立阅读，附属文件用于复核计算及访问边界。</p>
 <h2 id="10">10. 最终预测声明</h2>
-<p><strong>Meta 在 2027-03-06 23:59（美国东部时间）前正式下调可比口径名义资本开支计划的概率：32%；合理范围 20–45%；倾向 NO；主观置信度中低。</strong></p>
+<p><strong>Meta 在 2027-03-06 23:59（美国东部时间）前正式下调可比口径名义资本开支计划的概率：34%；合理范围 20–45%；倾向 NO；主观置信度中低。</strong></p>
 <p>最可能看到的现实是，Meta 继续争取近两年的计算资源，同时在部分项目上调整节奏、融资结构或交付安排。正式削减仍是值得认真对待的少数情景，其中最现实的是年度付款和工程进度导致指引下修；即使发生，也需要再判断是否代表长期需求减少。不构成投资建议。</p>
 <h2 id="a1">A1. 概率模型与数值代入</h2>
-<p><strong>第三版说明：</strong> 主模型继续使用第二版四轮证据回放。第 2 节按资产拆开同一决策链，未形成新的独立概率输入；分项风险不能平均或相乘得到总概率。第四版以四种情形说明净额变化的条件，已撤下假设金额演算。所有原计权、历史窗口与六条结果路径均维持。</p>
+<p><strong>第五版计算说明：</strong> 原证据回放约为 32.2%。本次纠正跨年首次预算的比较规则，另为新增且不与原 YES 重叠的情形保留约 2 个百分点，得到约 34%。这个增量是主观估计，不是新发现的市场证据、拟合出的参数或第五轮独立研究。业务产出核验增强了解释，没有再给同一财报加权。<a href="/investment-analysis/reports/meta-capex-6m-assets/thesis-v5/forecast-audit-v5.json" target="_blank" rel="noopener noreferrer">计算与路径审计</a>。</p>
 <h3 id="a11">A1.1 从经验频率到本次判断</h3>
 <div class="tablewrap"><table>
 <thead>
@@ -1040,14 +1071,14 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 </tr>
 <tr>
 <td>P（正式下调）</td>
-<td>当前事实修正后的主答案</td>
-<td>32%</td>
-<td>前三轮计权、第四轮补漏复核，整数呈现</td>
+<td>旧证据回放加恢复规则的增量</td>
+<td>34%</td>
+<td>原回放约 32.2%，新增事件差集约 2 个百分点，整数呈现</td>
 </tr>
 <tr>
 <td>P（不正式下调）</td>
 <td>主答案的补集</td>
-<td>68%</td>
+<td>66%</td>
 <td>与 YES 互斥且穷尽</td>
 </tr>
 <tr>
@@ -1060,7 +1091,7 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 <td>P（转鸽但不削减）</td>
 <td>无正式下调且明确放缓</td>
 <td>28%</td>
-<td>六条结果路径中的一条</td>
+<td>七条结果路径中的一条</td>
 </tr>
 </tbody>
 </table></div>
@@ -1070,12 +1101,14 @@ main td{min-width:100px}.org td:first-child{min-width:100px}
 起点几率＝0.60 ÷ 0.40＝1.5<br>
 有效调整合计＝−0.35＋0.35−0.70−0.25−0.25＋0.10＋0.10−0.15＝−1.15<br>
 更新后几率＝1.5 × exp(−1.15)<br>
-P（正式下调）＝更新后几率 ÷ (1＋更新后几率) ≈ <b>32%</b><br>
+原规则回放＝更新后几率 ÷ (1＋更新后几率) ≈ 32.2%<br>
+新增且不重叠的跨年情形＝约 2 个百分点（主观估计）<br>
+恢复原题规则后＝32.2%＋2% ≈ <b>34%</b><br>
 主观合理范围＝<b>20–45%</b>
 </div>
 
-<p>exp 表示把对数调整转回乘数。模型做了 URL 去重和同信息簇折减，没有假设六条路径的触发因素彼此独立。范围不是统计置信区间；它涵盖权重、历史类比和内部预算信息不足的共同不确定性。</p>
-<h3 id="a12">A1.2 每条调整为何给这个量级？</h3>
+<p>exp 表示把对数调整转回乘数。模型做了 URL 去重和同信息簇折减，没有假设各条路径的触发因素彼此独立。范围不是统计置信区间；它涵盖权重、历史类比和内部预算信息不足的共同不确定性。</p>
+<h3 id="a12">A1.2 原证据回放：每条调整为何给这个量级？</h3>
 <p>表内“调整”以<strong>百分点</strong>计，由整数端点之差计算，因此可逐行相加。程序保存未舍入结果，细微差异来自四舍五入；权重值本身不是概率。</p>
 <div class="tight1">
 <div class="tablewrap"><table>
@@ -1199,8 +1232,12 @@ P（正式下调）＝更新后几率 ÷ (1＋更新后几率) ≈ <b>32%</b><br
 </tr>
 </tbody>
 </table></div>
-<p>工程层实际执行第四轮，六项均进入来源日志，结果为 <strong>32.2% → 32.2%</strong>，仍按整数呈现为 <strong>32%</strong>。零增量表示不再增加概率权重，不表示材料没有研究价值。没有因来源更多而缩窄主观范围。原始八项权重、历史频率和情景分摊均保持不变。</p>
-<h3 id="a13">A1.3 六条互斥结果的分配</h3>
+<p>工程层实际执行第四轮，六项均进入来源日志，结果为 <strong>32.2% → 32.2%</strong>，仍按整数呈现为 <strong>32%</strong>。零增量表示不再增加概率权重，不表示材料没有研究价值。没有因来源更多而缩窄主观范围。在第二版中，原始八项权重、历史频率和情景分摊均保持不变；第五版的规则纠正另见下一小节。</p>
+<h3 id="a12b">A1.2b 恢复跨年规则，为何只增加约两个百分点？</h3>
+<p>设上年最终指引中点为 G、实际值为 A、次年首次预算中点为 N。新增部分只有 <strong>G &gt; A 且 A ≤ N &lt; G</strong>，并且整个观察窗没有其他旧规则已判为 YES 的事件。原模型本就包含跨年预算，不能把整条跨年渠道再加一遍。</p>
+<p>八个历史窗口按两项基准复查仍为 5/8，平滑起点仍是 60%。新增区域需要上年实际低于最终计划、公司未先正式下修，以及次年预算恰好落在两个基准之间；近期容量意愿又覆盖下一年。因此本版为这一组合留约 2 个百分点，并以 0–4 个百分点检查判断幅度，对应总概率约 32–36%。这不是由八个样本测出的差集频率。主观合理范围仍为 20–45%，不因规则复核而增加统计确定性。</p>
+<p>若把 G＝137.5、A＝134、N＝135 代入，原题判 YES；若只知道实际 134、没有任何新计划，仍不算下调。完整的边界和日期检查见<a href="/investment-analysis/reports/meta-capex-6m-assets/thesis-v5/resolution-review.html" target="_blank" rel="noopener noreferrer">结算复核</a>。</p>
+<h3 id="a13">A1.3 七条互斥结果的分配</h3>
 <div class="tablewrap"><table>
 <thead>
 <tr>
@@ -1226,6 +1263,11 @@ P（正式下调）＝更新后几率 ÷ (1＋更新后几率) ≈ <b>32%</b><br
 <td style="text-align: right;">20%</td>
 </tr>
 <tr>
+<td>仅由恢复的跨年边界触发，且无其他合格下调</td>
+<td>YES</td>
+<td style="text-align: right;">2%</td>
+</tr>
+<tr>
 <td>转鸽但不削减</td>
 <td>NO</td>
 <td style="text-align: right;">28%</td>
@@ -1236,18 +1278,18 @@ P（正式下调）＝更新后几率 ÷ (1＋更新后几率) ≈ <b>32%</b><br
 <td style="text-align: right;">14%</td>
 </tr>
 <tr>
-<td>再次上调或开启更高新财年预算</td>
+<td>再次上调或开启更高新财年预算，且不触发跨年边界</td>
 <td>NO</td>
-<td style="text-align: right;">26%</td>
+<td style="text-align: right;">24%</td>
 </tr>
 <tr>
 <td><strong>合计</strong></td>
-<td><strong>YES 32%；NO 68%</strong></td>
+<td><strong>YES 34%；NO 66%</strong></td>
 <td style="text-align: right;"><strong>100%</strong></td>
 </tr>
 </tbody>
 </table></div>
-<p>这是对主答案的情景分摊，不是额外六个独立模型。大类按第 5 节的优先级互斥；含有若干触发的现实事件只进入一行。</p>
+<p>这是对主答案的主观情景分摊，不是七个独立模型。新增加的跨年行不预设原因；为保持总和，本版从原“更高新财年预算”一行重分配 2 个百分点，因为次年高于实际、低于最终指引的预算原先可能落在那里。此分摊没有被新订单数据独立验证。工程支付类仍为 20 个百分点，占当前 YES 的约 59%，对应“如果下调，更可能来自时点变化”的条件判断；不要把新增跨年行也全部算作工程。</p>
 <h3 id="a14">A1.4 财务与承诺如何进入判断</h3>
 <p>以下金额仍为十亿美元。<a href="https://investor.atmeta.com/investor-news/press-release-details/2026/Meta-Reports-Second-Quarter-2026-Results/default.aspx" target="_blank" rel="noopener noreferrer">Q2 公告</a>与<a href="https://www.sec.gov/Archives/edgar/data/1326801/000162828026050705/meta-20260630.htm" target="_blank" rel="noopener noreferrer">Q2 季报</a>给出的关键检查是：上半年经营现金流 <strong>64.088</strong>，减资本支付 <strong>50.918</strong>，得到自由现金流 <strong>13.170</strong>；Q2 自由现金流为 <strong>0.784</strong>。不能用这个单季数字直接年化。</p>
 <p>六月末现金、现金等价物及有价证券 <strong>90.260</strong>，债务 <strong>83.664</strong>；它们不是都可自由支配、同日到期的对称头寸。单独列示的受限资金不再从前述现金数字重复扣除。2026 年没有披露到期债务本金，2027 年为 <strong>2.75</strong>；五月融资增加了缓冲，同时增加以后利息成本。</p>
@@ -1890,7 +1932,7 @@ P（正式下调）＝更新后几率 ÷ (1＋更新后几率) ≈ <b>32%</b><br
 <tbody>
 <tr>
 <td>正式下调任意幅度的可比名义计划</td>
-<td style="text-align: right;"><strong>32%</strong></td>
+<td style="text-align: right;"><strong>34%</strong></td>
 <td><strong>20–45%</strong></td>
 <td>小幅年末时点修订也可以成立，但必须正式公开。</td>
 </tr>
@@ -1908,62 +1950,63 @@ P（正式下调）＝更新后几率 ÷ (1＋更新后几率) ≈ <b>32%</b><br
 </tr>
 <tr>
 <td>放宽到“项目延期导致当期实际资本开支下降”</td>
-<td style="text-align: right;">44%</td>
+<td style="text-align: right;">46%</td>
 <td>30–58%</td>
-<td>主口径之外再纳入 12 个百分点的实际支出下降情景；必须有延期导致下降的证据，不只看季节性。<strong>这不是主答案。</strong></td>
+<td>修正规则后的主口径之外再主观纳入 12 个百分点的实际支出下降情景；必须有延期导致下降的证据，不只看季节性。<strong>这不是主答案。</strong></td>
 </tr>
 </tbody>
 </table></div>
-<p>为说明重叠，一种与上述数字一致的主观交叉分配是：正式下调且达到实质削减 14%，正式下调但未达到实质削减 18%，实质削减证据充分但未正式下调 4%，两者均无 64%。于是主口径为 32%，实质口径为 18%；不是把 18% 简单称为 32% 的全部子集。</p>
-<p>“转鸽但不削减”占所有结果 28%；在最终没有正式下调的条件下，约占 41%。这是同一情景表的条件表达，并不是另一个新增风险。</p>
+<p>为说明重叠，一种与上述数字一致的主观交叉分配是：正式下调且达到实质削减 14%，正式下调但未达到实质削减 20%，实质削减证据充分但未正式下调 4%，两者均无 62%。于是主口径为 34%，实质口径为 18%。本版把新增跨年留量放入未达实质削减的一格，这是主观分配；两个口径并非严格包含。</p>
+<p>“转鸽但不削减”占所有结果 28%；在最终没有正式下调的条件下，约占 42%。这是同一情景表的条件表达，并不是另一个新增风险。</p>
 <h3 id="a32">A3.2 更换主观校准力度会怎样？</h3>
+<p>下表对原证据回放改变一个假设，再保留同样的 2 个百分点规则增量；其余相关性固定，属于压力检验。</p>
 <div class="tablewrap"><table>
 <thead>
 <tr>
 <th>改动</th>
-<th>保持不变的部分</th>
-<th style="text-align: right;">主口径结果</th>
+<th style="text-align: right;">原回放</th>
+<th style="text-align: right;">加规则增量后的主口径</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>历史起点改为 50%</td>
-<td>总对数调整仍为 −1.15</td>
+<td>历史起点改为 50%，总对数调整仍为 −1.15</td>
 <td style="text-align: right;">24%</td>
+<td style="text-align: right;">26%</td>
 </tr>
 <tr>
-<td>本报告起点 60%</td>
-<td>本报告证据权重</td>
+<td>本报告起点 60%，原证据权重</td>
 <td style="text-align: right;">32%</td>
+<td style="text-align: right;">34%</td>
 </tr>
 <tr>
-<td>历史起点改为 70%</td>
-<td>总对数调整仍为 −1.15</td>
+<td>历史起点改为 70%，总对数调整仍为 −1.15</td>
+<td style="text-align: right;">42%</td>
+<td style="text-align: right;">44%</td>
+</tr>
+<tr>
+<td>所有个案调整取原分量的七成，起点仍为 60%</td>
+<td style="text-align: right;">40%</td>
 <td style="text-align: right;">42%</td>
 </tr>
 <tr>
-<td>所有个案调整只取原分量的七成</td>
-<td>起点仍为 60%</td>
-<td style="text-align: right;">40%</td>
-</tr>
-<tr>
-<td>所有个案调整取原分量的一点三倍</td>
-<td>起点仍为 60%</td>
+<td>所有个案调整取原分量的一点三倍，起点仍为 60%</td>
 <td style="text-align: right;">25%</td>
+<td style="text-align: right;">27%</td>
 </tr>
 <tr>
-<td>去掉“近期容量意愿”这一最强调整</td>
-<td>其他有效调整固定，作压力检验</td>
+<td>去掉近期容量意愿这一最强调整</td>
 <td style="text-align: right;">49%</td>
+<td style="text-align: right;">51%</td>
 </tr>
 <tr>
 <td>去掉当年支付后置这一正向调整</td>
-<td>其他有效调整固定</td>
 <td style="text-align: right;">25%</td>
+<td style="text-align: right;">27%</td>
 </tr>
 </tbody>
 </table></div>
-<p>删除一项的检验只是暴露模型依赖，不是重新进行全部相关性估计。其中去掉容量意愿后，和解确认的折减仍固定，故不能把 49% 当作严密的新预测。</p>
+<p>整数由各项未舍入结果计算。固定差集增量只是便于观察权重影响，实际新增区域也可能随经济情景变化。去掉容量意愿后，和解确认的折减仍固定，不能把 51% 当成完整重估后的新预测。</p>
 <p>结论的真正分歧点是<strong>当前管理层表态对未来预算约束有多强</strong>，而非公式的小数。合理范围没有机械取敏感性最小值和最大值；它反映中低置信的判断范围，内部预算或执行证据一旦出现，需要重新计算。</p>
 <h2 id="a4">A4. 下一次更新清单</h2>
 <p>以下为研究更新日历，不是已创建的自动监控或提醒。预计日期都标明为时间窗，不冒充已正式排期。</p>
@@ -2038,5 +2081,20 @@ P（正式下调）＝更新后几率 ÷ (1＋更新后几率) ≈ <b>32%</b><br
   select('timing');
 })();
 
-</script></main></div>
+</script>
+
+<style>
+.tv-evidence{scroll-margin-top:85px;margin:24px 0;border-top:2px solid var(--ink)}
+.tv-evidence .tv-evidence-row{display:grid;grid-template-columns:minmax(90px,.65fr) minmax(0,1.45fr) minmax(0,1.5fr);gap:20px;padding:22px 0;border-bottom:1px solid var(--line);line-height:1.85}
+.tv-evidence .tv-evidence-head{font-size:12px;color:var(--muted);padding:12px 0}
+.tv-evidence h4{font-size:16px;margin:0!important;line-height:1.7}.tv-evidence p{margin:0 0 10px!important;font-size:14px}.tv-evidence small{font-size:12px;line-height:1.75;color:var(--muted);display:block}
+.tv-evidence .tv-label{display:none}.tv-evidence a{font-size:12px}.tv-budget-chain{padding:18px 20px;border-left:3px solid var(--accent);background:var(--accent-soft);line-height:1.9}
+.tv-steps{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:20px;margin:22px 0 18px!important;padding:0!important;list-style:none!important;counter-reset:step}
+.tv-steps li{counter-increment:step;margin:0!important;padding-top:14px;border-top:2px solid var(--line);line-height:1.8;font-size:14px}
+.tv-steps li:before{content:counter(step,decimal-leading-zero);color:var(--accent);font-size:12px;display:block;margin-bottom:8px}.tv-steps strong{display:block}.tv-steps span{color:var(--muted);font-size:12px}
+#insight-buyers{display:block;scroll-margin-top:85px}
+@media(max-width:780px){.tv-evidence .tv-evidence-row{grid-template-columns:1fr;gap:10px;padding:22px 0}.tv-evidence .tv-evidence-head{display:none}.tv-evidence .tv-label{display:block;color:var(--muted);font-size:12px;font-weight:400;margin-bottom:5px}.tv-steps{grid-template-columns:1fr 1fr;gap:18px}.tv-budget-chain{padding:14px}.tv-evidence h4{font-size:17px}}
+@media(max-width:420px){.tv-steps{grid-template-columns:1fr}.tv-steps li{display:grid;grid-template-columns:26px 1fr;gap:0 10px}.tv-steps li:before{grid-row:span 2;margin:0}.tv-steps span{grid-column:2}}
+
+</style></main></div>
 </body></html>

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -28,10 +28,10 @@
 | Delta PM | `services/delta-pm`、`apps/delta-pm-console`、`/live-delta-pm` | 新闻→重要性→priced-in→纸面决策审计链 |
 | Raven Delta | `apps/raven-delta`、`/delta` | 美股新闻影响分析、邮件 / WebSocket 推送 |
 | World Cup blind forecast | `scripts/world-cup`、`apps/web/app/world-cup` | 预测生成严禁读取市场价格；事后评分可使用市场基准 |
-| AI 投研系统案例 | `apps/web/app/[locale]/investment-analysis`、`/investment-analysis` | 三份公开案例：腾讯混元 × WorkBuddy、Hassabis × Alphabet、[Meta 半年资本开支](https://forecasting-agent.com/investment-analysis/meta-capex-6m)（v4，截点 2026-09-06） |
+| AI 投研系统案例 | `apps/web/app/[locale]/investment-analysis`、`/investment-analysis` | 三份公开案例：腾讯混元 × WorkBuddy、Hassabis × Alphabet、[Meta 半年资本开支](https://forecasting-agent.com/investment-analysis/meta-capex-6m)（v5，截点 2026-09-06） |
 | Polymarket live pipeline | `services/orchestrator`、`services/executor` | 真钱路径；任何 live 命令、风控调整或订单测试都需要用户明确确认 |
 
-后续投资资料统一去除客户品牌标签。Meta v4 公开经过复核的来源摘要与审计附件，完整字幕留在本地；第四版用四种条件情形替代假设金额演算，先概括付款、需求转订单、价格、承诺与融资，再展开 Insights；按用户要求，本站报告 iframe 统一不设置 `sandbox`，脚本交互与附件下载正常启用；新报告沿用同一容器，不再按公司单独放行。
+后续投资资料统一去除客户品牌标签。Meta v5 增加“我们判断”的立场，以多个内部业务需求、资源重配、融资缓冲解释预算支撑，单列六类产出与预算申请证据，并解释交付/付款跨年。恢复首次次年预算与上年最终指引或实际值分别比较的原规则，主概率由 32% 调至 34%（范围仍 20–45%）；约 2 个百分点为新增事件差集的主观估计，不是新证据权重。公开摘要与审计附件，完整字幕留在本地。本站报告 iframe 统一不设置 `sandbox`，脚本与附件下载保持可用。
 
 ## 3. 当前最主要的技术 WIP：GPT Pro v2 harness
 

--- a/docs/en/agent-handoff.md
+++ b/docs/en/agent-handoff.md
@@ -28,10 +28,10 @@
 | Delta PM | `services/delta-pm`, `apps/delta-pm-console`, `/live-delta-pm` | News → importance → priced-in → paper-decision audit chain |
 | Raven Delta | `apps/raven-delta`, `/delta` | US-equity news-impact analysis with email / WebSocket delivery |
 | World Cup blind forecast | `scripts/world-cup`, `apps/web/app/world-cup` | Generation may not read prices; post-hoc scoring may use a market benchmark |
-| AI investment research cases | `apps/web/app/[locale]/investment-analysis`, `/investment-analysis` | Three public cases: Tencent Hunyuan × WorkBuddy, Hassabis × Alphabet, and [Meta six-month capex](https://forecasting-agent.com/investment-analysis/meta-capex-6m) (v4, as of 2026-09-06) |
+| AI investment research cases | `apps/web/app/[locale]/investment-analysis`, `/investment-analysis` | Three public cases: Tencent Hunyuan × WorkBuddy, Hassabis × Alphabet, and [Meta six-month capex](https://forecasting-agent.com/investment-analysis/meta-capex-6m) (v5, as of 2026-09-06) |
 | Polymarket live pipeline | `services/orchestrator`, `services/executor` | Real-money path; live runs, risk changes, and order probes require explicit user approval |
 
-Investment reports omit customer branding from now on. Meta v4 publishes reviewed source summaries and audit attachments; full transcripts remain local. Version 4 replaces the arbitrary-dollar calculator with four conditional scenarios and prioritizes payment timing, demand-to-order conversion, prices, commitments and financing. Per the user request, first-party report iframes omit `sandbox`, so scripts and attachment downloads work normally. Future reports use the same container without company-specific exceptions.
+Investment reports omit customer branding. Meta v5 adds an explicit stance and explains budget support through business demand, resource reallocation and financing. It presents six business-output/budget-stage rows and distinguishes year-end delivery from cash payment shifts. The original cross-year rule is restored: compare the first next-year guide with either prior final guidance or actuals. YES changes from 32% to 34% (range remains 20–45%); roughly two points are a subjective event-set correction, not new evidence weight. Reviewed summaries and audits are public; full transcripts remain local. First-party report iframes omit `sandbox`, preserving scripts and downloads.
 
 ## 3. Primary technical WIP: GPT Pro v2 harness
 


### PR DESCRIPTION
Meta 报告此前缺少明确立场，业务产出与预算之间的解释分散，交付跨年、付款跨年和融资缓冲也未充分区分。第五版增加“我们判断”，集中说明多个业务需求、资源重配与融资如何支撑预算，并以六项官方业务证据列明预算申请的支持程度与边界。

修复跨年首次预算规则：与上年最终指引中点或实际值分别比较，任一下降即成立。主概率由 32% 调整至 34%（合理范围仍 20–45%）；新增约 2 个百分点明确为主观事件差集估计，不作为新证据权重。保留原始回放和旧版记录，新增公开审计附件。网站摘要及三语元数据同步更新；报告 iframe 继续无 sandbox。

验证：`pnpm --filter @autopoly/web build` 通过；89 项文稿、数字与计算检查通过；独立规则复核 24 个边界案例及 1,029 个数学断言通过；1440、390、360 像素浏览器检查和实际截图阅读通过。四种情形、键盘切换、资产证据展开、新版附件及 14 个附件/下载地址均正常，无控制台错误。

范围仅为公开报告、摘要和双语交接记录，不涉及交易、风险或执行逻辑。独立 web 项目的正式域名在合并后手动部署并再次验收。

English: Add a clear investment stance, six official business-output/budget-stage comparisons, and explanations of resource reallocation, financing, and delivery versus payment timing. Restore the original cross-year OR rule; YES moves from 32% to 34% through a transparent subjective two-point event-set correction. Web build, document/calculation checks and desktop/mobile browser verification pass. Public research content only; no trading changes.
